### PR TITLE
Add ZooKeeper data source for Sentinel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,11 @@
             </dependency>
             <dependency>
                 <groupId>com.alibaba.csp</groupId>
+                <artifactId>sentinel-datasource-zookeeper</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.alibaba.csp</groupId>
                 <artifactId>sentinel-adapter</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/sentinel-demo/pom.xml
+++ b/sentinel-demo/pom.xml
@@ -18,6 +18,7 @@
         <module>sentinel-demo-rocketmq</module>
         <module>sentinel-demo-dubbo</module>
         <module>sentinel-demo-nacos-datasource</module>
+        <module>sentinel-demo-zookeeper-datasource</module>
     </modules>
 
     <dependencies>

--- a/sentinel-demo/sentinel-demo-zookeeper-datasource/pom.xml
+++ b/sentinel-demo/sentinel-demo-zookeeper-datasource/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sentinel-demo</artifactId>
+        <groupId>com.alibaba.csp</groupId>
+        <version>0.1.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>sentinel-demo-zookeeper-datasource</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-datasource-extension</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-datasource-zookeeper</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>fastjson</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.version}</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <encoding>${java.encoding}</encoding>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/sentinel-demo/sentinel-demo-zookeeper-datasource/pom.xml
+++ b/sentinel-demo/sentinel-demo-zookeeper-datasource/pom.xml
@@ -11,6 +11,12 @@
 
     <artifactId>sentinel-demo-zookeeper-datasource</artifactId>
 
+    <properties>
+        <zookeeper.version>3.4.13</zookeeper.version>
+        <curator.version>4.0.1</curator.version>
+        <curator-test.version>2.12.0</curator-test.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.alibaba.csp</groupId>
@@ -28,6 +34,24 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <version>${zookeeper.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
+            <version>${curator-test.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/sentinel-demo/sentinel-demo-zookeeper-datasource/src/main/java/com/alibaba/csp/sentinel/demo/datasource/zookeeper/ZookeeperConfigSender.java
+++ b/sentinel-demo/sentinel-demo-zookeeper-datasource/src/main/java/com/alibaba/csp/sentinel/demo/datasource/zookeeper/ZookeeperConfigSender.java
@@ -1,0 +1,37 @@
+package com.alibaba.csp.sentinel.demo.datasource.zookeeper;
+
+import org.I0Itec.zkclient.ZkClient;
+
+/**
+ * Zookeeper config sender for demo
+ *
+ * @author guonanjun
+ */
+public class ZookeeperConfigSender {
+
+    public static void main(String[] args) throws Exception {
+
+
+
+        final String remoteAddress = "127.0.0.1:2181";
+        final String groupId = "Sentinel-Demo";
+        final String dataId = "SYSTEM-CODE-DEMO-FLOW";
+        final String rule = "[\n"
+                + "  {\n"
+                + "    \"resource\": \"TestResource\",\n"
+                + "    \"controlBehavior\": 0,\n"
+                + "    \"count\": 10.0,\n"
+                + "    \"grade\": 1,\n"
+                + "    \"limitApp\": \"default\",\n"
+                + "    \"strategy\": 0\n"
+                + "  }\n"
+                + "]";
+
+        ZkClient zkClient = new ZkClient(remoteAddress, 5000);
+        String path = "/" + groupId + "/" + dataId;
+        if (!zkClient.exists(path)) {
+            zkClient.createPersistent(path, true);
+        }
+        zkClient.writeData(path, rule);
+    }
+}

--- a/sentinel-demo/sentinel-demo-zookeeper-datasource/src/main/java/com/alibaba/csp/sentinel/demo/datasource/zookeeper/ZookeeperConfigSender.java
+++ b/sentinel-demo/sentinel-demo-zookeeper-datasource/src/main/java/com/alibaba/csp/sentinel/demo/datasource/zookeeper/ZookeeperConfigSender.java
@@ -19,6 +19,7 @@ public class ZookeeperConfigSender {
 
     public static void main(String[] args) throws Exception {
 
+        // 启动Zookeeper服务
         TestingServer server = new TestingServer(2181);
 
         final String remoteAddress = server.getConnectString();
@@ -37,7 +38,7 @@ public class ZookeeperConfigSender {
 
         CuratorFramework zkClient = CuratorFrameworkFactory.newClient(remoteAddress, new ExponentialBackoffRetry(SLEEP_TIME, RETRY_TIMES));
         zkClient.start();
-        String path = "/" + groupId + "/" + dataId;
+        String path = getPath(groupId, dataId);
         Stat stat = zkClient.checkExists().forPath(path);
         if (stat == null) {
             zkClient.create().creatingParentContainersIfNeeded().withMode(CreateMode.PERSISTENT).forPath(path, null);
@@ -52,6 +53,23 @@ public class ZookeeperConfigSender {
         }
 
         zkClient.close();
+
+        //停止zookeeper服务
         server.stop();
+    }
+
+    private static String getPath(String groupId, String dataId) {
+        String path = "";
+        if (groupId.startsWith("/")) {
+            path += groupId;
+        } else {
+            path += "/" + groupId;
+        }
+        if (dataId.startsWith("/")) {
+            path += dataId;
+        } else {
+            path += "/" + dataId;
+        }
+        return path;
     }
 }

--- a/sentinel-demo/sentinel-demo-zookeeper-datasource/src/main/java/com/alibaba/csp/sentinel/demo/datasource/zookeeper/ZookeeperConfigSender.java
+++ b/sentinel-demo/sentinel-demo-zookeeper-datasource/src/main/java/com/alibaba/csp/sentinel/demo/datasource/zookeeper/ZookeeperConfigSender.java
@@ -11,8 +11,6 @@ public class ZookeeperConfigSender {
 
     public static void main(String[] args) throws Exception {
 
-
-
         final String remoteAddress = "127.0.0.1:2181";
         final String groupId = "Sentinel-Demo";
         final String dataId = "SYSTEM-CODE-DEMO-FLOW";

--- a/sentinel-demo/sentinel-demo-zookeeper-datasource/src/main/java/com/alibaba/csp/sentinel/demo/datasource/zookeeper/ZookeeperDataSourceDemo.java
+++ b/sentinel-demo/sentinel-demo-zookeeper-datasource/src/main/java/com/alibaba/csp/sentinel/demo/datasource/zookeeper/ZookeeperDataSourceDemo.java
@@ -29,6 +29,9 @@ public class ZookeeperDataSourceDemo {
         // final String systemDataId = "SYSTEM-CODE-DEMO-SYSTEM";
 
 
+        // 规则会持久化到zk的/groupId/flowDataId节点
+        // groupId和和flowDataId可以用/开头也可以不用
+        // 建议不用以/开头，目的是为了如果从Zookeeper切换到nacos的话，只需要改个数据源类名就可以
         DataSource<String, List<FlowRule>> flowRuleDataSource = new ZookeeperDataSource<>(remoteAddress, groupId, flowDataId,
                 source -> JSON.parseObject(source, new TypeReference<List<FlowRule>>() {}));
         FlowRuleManager.register2Property(flowRuleDataSource.getProperty());

--- a/sentinel-demo/sentinel-demo-zookeeper-datasource/src/main/java/com/alibaba/csp/sentinel/demo/datasource/zookeeper/ZookeeperDataSourceDemo.java
+++ b/sentinel-demo/sentinel-demo-zookeeper-datasource/src/main/java/com/alibaba/csp/sentinel/demo/datasource/zookeeper/ZookeeperDataSourceDemo.java
@@ -4,12 +4,8 @@ import java.util.List;
 
 import com.alibaba.csp.sentinel.datasource.DataSource;
 import com.alibaba.csp.sentinel.datasource.zookeeper.ZookeeperDataSource;
-import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRule;
-import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRuleManager;
 import com.alibaba.csp.sentinel.slots.block.flow.FlowRule;
 import com.alibaba.csp.sentinel.slots.block.flow.FlowRuleManager;
-import com.alibaba.csp.sentinel.slots.system.SystemRule;
-import com.alibaba.csp.sentinel.slots.system.SystemRuleManager;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.TypeReference;
 
@@ -20,31 +16,30 @@ import com.alibaba.fastjson.TypeReference;
  */
 public class ZookeeperDataSourceDemo {
 
-    private static final String KEY = "TestResource";
-
     public static void main(String[] args) {
         loadRules();
     }
 
     private static void loadRules() {
+
         final String remoteAddress = "127.0.0.1:2181";
         final String groupId = "Sentinel-Demo";
         final String flowDataId = "SYSTEM-CODE-DEMO-FLOW";
-        final String degradeDataId = "SYSTEM-CODE-DEMO-DEGRADE";
-        final String systemDataId = "SYSTEM-CODE-DEMO-SYSTEM";
+        // final String degradeDataId = "SYSTEM-CODE-DEMO-DEGRADE";
+        // final String systemDataId = "SYSTEM-CODE-DEMO-SYSTEM";
 
 
         DataSource<String, List<FlowRule>> flowRuleDataSource = new ZookeeperDataSource<>(remoteAddress, groupId, flowDataId,
                 source -> JSON.parseObject(source, new TypeReference<List<FlowRule>>() {}));
         FlowRuleManager.register2Property(flowRuleDataSource.getProperty());
 
-        DataSource<String, List<DegradeRule>> degradeRuleDataSource = new ZookeeperDataSource<>(remoteAddress, groupId, degradeDataId,
-                source -> JSON.parseObject(source, new TypeReference<List<DegradeRule>>() {}));
-        DegradeRuleManager.register2Property(degradeRuleDataSource.getProperty());
-
-        DataSource<String, List<SystemRule>> systemRuleDataSource = new ZookeeperDataSource<>(remoteAddress, groupId, systemDataId,
-                source -> JSON.parseObject(source, new TypeReference<List<SystemRule>>() {}));
-        SystemRuleManager.register2Property(systemRuleDataSource.getProperty());
+        // DataSource<String, List<DegradeRule>> degradeRuleDataSource = new ZookeeperDataSource<>(remoteAddress, groupId, degradeDataId,
+        //         source -> JSON.parseObject(source, new TypeReference<List<DegradeRule>>() {}));
+        // DegradeRuleManager.register2Property(degradeRuleDataSource.getProperty());
+        //
+        // DataSource<String, List<SystemRule>> systemRuleDataSource = new ZookeeperDataSource<>(remoteAddress, groupId, systemDataId,
+        //         source -> JSON.parseObject(source, new TypeReference<List<SystemRule>>() {}));
+        // SystemRuleManager.register2Property(systemRuleDataSource.getProperty());
 
     }
 }

--- a/sentinel-demo/sentinel-demo-zookeeper-datasource/src/main/java/com/alibaba/csp/sentinel/demo/datasource/zookeeper/ZookeeperDataSourceDemo.java
+++ b/sentinel-demo/sentinel-demo-zookeeper-datasource/src/main/java/com/alibaba/csp/sentinel/demo/datasource/zookeeper/ZookeeperDataSourceDemo.java
@@ -17,12 +17,29 @@ import com.alibaba.fastjson.TypeReference;
 public class ZookeeperDataSourceDemo {
 
     public static void main(String[] args) {
+        // 使用zookeeper的场景
         loadRules();
+
+        // 方便扩展的场景
+        //loadRules2();
     }
 
     private static void loadRules() {
 
         final String remoteAddress = "127.0.0.1:2181";
+        final String path = "/Sentinel-Demo/SYSTEM-CODE-DEMO-FLOW";
+
+        DataSource<String, List<FlowRule>> flowRuleDataSource = new ZookeeperDataSource<>(remoteAddress, path,
+                source -> JSON.parseObject(source, new TypeReference<List<FlowRule>>() {}));
+        FlowRuleManager.register2Property(flowRuleDataSource.getProperty());
+
+
+    }
+
+    private static void loadRules2() {
+
+        final String remoteAddress = "127.0.0.1:2181";
+        // 引入groupId和dataId的概念，是为了方便和Nacos进行切换
         final String groupId = "Sentinel-Demo";
         final String flowDataId = "SYSTEM-CODE-DEMO-FLOW";
         // final String degradeDataId = "SYSTEM-CODE-DEMO-DEGRADE";
@@ -31,7 +48,7 @@ public class ZookeeperDataSourceDemo {
 
         // 规则会持久化到zk的/groupId/flowDataId节点
         // groupId和和flowDataId可以用/开头也可以不用
-        // 建议不用以/开头，目的是为了如果从Zookeeper切换到nacos的话，只需要改个数据源类名就可以
+        // 建议不用以/开头，目的是为了如果从Zookeeper切换到Nacos的话，只需要改数据源类名就可以
         DataSource<String, List<FlowRule>> flowRuleDataSource = new ZookeeperDataSource<>(remoteAddress, groupId, flowDataId,
                 source -> JSON.parseObject(source, new TypeReference<List<FlowRule>>() {}));
         FlowRuleManager.register2Property(flowRuleDataSource.getProperty());

--- a/sentinel-demo/sentinel-demo-zookeeper-datasource/src/main/java/com/alibaba/csp/sentinel/demo/datasource/zookeeper/ZookeeperDataSourceDemo.java
+++ b/sentinel-demo/sentinel-demo-zookeeper-datasource/src/main/java/com/alibaba/csp/sentinel/demo/datasource/zookeeper/ZookeeperDataSourceDemo.java
@@ -1,0 +1,50 @@
+package com.alibaba.csp.sentinel.demo.datasource.zookeeper;
+
+import java.util.List;
+
+import com.alibaba.csp.sentinel.datasource.DataSource;
+import com.alibaba.csp.sentinel.datasource.zookeeper.ZookeeperDataSource;
+import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRule;
+import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRuleManager;
+import com.alibaba.csp.sentinel.slots.block.flow.FlowRule;
+import com.alibaba.csp.sentinel.slots.block.flow.FlowRuleManager;
+import com.alibaba.csp.sentinel.slots.system.SystemRule;
+import com.alibaba.csp.sentinel.slots.system.SystemRuleManager;
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.TypeReference;
+
+/**
+ * Zookeeper DataSource Demo
+ *
+ * @author guonanjun
+ */
+public class ZookeeperDataSourceDemo {
+
+    private static final String KEY = "TestResource";
+
+    public static void main(String[] args) {
+        loadRules();
+    }
+
+    private static void loadRules() {
+        final String remoteAddress = "127.0.0.1:2181";
+        final String groupId = "Sentinel-Demo";
+        final String flowDataId = "SYSTEM-CODE-DEMO-FLOW";
+        final String degradeDataId = "SYSTEM-CODE-DEMO-DEGRADE";
+        final String systemDataId = "SYSTEM-CODE-DEMO-SYSTEM";
+
+
+        DataSource<String, List<FlowRule>> flowRuleDataSource = new ZookeeperDataSource<>(remoteAddress, groupId, flowDataId,
+                source -> JSON.parseObject(source, new TypeReference<List<FlowRule>>() {}));
+        FlowRuleManager.register2Property(flowRuleDataSource.getProperty());
+
+        DataSource<String, List<DegradeRule>> degradeRuleDataSource = new ZookeeperDataSource<>(remoteAddress, groupId, degradeDataId,
+                source -> JSON.parseObject(source, new TypeReference<List<DegradeRule>>() {}));
+        DegradeRuleManager.register2Property(degradeRuleDataSource.getProperty());
+
+        DataSource<String, List<SystemRule>> systemRuleDataSource = new ZookeeperDataSource<>(remoteAddress, groupId, systemDataId,
+                source -> JSON.parseObject(source, new TypeReference<List<SystemRule>>() {}));
+        SystemRuleManager.register2Property(systemRuleDataSource.getProperty());
+
+    }
+}

--- a/sentinel-extension/pom.xml
+++ b/sentinel-extension/pom.xml
@@ -14,6 +14,7 @@
     <modules>
         <module>sentinel-datasource-extension</module>
         <module>sentinel-datasource-nacos</module>
+        <module>sentinel-datasource-zookeeper</module>
     </modules>
 
 </project>

--- a/sentinel-extension/sentinel-datasource-zookeeper/pom.xml
+++ b/sentinel-extension/sentinel-datasource-zookeeper/pom.xml
@@ -13,7 +13,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <zkclient.version>0.10</zkclient.version>
+        <zookeeper.version>3.4.13</zookeeper.version>
+        <curator.version>4.0.1</curator.version>
     </properties>
 
     <dependencies>
@@ -23,9 +24,20 @@
         </dependency>
 
         <dependency>
-            <groupId>com.101tec</groupId>
-            <artifactId>zkclient</artifactId>
-            <version>${zkclient.version}</version>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <version>${zookeeper.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+            <version>${curator.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>

--- a/sentinel-extension/sentinel-datasource-zookeeper/pom.xml
+++ b/sentinel-extension/sentinel-datasource-zookeeper/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sentinel-extension</artifactId>
+        <groupId>com.alibaba.csp</groupId>
+        <version>0.1.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>sentinel-datasource-zookeeper</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <zkclient.version>0.10</zkclient.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-datasource-extension</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.101tec</groupId>
+            <artifactId>zkclient</artifactId>
+            <version>${zkclient.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/sentinel-extension/sentinel-datasource-zookeeper/src/main/java/com/alibaba/csp/sentinel/datasource/zookeeper/ZookeeperDataSource.java
+++ b/sentinel-extension/sentinel-datasource-zookeeper/src/main/java/com/alibaba/csp/sentinel/datasource/zookeeper/ZookeeperDataSource.java
@@ -85,7 +85,7 @@ public class ZookeeperDataSource<T> extends AbstractDataSource<String, T> {
         try {
             this.zkClient = CuratorFrameworkFactory.newClient(serverAddr, new ExponentialBackoffRetry(SLEEP_TIME, RETRY_TIMES));
             this.zkClient.start();
-            String path = "/" + this.groupId + "/" + this.dataId;
+            String path = getPath(this.groupId, this.dataId);
             Stat stat = this.zkClient.checkExists().forPath(path);
             if (stat == null) {
                 this.zkClient.create().creatingParentContainersIfNeeded().withMode(CreateMode.PERSISTENT).forPath(path, null);
@@ -105,7 +105,7 @@ public class ZookeeperDataSource<T> extends AbstractDataSource<String, T> {
         if (this.zkClient == null) {
             throw new IllegalStateException("Zookeeper has not been initialized or error occurred");
         }
-        String path = "/" + this.groupId + "/" + this.dataId;
+        String path = getPath(this.groupId, this.dataId);
         byte[] data = this.zkClient.getData().forPath(path);
         if (data != null) {
             return new String(data);
@@ -123,5 +123,20 @@ public class ZookeeperDataSource<T> extends AbstractDataSource<String, T> {
             this.zkClient.close();
         }
         pool.shutdown();
+    }
+
+    private String getPath(String groupId, String dataId) {
+        String path = "";
+        if (groupId.startsWith("/")) {
+            path += groupId;
+        } else {
+            path += "/" + groupId;
+        }
+        if (dataId.startsWith("/")) {
+            path += dataId;
+        } else {
+            path += "/" + dataId;
+        }
+        return path;
     }
 }

--- a/sentinel-extension/sentinel-datasource-zookeeper/src/main/java/com/alibaba/csp/sentinel/datasource/zookeeper/ZookeeperDataSource.java
+++ b/sentinel-extension/sentinel-datasource-zookeeper/src/main/java/com/alibaba/csp/sentinel/datasource/zookeeper/ZookeeperDataSource.java
@@ -1,0 +1,100 @@
+package com.alibaba.csp.sentinel.datasource.zookeeper;
+
+import com.alibaba.csp.sentinel.datasource.AbstractDataSource;
+import com.alibaba.csp.sentinel.datasource.ConfigParser;
+import com.alibaba.csp.sentinel.log.RecordLog;
+import com.alibaba.csp.sentinel.util.StringUtil;
+import org.I0Itec.zkclient.IZkDataListener;
+import org.I0Itec.zkclient.ZkClient;
+
+/**
+ * Zookeeper DataSource
+ *
+ * @author guonanjun
+ */
+public class ZookeeperDataSource<T> extends AbstractDataSource<String, T> {
+
+    private static final int DEFAULT_TIMEOUT = 3000;
+
+    private final IZkDataListener zkDataListener;
+    private final String groupId;
+    private final String dataId;
+
+    private ZkClient zkClient = null;
+
+    public ZookeeperDataSource(final String serverAddr, final String groupId, final String dataId,
+                               ConfigParser<String, T> parser) {
+        super(parser);
+        if (StringUtil.isBlank(serverAddr) || StringUtil.isBlank(groupId) || StringUtil.isBlank(dataId)) {
+            throw new IllegalArgumentException(String.format("Bad argument: serverAddr=[%s], groupId=[%s], dataId=[%s]",
+                    serverAddr, groupId, dataId));
+        }
+        this.groupId = groupId;
+        this.dataId = dataId;
+        this.zkDataListener = new IZkDataListener() {
+            @Override
+            public void handleDataChange(String path, Object configInfo) throws Exception {
+                RecordLog.info(String.format("[ZookeeperDataSource] New property value received for (%s, %s, %s): %s",
+                        serverAddr, dataId, groupId, configInfo));
+                System.out.println("===========" + configInfo);
+                T newValue = ZookeeperDataSource.this.parser.parse(String.valueOf(configInfo));
+                // Update the new value to the property.
+                getProperty().updateValue(newValue);
+            }
+
+            @Override
+            public void handleDataDeleted(String s) throws Exception {
+                RecordLog.info(String.format("[ZookeeperDataSource] New property value received for (%s, %s, %s): %s",
+                        serverAddr, dataId, groupId, null));
+                // Update the new value to the property.
+                getProperty().updateValue(null);
+            }
+        };
+        initZookeeperListener(serverAddr);
+        loadInitialConfig();
+    }
+
+    private void loadInitialConfig() {
+        try {
+            T newValue = loadConfig();
+            if (newValue == null) {
+                RecordLog.info("[ZookeeperDataSource] WARN: initial config is null, you may have to check your data source");
+            }
+            getProperty().updateValue(newValue);
+        } catch (Exception ex) {
+            RecordLog.info("[ZookeeperDataSource] Error when loading initial config", ex);
+        }
+    }
+
+    private void initZookeeperListener(String serverAddr) {
+        try {
+            this.zkClient = new ZkClient(serverAddr, DEFAULT_TIMEOUT);
+            String path = "/" + this.groupId + "/" + this.dataId;
+            if (!zkClient.exists(path)) {
+                zkClient.createPersistent(path, true);
+            }
+            zkClient.subscribeDataChanges(path, zkDataListener);
+        } catch (Exception e) {
+            RecordLog.info("[ZookeeperDataSource] Error occurred when initializing Zookeeper data source", e);
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public String readSource() throws Exception {
+        if (zkClient == null) {
+            throw new IllegalStateException("Zookeeper has not been initialized or error occurred");
+        }
+        String path = "/" + this.groupId + "/" + this.dataId;
+        return zkClient.readData(path);
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (zkClient != null) {
+            String path = "/" + this.groupId + "/" + this.dataId;
+            zkClient.unsubscribeDataChanges(path, zkDataListener);
+        }
+        zkClient.close();
+    }
+}

--- a/sentinel-extension/sentinel-datasource-zookeeper/src/main/java/com/alibaba/csp/sentinel/datasource/zookeeper/ZookeeperDataSource.java
+++ b/sentinel-extension/sentinel-datasource-zookeeper/src/main/java/com/alibaba/csp/sentinel/datasource/zookeeper/ZookeeperDataSource.java
@@ -15,7 +15,7 @@ import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.recipes.cache.ChildData;
 import org.apache.curator.framework.recipes.cache.NodeCache;
 import org.apache.curator.framework.recipes.cache.NodeCacheListener;
-import org.apache.curator.retry.RetryNTimes;
+import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.data.Stat;
 
@@ -27,7 +27,7 @@ import org.apache.zookeeper.data.Stat;
 public class ZookeeperDataSource<T> extends AbstractDataSource<String, T> {
 
     private static final int RETRY_TIMES = 3;
-    private static final int SLEEP_TIME = 3000;
+    private static final int SLEEP_TIME = 1000;
 
     private final ExecutorService pool = new ThreadPoolExecutor(1, 1, 0, TimeUnit.MILLISECONDS,
             new ArrayBlockingQueue<Runnable>(1), new NamedThreadFactory("sentinel-zookeeper-ds-update"),
@@ -83,7 +83,7 @@ public class ZookeeperDataSource<T> extends AbstractDataSource<String, T> {
 
     private void initZookeeperListener(String serverAddr) {
         try {
-            this.zkClient = CuratorFrameworkFactory.newClient(serverAddr, new RetryNTimes(RETRY_TIMES, SLEEP_TIME));
+            this.zkClient = CuratorFrameworkFactory.newClient(serverAddr, new ExponentialBackoffRetry(SLEEP_TIME, RETRY_TIMES));
             this.zkClient.start();
             String path = "/" + this.groupId + "/" + this.dataId;
             Stat stat = this.zkClient.checkExists().forPath(path);

--- a/sentinel-extension/sentinel-datasource-zookeeper/src/main/java/com/alibaba/csp/sentinel/datasource/zookeeper/ZookeeperDataSource.java
+++ b/sentinel-extension/sentinel-datasource-zookeeper/src/main/java/com/alibaba/csp/sentinel/datasource/zookeeper/ZookeeperDataSource.java
@@ -42,7 +42,7 @@ public class ZookeeperDataSource<T> extends AbstractDataSource<String, T> {
             }
 
             @Override
-            public void handleDataDeleted(String s) throws Exception {
+            public void handleDataDeleted(String path) throws Exception {
                 RecordLog.info(String.format("[ZookeeperDataSource] New property value received for (%s, %s, %s): %s",
                         serverAddr, dataId, groupId, null));
                 // Update the new value to the property.

--- a/sentinel-extension/sentinel-datasource-zookeeper/src/main/java/com/alibaba/csp/sentinel/datasource/zookeeper/ZookeeperDataSource.java
+++ b/sentinel-extension/sentinel-datasource-zookeeper/src/main/java/com/alibaba/csp/sentinel/datasource/zookeeper/ZookeeperDataSource.java
@@ -36,7 +36,6 @@ public class ZookeeperDataSource<T> extends AbstractDataSource<String, T> {
             public void handleDataChange(String path, Object configInfo) throws Exception {
                 RecordLog.info(String.format("[ZookeeperDataSource] New property value received for (%s, %s, %s): %s",
                         serverAddr, dataId, groupId, configInfo));
-                System.out.println("===========" + configInfo);
                 T newValue = ZookeeperDataSource.this.parser.parse(String.valueOf(configInfo));
                 // Update the new value to the property.
                 getProperty().updateValue(newValue);


### PR DESCRIPTION
### Describe what this PR does / why we need it
增加了zookeeper的数据源和测试demo

Resolves #29 

### Describe how you did it

参考nacos数据源，保持和nacos数据源风格一致，通过zkclient实现zookeeper的发布订阅功能，可以在规则变更的时候主动推送规则。

### Describe how to verify it
sentinel-demo-zookeeper-datasource里面的ZookeeperDataSourceDemo是模拟微服务启动的时候注册数据源的场景，ZookeeperConfigSender是模拟Sentinel控制台在规则变更时，主动推送规则给微服务的场景。