### PR TITLE
Add dynamic data-source integration with Nacos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
             </dependency>
             <dependency>
                 <groupId>com.alibaba.csp</groupId>
+                <artifactId>sentinel-datasource-nacos</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.alibaba.csp</groupId>
                 <artifactId>sentinel-adapter</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/property/DynamicSentinelProperty.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/property/DynamicSentinelProperty.java
@@ -59,12 +59,12 @@ public class DynamicSentinelProperty<T> implements SentinelProperty<T> {
 
     }
 
-    public boolean isEqual(T oldValue, T newValue) {
+    private boolean isEqual(T oldValue, T newValue) {
         if (oldValue == null && newValue == null) {
             return true;
         }
 
-        if (oldValue == null && newValue != null) {
+        if (oldValue == null) {
             return false;
         }
 

--- a/sentinel-demo/pom.xml
+++ b/sentinel-demo/pom.xml
@@ -17,16 +17,13 @@
         <module>sentinel-demo-dynamic-file-rule</module>
         <module>sentinel-demo-rocketmq</module>
         <module>sentinel-demo-dubbo</module>
+        <module>sentinel-demo-nacos-datasource</module>
     </modules>
 
     <dependencies>
         <dependency>
             <groupId>com.alibaba.csp</groupId>
             <artifactId>sentinel-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.alibaba.csp</groupId>
-            <artifactId>sentinel-datasource-extension</artifactId>
         </dependency>
     </dependencies>
 

--- a/sentinel-demo/sentinel-demo-dynamic-file-rule/pom.xml
+++ b/sentinel-demo/sentinel-demo-dynamic-file-rule/pom.xml
@@ -19,6 +19,11 @@
             <groupId>com.alibaba.csp</groupId>
             <artifactId>sentinel-datasource-extension</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>fastjson</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/sentinel-demo/sentinel-demo-nacos-datasource/pom.xml
+++ b/sentinel-demo/sentinel-demo-nacos-datasource/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sentinel-demo</artifactId>
+        <groupId>com.alibaba.csp</groupId>
+        <version>0.1.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>sentinel-demo-nacos-datasource</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-datasource-extension</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-datasource-nacos</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>fastjson</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.version}</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <encoding>${java.encoding}</encoding>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/sentinel-demo/sentinel-demo-nacos-datasource/src/main/java/com/alibaba/csp/sentinel/demo/datasource/nacos/FlowQpsRunner.java
+++ b/sentinel-demo/sentinel-demo-nacos-datasource/src/main/java/com/alibaba/csp/sentinel/demo/datasource/nacos/FlowQpsRunner.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.demo.datasource.nacos;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.alibaba.csp.sentinel.Entry;
+import com.alibaba.csp.sentinel.SphU;
+import com.alibaba.csp.sentinel.slots.block.BlockException;
+import com.alibaba.csp.sentinel.util.TimeUtil;
+
+/**
+ * Flow QPS runner.
+ *
+ * @author Carpenter Lee
+ * @author Eric Zhao
+ */
+class FlowQpsRunner {
+
+    private final String resourceName;
+    private final int threadCount;
+    private int seconds;
+
+    public FlowQpsRunner(String resourceName, int threadCount, int seconds) {
+        this.resourceName = resourceName;
+        this.threadCount = threadCount;
+        this.seconds = seconds;
+    }
+
+    private final AtomicInteger pass = new AtomicInteger();
+    private final AtomicInteger block = new AtomicInteger();
+    private final AtomicInteger total = new AtomicInteger();
+
+    private volatile boolean stop = false;
+
+    public void simulateTraffic() {
+        for (int i = 0; i < threadCount; i++) {
+            Thread t = new Thread(new RunTask());
+            t.setName("simulate-traffic-Task");
+            t.start();
+        }
+    }
+
+    public void tick() {
+        Thread timer = new Thread(new TimerTask());
+        timer.setName("sentinel-timer-task");
+        timer.start();
+    }
+
+    final class RunTask implements Runnable {
+        @Override
+        public void run() {
+            while (!stop) {
+                Entry entry = null;
+
+                try {
+                    entry = SphU.entry(resourceName);
+                    // token acquired, means pass
+                    pass.addAndGet(1);
+                } catch (BlockException e1) {
+                    block.incrementAndGet();
+                } catch (Exception e2) {
+                    // biz exception
+                } finally {
+                    total.incrementAndGet();
+                    if (entry != null) {
+                        entry.exit();
+                    }
+                }
+
+                Random random2 = new Random();
+                try {
+                    TimeUnit.MILLISECONDS.sleep(random2.nextInt(50));
+                } catch (InterruptedException e) {
+                    // ignore
+                }
+            }
+        }
+    }
+
+    final class TimerTask implements Runnable {
+        @Override
+        public void run() {
+            long start = System.currentTimeMillis();
+            System.out.println("begin to statistic!!!");
+
+            long oldTotal = 0;
+            long oldPass = 0;
+            long oldBlock = 0;
+            while (!stop) {
+                try {
+                    TimeUnit.SECONDS.sleep(1);
+                } catch (InterruptedException e) {
+                }
+                long globalTotal = total.get();
+                long oneSecondTotal = globalTotal - oldTotal;
+                oldTotal = globalTotal;
+
+                long globalPass = pass.get();
+                long oneSecondPass = globalPass - oldPass;
+                oldPass = globalPass;
+
+                long globalBlock = block.get();
+                long oneSecondBlock = globalBlock - oldBlock;
+                oldBlock = globalBlock;
+
+                System.out.println(seconds + " send qps is: " + oneSecondTotal);
+                System.out.println(TimeUtil.currentTimeMillis() + ", total:" + oneSecondTotal
+                    + ", pass:" + oneSecondPass
+                    + ", block:" + oneSecondBlock);
+
+                if (seconds-- <= 0) {
+                    stop = true;
+                }
+            }
+
+            long cost = System.currentTimeMillis() - start;
+            System.out.println("time cost: " + cost + " ms");
+            System.out.println("total:" + total.get() + ", pass:" + pass.get()
+                + ", block:" + block.get());
+            System.exit(0);
+        }
+    }
+}

--- a/sentinel-demo/sentinel-demo-nacos-datasource/src/main/java/com/alibaba/csp/sentinel/demo/datasource/nacos/NacosConfigSender.java
+++ b/sentinel-demo/sentinel-demo-nacos-datasource/src/main/java/com/alibaba/csp/sentinel/demo/datasource/nacos/NacosConfigSender.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.demo.datasource.nacos;
+
+import com.alibaba.nacos.api.NacosFactory;
+import com.alibaba.nacos.api.config.ConfigService;
+
+/**
+ * Nacos config sender for demo.
+ *
+ * @author Eric Zhao
+ */
+public class NacosConfigSender {
+
+    public static void main(String[] args) throws Exception {
+        final String remoteAddress = "localhost";
+        final String groupId = "Sentinel:Demo";
+        final String dataId = "com.alibaba.csp.sentinel.demo.flow.rule";
+        final String rule = "[\n"
+            + "  {\n"
+            + "    \"resource\": \"TestResource\",\n"
+            + "    \"controlBehavior\": 0,\n"
+            + "    \"count\": 5.0,\n"
+            + "    \"grade\": 1,\n"
+            + "    \"limitApp\": \"default\",\n"
+            + "    \"strategy\": 0\n"
+            + "  }\n"
+            + "]";
+        ConfigService configService = NacosFactory.createConfigService(remoteAddress);
+        System.out.println(configService.publishConfig(dataId, groupId, rule));
+    }
+}

--- a/sentinel-demo/sentinel-demo-nacos-datasource/src/main/java/com/alibaba/csp/sentinel/demo/datasource/nacos/NacosDataSourceDemo.java
+++ b/sentinel-demo/sentinel-demo-nacos-datasource/src/main/java/com/alibaba/csp/sentinel/demo/datasource/nacos/NacosDataSourceDemo.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.demo.datasource.nacos;
+
+import java.util.List;
+
+import com.alibaba.csp.sentinel.datasource.DataSource;
+import com.alibaba.csp.sentinel.datasource.nacos.NacosDataSource;
+import com.alibaba.csp.sentinel.slots.block.flow.FlowRule;
+import com.alibaba.csp.sentinel.slots.block.flow.FlowRuleManager;
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.TypeReference;
+
+/**
+ * This demo demonstrates how to use Nacos as the data source of Sentinel rules.
+ *
+ * Before you start, you need to start a Nacos server in local first, and then
+ * use {@link NacosConfigSender} to publish initial rule configuration to Nacos.
+ *
+ * @author Eric Zhao
+ */
+public class NacosDataSourceDemo {
+
+    private static final String KEY = "TestResource";
+
+    public static void main(String[] args) {
+        loadRules();
+        // Assume we config: resource is `TestResource`, initial QPS threshold is 5.
+        FlowQpsRunner runner = new FlowQpsRunner(KEY, 1, 100);
+        runner.simulateTraffic();
+        runner.tick();
+    }
+
+    private static void loadRules() {
+        final String remoteAddress = "localhost";
+        final String groupId = "Sentinel:Demo";
+        final String dataId = "com.alibaba.csp.sentinel.demo.flow.rule";
+
+        DataSource<String, List<FlowRule>> flowRuleDataSource = new NacosDataSource<>(remoteAddress, groupId, dataId,
+            source -> JSON.parseObject(source, new TypeReference<List<FlowRule>>() {}));
+        FlowRuleManager.register2Property(flowRuleDataSource.getProperty());
+    }
+}

--- a/sentinel-extension/pom.xml
+++ b/sentinel-extension/pom.xml
@@ -13,6 +13,7 @@
 
     <modules>
         <module>sentinel-datasource-extension</module>
+        <module>sentinel-datasource-nacos</module>
     </modules>
 
 </project>

--- a/sentinel-extension/sentinel-datasource-extension/pom.xml
+++ b/sentinel-extension/sentinel-datasource-extension/pom.xml
@@ -17,10 +17,7 @@
             <groupId>com.alibaba.csp</groupId>
             <artifactId>sentinel-core</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.alibaba</groupId>
-            <artifactId>fastjson</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/AbstractDataSource.java
+++ b/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/AbstractDataSource.java
@@ -20,8 +20,8 @@ import com.alibaba.csp.sentinel.property.SentinelProperty;
 
 public abstract class AbstractDataSource<S, T> implements DataSource<S, T> {
 
-    protected ConfigParser<S, T> parser;
-    protected SentinelProperty<T> property;
+    protected final ConfigParser<S, T> parser;
+    protected final SentinelProperty<T> property;
 
     public AbstractDataSource(ConfigParser<S, T> parser) {
         if (parser == null) {

--- a/sentinel-extension/sentinel-datasource-nacos/pom.xml
+++ b/sentinel-extension/sentinel-datasource-nacos/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sentinel-extension</artifactId>
+        <groupId>com.alibaba.csp</groupId>
+        <version>0.1.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>sentinel-datasource-nacos</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <nacos.version>0.1.0</nacos.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-datasource-extension</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alibaba.nacos</groupId>
+            <artifactId>nacos-client</artifactId>
+            <version>${nacos.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/sentinel-extension/sentinel-datasource-nacos/src/main/java/com/alibaba/csp/sentinel/datasource/nacos/NacosDataSource.java
+++ b/sentinel-extension/sentinel-datasource-nacos/src/main/java/com/alibaba/csp/sentinel/datasource/nacos/NacosDataSource.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.datasource.nacos;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import com.alibaba.csp.sentinel.concurrent.NamedThreadFactory;
+import com.alibaba.csp.sentinel.datasource.AbstractDataSource;
+import com.alibaba.csp.sentinel.datasource.ConfigParser;
+import com.alibaba.csp.sentinel.datasource.DataSource;
+import com.alibaba.csp.sentinel.log.RecordLog;
+import com.alibaba.csp.sentinel.util.StringUtil;
+import com.alibaba.nacos.api.NacosFactory;
+import com.alibaba.nacos.api.config.ConfigService;
+import com.alibaba.nacos.api.config.listener.Listener;
+
+/**
+ * A {@link DataSource} with Nacos backend. When the data in Nacos backend has been modified,
+ * Nacos will automatically push the new value so that the dynamic configuration can be real-time.
+ *
+ * @author Eric Zhao
+ */
+public class NacosDataSource<T> extends AbstractDataSource<String, T> {
+
+    private static final int DEFAULT_TIMEOUT = 3000;
+
+    /**
+     * Single-thread pool. Once the thread pool is blocked, we throw up the old task.
+     */
+    private final ExecutorService pool = new ThreadPoolExecutor(1, 1, 0, TimeUnit.MILLISECONDS,
+        new ArrayBlockingQueue<Runnable>(1), new NamedThreadFactory("sentinel-nacos-ds-update"),
+        new ThreadPoolExecutor.DiscardOldestPolicy());
+
+    private final Listener configListener;
+    private final String groupId;
+    private final String dataId;
+
+    /**
+     * Note: The Nacos config might be null if its initialization failed.
+     */
+    private ConfigService configService = null;
+
+    /**
+     * Constructs an DataSource with Nacos backend.
+     *
+     * @param serverAddr server address of Nacos, cannot be empty
+     * @param groupId    group ID, cannot be empty
+     * @param dataId     data ID, cannot be empty
+     * @param parser     customized data parser, cannot be empty
+     */
+    public NacosDataSource(final String serverAddr, final String groupId, final String dataId,
+                           ConfigParser<String, T> parser) {
+        super(parser);
+        if (StringUtil.isBlank(serverAddr) || StringUtil.isBlank(groupId) || StringUtil.isBlank(dataId)) {
+            throw new IllegalArgumentException(String.format("Bad argument: serverAddr=[%s], groupId=[%s], dataId=[%s]",
+                serverAddr, groupId, dataId));
+        }
+        this.groupId = groupId;
+        this.dataId = dataId;
+        this.configListener = new Listener() {
+            @Override
+            public Executor getExecutor() {
+                return pool;
+            }
+
+            @Override
+            public void receiveConfigInfo(final String configInfo) {
+                RecordLog.info(String.format("[NacosDataSource] New property value received for (%s, %s, %s): %s",
+                    serverAddr, dataId, groupId, configInfo));
+                T newValue = NacosDataSource.this.parser.parse(configInfo);
+                // Update the new value to the property.
+                getProperty().updateValue(newValue);
+            }
+        };
+        initNacosListener(serverAddr);
+        loadInitialConfig();
+    }
+
+    private void loadInitialConfig() {
+        try {
+            T newValue = loadConfig();
+            if (newValue == null) {
+                RecordLog.info("[NacosDataSource] WARN: initial config is null, you may have to check your data source");
+            }
+            getProperty().updateValue(newValue);
+        } catch (Exception ex) {
+            RecordLog.info("[NacosDataSource] Error when loading initial config", ex);
+        }
+    }
+
+    private void initNacosListener(String serverAddr) {
+        try {
+            this.configService = NacosFactory.createConfigService(serverAddr);
+            // Add config listener.
+            configService.addListener(dataId, groupId, configListener);
+        } catch (Exception e) {
+            RecordLog.info("[NacosDataSource] Error occurred when initializing Nacos data source", e);
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public String readSource() throws Exception {
+        if (configService == null) {
+            throw new IllegalStateException("Nacos config service has not been initialized or error occurred");
+        }
+        return configService.getConfig(dataId, groupId, DEFAULT_TIMEOUT);
+    }
+
+    @Override
+    public void close() {
+        if (configService != null) {
+            configService.removeListener(dataId, groupId, configListener);
+        }
+        pool.shutdownNow();
+    }
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

Add dynamic rule configuration integration (`DataSource`) with [Nacos](https://github.com/alibaba/nacos).

### Does this pull request fix one issue?

Closes #7 

### Describe how you did it

1. User should provide `serverAddress`, `groupId` and `dataId` of Nacos, as well as a config parser that can parse string to target type.
2. The Nacos datasource will initiate a `ConfigService` and bind with a listener, where Sentinel can get real-time configuration update.
3. The Nacos datasource will pull the initial config when initializing. Then listen to remote changes.

See `NacosDataSource` for details.
