### PR TITLE
修改StatisticNode中curThreadNum的类型和处理方式；修改SystemRuleManager#maxThread类型

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/ConcurrentCounter.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/ConcurrentCounter.java
@@ -1,0 +1,98 @@
+package com.alibaba.csp.sentinel.node;
+
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * a concurrent counter implemented by {@link java.util.concurrent.Semaphore}
+ * <p>
+ * In principle, statistics and limiting concurrency values require the use of semaphores.
+ * If you use an atomic counter like AtomicInteger, it will lead to race conditions, which
+ * will not achieve the desired effect in extreme cases.
+ * </p>
+ *
+ * @author yizhenqiang
+ */
+public class ConcurrentCounter {
+
+    /**
+     * The volatitle keyword is needed here because the semaphore may be replaced by the whole
+     */
+    private AtomicReference<PermitsSemaphore> threshold = new AtomicReference<PermitsSemaphore>();
+
+    /**
+     * Because the {@link #threshold} may be replaced entirely, you need to ensure that the {@link PermitsSemaphore#acquire()} and
+     * {@link PermitsSemaphore#release()} operations are based on the same semaphore, so you need to use {@link ThreadLocal} here.
+     */
+    private static ThreadLocal<PermitsSemaphore> guaranteedUseSame = new ThreadLocal<PermitsSemaphore>();
+
+    public ConcurrentCounter() {}
+
+    public ConcurrentCounter(int threshold) {
+        this.threshold.set(new PermitsSemaphore(threshold));
+    }
+
+    /**
+     * Try to +1 the counter and compare it with maxConcurrentValue
+     *
+     * @param maxConcurrentValue
+     * @return true-has not exceeded the threshold, false-has exceeded the threshold
+     */
+    public boolean tryCompareAndIncrease (int maxConcurrentValue) {
+        PermitsSemaphore curThreshold = threshold.get();
+        if (curThreshold == null || curThreshold.getPermits() != maxConcurrentValue) {
+            threshold.compareAndSet(curThreshold, new PermitsSemaphore(maxConcurrentValue));
+            // can not be null
+            curThreshold = threshold.get();
+        }
+
+        guaranteedUseSame.set(curThreshold);
+
+        return curThreshold.tryAcquire();
+    }
+
+    /**
+     * Try to -1 the counter
+     */
+    public void tryDecrease () {
+        PermitsSemaphore curThreshold = guaranteedUseSame.get();
+        if (curThreshold != null) {
+            curThreshold.release();
+
+            guaranteedUseSame.remove();
+        }
+    }
+
+    /**
+     * get the current concurrency value
+     *
+     * @return
+     */
+    public int getCurConcurrentValue () {
+        PermitsSemaphore permitsSemaphore = threshold.get();
+        return permitsSemaphore == null ? 0 : permitsSemaphore.getCurValue();
+    }
+
+    /**
+     * The semaphore in the JDK doesn't even keep the number of permissions in the constructor, so wrap it here.
+     */
+    private class PermitsSemaphore extends Semaphore {
+
+        /**
+         * maximum permissive number
+         */
+        private int permits;
+
+        public PermitsSemaphore(int permits) {
+            super(permits);
+        }
+
+        public int getCurValue() {
+            return permits - availablePermits();
+        }
+
+        public int getPermits() {
+            return permits;
+        }
+    }
+}

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/Node.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/Node.java
@@ -105,6 +105,8 @@ public interface Node {
 
     void increaseThreadNum();
 
+    boolean compareAndIncreaseThreadNum(int maxThreadNum);
+
     void decreaseThreadNum();
 
     /**

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/StatisticNode.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/StatisticNode.java
@@ -18,8 +18,6 @@ package com.alibaba.csp.sentinel.node;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import com.alibaba.csp.sentinel.util.TimeUtil;
 import com.alibaba.csp.sentinel.node.metric.MetricNode;
 import com.alibaba.csp.sentinel.slots.statistic.metric.ArrayMetric;
@@ -36,7 +34,7 @@ public class StatisticNode implements Node {
 
     private transient Metric rollingCounterInMinute = new ArrayMetric(1000, 2 * 60);
 
-    private AtomicInteger curThreadNum = new AtomicInteger(0);
+    private ConcurrentCounter curThreadNum = new ConcurrentCounter();
 
     private long lastFetchTime = -1;
 
@@ -141,7 +139,7 @@ public class StatisticNode implements Node {
 
     @Override
     public int curThreadNum() {
-        return curThreadNum.get();
+        return curThreadNum.getCurConcurrentValue();
     }
 
     @Override
@@ -174,12 +172,17 @@ public class StatisticNode implements Node {
 
     @Override
     public void increaseThreadNum() {
-        curThreadNum.incrementAndGet();
+        // do nothings
+    }
+
+    @Override
+    public boolean compareAndIncreaseThreadNum(int maxThreadNum) {
+        return curThreadNum.tryCompareAndIncrease(maxThreadNum);
     }
 
     @Override
     public void decreaseThreadNum() {
-        curThreadNum.decrementAndGet();
+        curThreadNum.tryDecrease();
     }
 
     @Override

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/system/SystemRule.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/system/SystemRule.java
@@ -44,7 +44,7 @@ public class SystemRule extends AbstractRule {
     private double highestSystemLoad = -1;
     private double qps = -1;
     private long avgRt = -1;
-    private long maxThread = -1;
+    private int maxThread = -1;
 
     public double getQps() {
         return qps;
@@ -62,7 +62,7 @@ public class SystemRule extends AbstractRule {
         this.qps = qps;
     }
 
-    public long getMaxThread() {
+    public int getMaxThread() {
         return maxThread;
     }
 
@@ -72,7 +72,7 @@ public class SystemRule extends AbstractRule {
      *
      * @param maxThread max parallel thread number, values <= 0 are special for clearing the threshold.
      */
-    public void setMaxThread(long maxThread) {
+    public void setMaxThread(int maxThread) {
         this.maxThread = maxThread;
     }
 
@@ -154,7 +154,7 @@ public class SystemRule extends AbstractRule {
         result = 31 * result + (int)(temp ^ (temp >>> 32));
 
         result = 31 * result + (int)(avgRt ^ (avgRt >>> 32));
-        result = 31 * result + (int)(maxThread ^ (maxThread >>> 32));
+        result = 31 * result + (maxThread ^ (maxThread >>> 32));
         return result;
     }
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/system/SystemRuleManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/system/SystemRuleManager.java
@@ -280,7 +280,7 @@ public class SystemRuleManager {
         // total thread
         int currentThread = 0;
         if (Constants.ENTRY_NODE != null) {
-            if(Constants.ENTRY_NODE.compareAndIncreaseThreadNum((int) maxThread)){
+            if(!Constants.ENTRY_NODE.compareAndIncreaseThreadNum(maxThread)){
                 throw new SystemBlockException(resourceWrapper.getName(), "thread");
             }
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/system/SystemRuleManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/system/SystemRuleManager.java
@@ -68,7 +68,7 @@ public class SystemRuleManager {
     private static volatile double highestSystemLoad = Double.MAX_VALUE;
     private static volatile double qps = Double.MAX_VALUE;
     private static volatile long maxRt = Long.MAX_VALUE;
-    private static volatile long maxThread = Long.MAX_VALUE;
+    private static volatile int maxThread = Integer.MAX_VALUE;
     /**
      * mark whether the threshold are set by user.
      */
@@ -167,7 +167,7 @@ public class SystemRuleManager {
         return maxRt;
     }
 
-    public static long getMaxThread() {
+    public static int getMaxThread() {
         return maxThread;
     }
 
@@ -198,7 +198,7 @@ public class SystemRuleManager {
             // should restore changes
             highestSystemLoad = Double.MAX_VALUE;
             maxRt = Long.MAX_VALUE;
-            maxThread = Long.MAX_VALUE;
+            maxThread = Integer.MAX_VALUE;
             qps = Double.MAX_VALUE;
 
             highestSystemLoadIsSet = false;
@@ -278,9 +278,13 @@ public class SystemRuleManager {
         }
 
         // total thread
-        int currentThread = Constants.ENTRY_NODE == null ? 0 : Constants.ENTRY_NODE.curThreadNum();
-        if (currentThread > maxThread) {
-            throw new SystemBlockException(resourceWrapper.getName(), "thread");
+        int currentThread = 0;
+        if (Constants.ENTRY_NODE != null) {
+            if(Constants.ENTRY_NODE.compareAndIncreaseThreadNum((int) maxThread)){
+                throw new SystemBlockException(resourceWrapper.getName(), "thread");
+            }
+
+            currentThread =  Constants.ENTRY_NODE.curThreadNum();
         }
 
         double rt = Constants.ENTRY_NODE == null ? 0 : Constants.ENTRY_NODE.avgRt();

--- a/sentinel-dashboard/src/main/java/com/taobao/csp/sentinel/dashboard/datasource/entity/SystemRuleEntity.java
+++ b/sentinel-dashboard/src/main/java/com/taobao/csp/sentinel/dashboard/datasource/entity/SystemRuleEntity.java
@@ -31,7 +31,7 @@ public class SystemRuleEntity implements RuleEntity {
     private Integer port;
     private Double avgLoad;
     private Long avgRt;
-    private Long maxThread;
+    private Integer maxThread;
     private Double qps;
 
     private Date gmtCreate;
@@ -102,11 +102,11 @@ public class SystemRuleEntity implements RuleEntity {
         this.avgRt = avgRt;
     }
 
-    public Long getMaxThread() {
+    public Integer getMaxThread() {
         return maxThread;
     }
 
-    public void setMaxThread(Long maxThread) {
+    public void setMaxThread(Integer maxThread) {
         this.maxThread = maxThread;
     }
 

--- a/sentinel-dashboard/src/main/java/com/taobao/csp/sentinel/dashboard/view/SystemController.java
+++ b/sentinel-dashboard/src/main/java/com/taobao/csp/sentinel/dashboard/view/SystemController.java
@@ -79,7 +79,7 @@ public class SystemController {
 
     @ResponseBody
     @RequestMapping("/new.json")
-    Result<?> add(String app, String ip, Integer port, Double avgLoad, Long avgRt, Long maxThread, Double qps) {
+    Result<?> add(String app, String ip, Integer port, Double avgLoad, Long avgRt, Integer maxThread, Double qps) {
         if (StringUtil.isBlank(app)) {
             return Result.ofFail(-1, "app can't be null or empty");
         }
@@ -112,7 +112,7 @@ public class SystemController {
         if (maxThread != null) {
             entity.setMaxThread(maxThread);
         } else {
-            entity.setMaxThread(-1L);
+            entity.setMaxThread(-1);
         }
         if (qps != null) {
             entity.setQps(qps);
@@ -136,7 +136,7 @@ public class SystemController {
 
     @ResponseBody
     @RequestMapping("/save.json")
-    Result<?> updateIfNotNull(Long id, String app, Double avgLoad, Long avgRt, Long maxThread, Double qps) {
+    Result<?> updateIfNotNull(Long id, String app, Double avgLoad, Long avgRt, Integer maxThread, Double qps) {
         if (id == null) {
             return Result.ofFail(-1, "id can't be null");
         }


### PR DESCRIPTION
修改StatisticNode中curThreadNum的类型和处理方式，避免竞态条件问题；修改SystemRuleManager中的maxThread类型，由long改为int，int对于线程数（或并发数）已经足够，而且性能比long要好

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
StatisticNode中curThreadNum是用来统计并发值的（即线程数），有自增和自减操作，如果先自增（StatisticSlot）和自减，再进行比较（SystemSlot），就会产生竞态条件，所以这里使用信号量来规避。

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
