### PR TITLE
Add Sentinel annotation and AspectJ support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,11 @@
             </dependency>
             <dependency>
                 <groupId>com.alibaba.csp</groupId>
+                <artifactId>sentinel-annotation-aspectj</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.alibaba.csp</groupId>
                 <artifactId>sentinel-datasource-extension</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -94,6 +99,11 @@
             <dependency>
                 <groupId>com.alibaba.csp</groupId>
                 <artifactId>sentinel-datasource-zookeeper</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.alibaba.csp</groupId>
+                <artifactId>sentinel-transport-simple-http</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/annotation/SentinelResource.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/annotation/SentinelResource.java
@@ -24,7 +24,10 @@ import java.lang.annotation.Target;
 import com.alibaba.csp.sentinel.EntryType;
 
 /**
+ * The annotation indicates a definition of Sentinel resource.
+ *
  * @author Eric Zhao
+ * @since 0.1.1
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
@@ -45,6 +48,16 @@ public @interface SentinelResource {
      * @return name of the block exception function, empty by default
      */
     String blockHandler() default "";
+
+    /**
+     * The {@code blockHandler} is located in the same class with the original method by default.
+     * However, if some methods share the same signature and intend to set the same block handler,
+     * then users can set the class where the block handler exists. Note that the block handler method
+     * must be static.
+     *
+     * @return the class where the block handler exists, should not provide more than one classes
+     */
+    Class<?>[] blockHandlerClass() default {};
 
     /**
      * @return name of the fallback function, empty by default

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/annotation/SentinelResource.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/annotation/SentinelResource.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.alibaba.csp.sentinel.EntryType;
+
+/**
+ * @author Eric Zhao
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface SentinelResource {
+
+    /**
+     * @return name of the Sentinel resource
+     */
+    String value();
+
+    /**
+     * @return the entry type (inbound or outbound), outbound by default
+     */
+    EntryType entryType() default EntryType.OUT;
+
+    /**
+     * @return name of the block exception function, empty by default
+     */
+    String blockHandler() default "";
+
+    /**
+     * @return name of the fallback function, empty by default
+     */
+    String fallback() default "";
+}

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/RecordLog.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/RecordLog.java
@@ -50,4 +50,14 @@ public class RecordLog extends LogBase {
         LoggerUtils.disableOtherHandlers(heliumRecordLog, logHandler);
         heliumRecordLog.log(Level.INFO, detail, e);
     }
+
+    public static void warn(String detail) {
+        LoggerUtils.disableOtherHandlers(heliumRecordLog, logHandler);
+        heliumRecordLog.log(Level.WARNING, detail);
+    }
+
+    public static void warn(String detail, Throwable e) {
+        LoggerUtils.disableOtherHandlers(heliumRecordLog, logHandler);
+        heliumRecordLog.log(Level.WARNING, detail, e);
+    }
 }

--- a/sentinel-demo/pom.xml
+++ b/sentinel-demo/pom.xml
@@ -19,6 +19,7 @@
         <module>sentinel-demo-dubbo</module>
         <module>sentinel-demo-nacos-datasource</module>
         <module>sentinel-demo-zookeeper-datasource</module>
+        <module>sentinel-demo-annotation-spring-aop</module>
     </modules>
 
     <dependencies>

--- a/sentinel-demo/sentinel-demo-annotation-spring-aop/pom.xml
+++ b/sentinel-demo/sentinel-demo-annotation-spring-aop/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sentinel-demo</artifactId>
+        <groupId>com.alibaba.csp</groupId>
+        <version>0.1.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>sentinel-demo-annotation-spring-aop</artifactId>
+
+    <properties>
+        <spring.boot.version>2.0.4.RELEASE</spring.boot.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-annotation-aspectj</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-transport-simple-http</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/sentinel-demo/sentinel-demo-annotation-spring-aop/src/main/java/com/alibaba/csp/sentinel/demo/annotation/aop/DemoApplication.java
+++ b/sentinel-demo/sentinel-demo-annotation-spring-aop/src/main/java/com/alibaba/csp/sentinel/demo/annotation/aop/DemoApplication.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.demo.annotation.aop;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * @author Eric Zhao
+ */
+@SpringBootApplication
+public class DemoApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(DemoApplication.class, args);
+    }
+}

--- a/sentinel-demo/sentinel-demo-annotation-spring-aop/src/main/java/com/alibaba/csp/sentinel/demo/annotation/aop/config/AopConfiguration.java
+++ b/sentinel-demo/sentinel-demo-annotation-spring-aop/src/main/java/com/alibaba/csp/sentinel/demo/annotation/aop/config/AopConfiguration.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.demo.annotation.aop.config;
+
+import com.alibaba.csp.sentinel.annotation.aspectj.SentinelResourceAspect;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Eric Zhao
+ */
+@Configuration
+public class AopConfiguration {
+
+    @Bean
+    public SentinelResourceAspect sentinelResourceAspect() {
+        return new SentinelResourceAspect();
+    }
+}

--- a/sentinel-demo/sentinel-demo-annotation-spring-aop/src/main/java/com/alibaba/csp/sentinel/demo/annotation/aop/controller/DemoController.java
+++ b/sentinel-demo/sentinel-demo-annotation-spring-aop/src/main/java/com/alibaba/csp/sentinel/demo/annotation/aop/controller/DemoController.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.demo.annotation.aop.controller;
+
+import com.alibaba.csp.sentinel.demo.annotation.aop.service.TestService;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Eric Zhao
+ */
+@RestController
+public class DemoController {
+
+    @Autowired
+    private TestService service;
+
+    @GetMapping("/foo")
+    public String foo() throws Exception {
+        service.test();
+        return service.hello(System.currentTimeMillis());
+    }
+}

--- a/sentinel-demo/sentinel-demo-annotation-spring-aop/src/main/java/com/alibaba/csp/sentinel/demo/annotation/aop/service/ExceptionUtil.java
+++ b/sentinel-demo/sentinel-demo-annotation-spring-aop/src/main/java/com/alibaba/csp/sentinel/demo/annotation/aop/service/ExceptionUtil.java
@@ -15,32 +15,14 @@
  */
 package com.alibaba.csp.sentinel.demo.annotation.aop.service;
 
-import com.alibaba.csp.sentinel.annotation.SentinelResource;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
-
-import org.springframework.stereotype.Service;
 
 /**
  * @author Eric Zhao
  */
-@Service
-public class TestServiceImpl implements TestService {
+public final class ExceptionUtil {
 
-    @Override
-    @SentinelResource(value = "test", blockHandler = "handleException", blockHandlerClass = {ExceptionUtil.class})
-    public void test() {
-        System.out.println("Test");
-    }
-
-    @Override
-    @SentinelResource(value = "hello", blockHandler = "exceptionHandler")
-    public String hello(long s) {
-        return String.format("Hello at %d", s);
-    }
-
-    public String exceptionHandler(long s, BlockException ex) {
-        // Do some log here.
-        ex.printStackTrace();
-        return "Oops, error occurred at " + s;
+    public static void handleException(BlockException ex) {
+        System.out.println("Oops: " + ex.getClass().getCanonicalName());
     }
 }

--- a/sentinel-demo/sentinel-demo-annotation-spring-aop/src/main/java/com/alibaba/csp/sentinel/demo/annotation/aop/service/TestService.java
+++ b/sentinel-demo/sentinel-demo-annotation-spring-aop/src/main/java/com/alibaba/csp/sentinel/demo/annotation/aop/service/TestService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.demo.annotation.aop.service;
+
+/**
+ * @author Eric Zhao
+ */
+public interface TestService {
+
+    void test();
+
+    String hello(long s);
+}

--- a/sentinel-demo/sentinel-demo-annotation-spring-aop/src/main/java/com/alibaba/csp/sentinel/demo/annotation/aop/service/TestServiceImpl.java
+++ b/sentinel-demo/sentinel-demo-annotation-spring-aop/src/main/java/com/alibaba/csp/sentinel/demo/annotation/aop/service/TestServiceImpl.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.demo.annotation.aop.service;
+
+import com.alibaba.csp.sentinel.annotation.SentinelResource;
+import com.alibaba.csp.sentinel.slots.block.BlockException;
+
+import org.springframework.stereotype.Service;
+
+/**
+ * @author Eric Zhao
+ */
+@Service
+public class TestServiceImpl implements TestService {
+
+    @Override
+    @SentinelResource("test")
+    public void test() {
+        System.out.println("Test");
+    }
+
+    @Override
+    @SentinelResource(value = "hello", blockHandler = "exceptionHandler")
+    public String hello(long s) {
+        return String.format("Hello at %d", s);
+    }
+
+    public String exceptionHandler(long s, BlockException ex) {
+        // Do some log here.
+        ex.printStackTrace();
+        return "Oops, error occurred at " + s;
+    }
+}

--- a/sentinel-demo/sentinel-demo-annotation-spring-aop/src/main/resources/application.properties
+++ b/sentinel-demo/sentinel-demo-annotation-spring-aop/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+spring.application.name=sentinel-annotation-aspectj-example
+server.port=19966

--- a/sentinel-extension/pom.xml
+++ b/sentinel-extension/pom.xml
@@ -15,6 +15,8 @@
         <module>sentinel-datasource-extension</module>
         <module>sentinel-datasource-nacos</module>
         <module>sentinel-datasource-zookeeper</module>
+
+        <module>sentinel-annotation-aspectj</module>
     </modules>
 
 </project>

--- a/sentinel-extension/sentinel-annotation-aspectj/README.md
+++ b/sentinel-extension/sentinel-annotation-aspectj/README.md
@@ -1,0 +1,63 @@
+# Sentinel Annotation AspectJ
+
+This extension is an AOP implementation using AspectJ for Sentinel annotations.
+Currently only runtime waving is supported.
+
+## Annotation
+
+The `@SentinelResource` annotation indicates a resource definition, including:
+
+- `value`: Resource name, required (cannot be empty)
+- `entryType`: Resource entry type (inbound or outbound), `EntryType.OUT` by default
+- `fallback`: Fallback method when degraded (optional). The fallback method should be located in the same class with original method. The signature of the fallback method should match the original method (parameter types and return type)
+- `blockHandler`: Handler method that handles `BlockException` when blocked. The block handler method should be located in the same class with original method, and the signature should match original method, with the last additional parameter type `BlockException`.
+
+For example:
+
+```java
+@SentinelResource(value = "abc", fallback = "doFallback", blockHandler = "handleException")
+public String doSomething(long i) {
+    return "Hello " + i;
+}
+
+public String doFallback(long i) {
+    // Return fallback value.
+    return "Oops, degraded";
+}
+
+public String handleException(long i, BlockException ex) {
+    // Handle the block exception here.
+    return null;
+}
+```
+
+## Configuration
+
+### AspectJ
+
+If you are using AspectJ directly, you can add the Sentinel annotation aspect to
+your `aop.xml`:
+
+```xml
+<aspects>
+    <aspect name="com.alibaba.csp.sentinel.annotation.aspectj.SentinelResourceAspect"/>
+</aspects>
+```
+
+### Spring AOP
+
+If you are using Spring AOP, you should add a configuration to register the aspect
+as a Spring bean:
+
+```java
+@Configuration
+public class SentinelAspectConfiguration {
+
+    @Bean
+    public SentinelResourceAspect sentinelResourceAspect() {
+        return new SentinelResourceAspect();
+    }
+}
+```
+
+An example for using Sentinel Annotation AspectJ with Spring Boot can be found [here](https://github.com/alibaba/Sentinel/tree/master/sentinel-demo/sentinel-demo-annotation-spring-aop).

--- a/sentinel-extension/sentinel-annotation-aspectj/README.md
+++ b/sentinel-extension/sentinel-annotation-aspectj/README.md
@@ -9,8 +9,14 @@ The `@SentinelResource` annotation indicates a resource definition, including:
 
 - `value`: Resource name, required (cannot be empty)
 - `entryType`: Resource entry type (inbound or outbound), `EntryType.OUT` by default
-- `fallback`: Fallback method when degraded (optional). The fallback method should be located in the same class with original method. The signature of the fallback method should match the original method (parameter types and return type)
-- `blockHandler`: Handler method that handles `BlockException` when blocked. The block handler method should be located in the same class with original method, and the signature should match original method, with the last additional parameter type `BlockException`.
+- `fallback`: Fallback method when degraded (optional).
+The fallback method should be located in the same class with original method.
+The signature of the fallback method should match the original method (parameter types and return type).
+- `blockHandler`: Handler method that handles `BlockException` when blocked.
+The signature should match original method, with the last additional parameter type `BlockException`.
+The block handler method should be located in the same class with original method by default.
+If you want to use method in other classes, you can set the `blockHandlerClass` with corresponding `Class`
+(Note the method in other classes must be *static*).
 
 For example:
 

--- a/sentinel-extension/sentinel-annotation-aspectj/pom.xml
+++ b/sentinel-extension/sentinel-annotation-aspectj/pom.xml
@@ -32,6 +32,12 @@
             <artifactId>aspectjweaver</artifactId>
             <version>${aspectj.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.25</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/sentinel-extension/sentinel-annotation-aspectj/pom.xml
+++ b/sentinel-extension/sentinel-annotation-aspectj/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sentinel-extension</artifactId>
+        <groupId>com.alibaba.csp</groupId>
+        <version>0.1.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>sentinel-annotation-aspectj</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <aspectj.version>1.9.1</aspectj.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjrt</artifactId>
+            <version>${aspectj.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjweaver</artifactId>
+            <version>${aspectj.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/MethodWrapper.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/MethodWrapper.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.annotation.aspectj;
+
+import java.lang.reflect.Method;
+
+/**
+ * @author Eric Zhao
+ */
+class MethodWrapper {
+
+    private final Method method;
+    private final boolean present;
+
+    private MethodWrapper(Method method, boolean present) {
+        this.method = method;
+        this.present = present;
+    }
+
+    static MethodWrapper wrap(Method method) {
+        if (method == null) {
+            return none();
+        }
+        return new MethodWrapper(method, true);
+    }
+
+    static MethodWrapper none() {
+        return new MethodWrapper(null, false);
+    }
+
+    Method getMethod() {
+        return method;
+    }
+
+    boolean isPresent() {
+        return present;
+    }
+}

--- a/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/ResourceMetadataRegistry.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/ResourceMetadataRegistry.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.annotation.aspectj;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.alibaba.csp.sentinel.util.StringUtil;
+
+/**
+ * @author Eric Zhao
+ */
+public final class ResourceMetadataRegistry {
+
+    private static final Map<String, MethodWrapper> FALLBACK_MAP = new ConcurrentHashMap<String, MethodWrapper>();
+    private static final Map<String, MethodWrapper> BLOCK_HANDLER_MAP = new ConcurrentHashMap<String, MethodWrapper>();
+
+    public static MethodWrapper lookupFallback(Class<?> clazz, String name) {
+        return FALLBACK_MAP.get(getKey(clazz, name));
+    }
+
+    public static MethodWrapper lookupBlockHandler(Class<?> clazz, String name) {
+        return BLOCK_HANDLER_MAP.get(getKey(clazz, name));
+    }
+
+    public static void updateFallbackFor(Class<?> clazz, String name, Method method) {
+        if (clazz == null || StringUtil.isBlank(name)) {
+            throw new IllegalArgumentException("Bad argument");
+        }
+        FALLBACK_MAP.put(getKey(clazz, name), MethodWrapper.wrap(method));
+    }
+
+    public static void updateBlockHandlerFor(Class<?> clazz, String name, Method method) {
+        if (clazz == null || StringUtil.isBlank(name)) {
+            throw new IllegalArgumentException("Bad argument");
+        }
+        BLOCK_HANDLER_MAP.put(getKey(clazz, name), MethodWrapper.wrap(method));
+    }
+
+    public static String getKey(Class<?> clazz, String name) {
+        return String.format("%s:%s", clazz.getCanonicalName(), name);
+    }
+}

--- a/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/ResourceMetadataRegistry.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/ResourceMetadataRegistry.java
@@ -22,36 +22,38 @@ import java.util.concurrent.ConcurrentHashMap;
 import com.alibaba.csp.sentinel.util.StringUtil;
 
 /**
+ * Registry for resource configuration metadata (e.g. fallback method)
+ *
  * @author Eric Zhao
  */
-public final class ResourceMetadataRegistry {
+final class ResourceMetadataRegistry {
 
     private static final Map<String, MethodWrapper> FALLBACK_MAP = new ConcurrentHashMap<String, MethodWrapper>();
     private static final Map<String, MethodWrapper> BLOCK_HANDLER_MAP = new ConcurrentHashMap<String, MethodWrapper>();
 
-    public static MethodWrapper lookupFallback(Class<?> clazz, String name) {
+    static MethodWrapper lookupFallback(Class<?> clazz, String name) {
         return FALLBACK_MAP.get(getKey(clazz, name));
     }
 
-    public static MethodWrapper lookupBlockHandler(Class<?> clazz, String name) {
+    static MethodWrapper lookupBlockHandler(Class<?> clazz, String name) {
         return BLOCK_HANDLER_MAP.get(getKey(clazz, name));
     }
 
-    public static void updateFallbackFor(Class<?> clazz, String name, Method method) {
+    static void updateFallbackFor(Class<?> clazz, String name, Method method) {
         if (clazz == null || StringUtil.isBlank(name)) {
             throw new IllegalArgumentException("Bad argument");
         }
         FALLBACK_MAP.put(getKey(clazz, name), MethodWrapper.wrap(method));
     }
 
-    public static void updateBlockHandlerFor(Class<?> clazz, String name, Method method) {
+    static void updateBlockHandlerFor(Class<?> clazz, String name, Method method) {
         if (clazz == null || StringUtil.isBlank(name)) {
             throw new IllegalArgumentException("Bad argument");
         }
         BLOCK_HANDLER_MAP.put(getKey(clazz, name), MethodWrapper.wrap(method));
     }
 
-    public static String getKey(Class<?> clazz, String name) {
+    private static String getKey(Class<?> clazz, String name) {
         return String.format("%s:%s", clazz.getCanonicalName(), name);
     }
 }

--- a/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/SentinelResourceAspect.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/SentinelResourceAspect.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.annotation.aspectj;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import com.alibaba.csp.sentinel.Entry;
+import com.alibaba.csp.sentinel.EntryType;
+import com.alibaba.csp.sentinel.SphU;
+import com.alibaba.csp.sentinel.annotation.SentinelResource;
+import com.alibaba.csp.sentinel.context.ContextUtil;
+import com.alibaba.csp.sentinel.log.RecordLog;
+import com.alibaba.csp.sentinel.slots.block.BlockException;
+import com.alibaba.csp.sentinel.slots.block.degrade.DegradeException;
+import com.alibaba.csp.sentinel.util.StringUtil;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+
+/**
+ * Aspect for methods with {@link SentinelResource} annotation.
+ *
+ * @author Eric Zhao
+ */
+@Aspect
+public class SentinelResourceAspect {
+
+    @Pointcut("@annotation(com.alibaba.csp.sentinel.annotation.SentinelResource)")
+    public void sentinelResourceAnnotationPointcut() {
+    }
+
+    @Around("sentinelResourceAnnotationPointcut()")
+    public Object invokeResourceWithSentinel(ProceedingJoinPoint pjp) throws Throwable {
+        Method originMethod = getMethod(pjp);
+
+        SentinelResource annotation = originMethod.getAnnotation(SentinelResource.class);
+        if (annotation == null) {
+            // Should not go through here.
+            throw new IllegalStateException("Wrong state for SentinelResource annotation");
+        }
+        String resourceName = annotation.value();
+        EntryType entryType = annotation.entryType();
+        Entry entry = null;
+        try {
+            ContextUtil.enter(resourceName);
+            entry = SphU.entry(resourceName, entryType);
+            Object result = pjp.proceed();
+            return result;
+        } catch (BlockException ex) {
+            return handleBlockException(pjp, annotation, ex);
+        } finally {
+            if (entry != null) {
+                entry.exit();
+            }
+            ContextUtil.exit();
+        }
+    }
+
+    private Object handleBlockException(ProceedingJoinPoint pjp, SentinelResource annotation, BlockException ex)
+        throws Exception {
+        // Execute fallback for degrading if configured.
+        Object[] originArgs = pjp.getArgs();
+        if (isDegradeFailure(ex)) {
+            Method method = extractFallbackMethod(pjp, annotation.fallback());
+            if (method != null) {
+                return method.invoke(pjp.getTarget(), originArgs);
+            }
+        }
+        // Execute block handler if configured.
+        Method blockHandler = extractBlockHandlerMethod(pjp, annotation.blockHandler());
+        if (blockHandler != null) {
+            Object[] args = Arrays.copyOf(originArgs, originArgs.length + 1);
+            args[args.length - 1] = ex;
+            return blockHandler.invoke(pjp.getTarget(), args);
+        }
+        // If no block handler is present, then directly throw the exception.
+        throw ex;
+    }
+
+    private boolean isDegradeFailure(/*@NonNull*/ BlockException ex) {
+        return ex instanceof DegradeException;
+    }
+
+    private Method extractFallbackMethod(ProceedingJoinPoint pjp, String fallbackName) {
+        if (StringUtil.isBlank(fallbackName)) {
+            return null;
+        }
+        Class<?> clazz = pjp.getTarget().getClass();
+        MethodWrapper m = ResourceMetadataRegistry.lookupFallback(clazz, fallbackName);
+        if (m == null) {
+            // First time, resolve the fallback.
+            Method method = resolveFallbackInternal(pjp, fallbackName);
+            // Cache the method instance.
+            ResourceMetadataRegistry.updateFallbackFor(clazz, fallbackName, method);
+            return method;
+        }
+        if (!m.isPresent()) {
+            return null;
+        }
+        return m.getMethod();
+    }
+
+    private Method resolveFallbackInternal(ProceedingJoinPoint pjp, /*@NonNull*/ String name) {
+        Method originMethod = getMethod(pjp);
+        Class<?>[] parameterTypes = originMethod.getParameterTypes();
+        return findMethod(pjp.getTarget().getClass(), name, originMethod.getReturnType(), parameterTypes);
+    }
+
+    private Method findMethod(Class<?> clazz, String name, Class<?> returnType, Class<?>... parameterTypes) {
+        Method[] methods = clazz.getDeclaredMethods();
+        for (Method method : methods) {
+            if (name.equals(method.getName()) && returnType.isAssignableFrom(method.getReturnType())
+                && Arrays.equals(parameterTypes, method.getParameterTypes())) {
+                return method;
+            }
+        }
+        // Current class nou found, find in the super classes recursively.
+        Class<?> superClass = clazz.getSuperclass();
+        if (superClass != null && !Object.class.equals(superClass)) {
+            return findMethod(superClass, name, returnType, parameterTypes);
+        } else {
+            RecordLog.info(
+                String.format("[SentinelResourceAspect] Cannot find method [%s] in class [%s] with parameters %s",
+                    name, clazz.getCanonicalName(), Arrays.toString(parameterTypes)));
+            return null;
+        }
+    }
+
+    private Method extractBlockHandlerMethod(ProceedingJoinPoint pjp, String name) {
+        if (StringUtil.isBlank(name)) {
+            return null;
+        }
+        Class<?> clazz = pjp.getTarget().getClass();
+        MethodWrapper m = ResourceMetadataRegistry.lookupBlockHandler(clazz, name);
+        if (m == null) {
+            // First time, resolve the block handler.
+            Method method = resolveBlockHandlerInternal(pjp, name);
+            // Cache the method instance.
+            ResourceMetadataRegistry.updateBlockHandlerFor(clazz, name, method);
+            return method;
+        }
+        if (!m.isPresent()) {
+            return null;
+        }
+        return m.getMethod();
+    }
+
+    private Method resolveBlockHandlerInternal(ProceedingJoinPoint pjp, /*@NonNull*/ String name) {
+        Method originMethod = getMethod(pjp);
+        Class<?>[] originList = originMethod.getParameterTypes();
+        Class<?>[] parameterTypes = Arrays.copyOf(originList, originList.length + 1);
+        parameterTypes[parameterTypes.length - 1] = BlockException.class;
+        return findMethod(pjp.getTarget().getClass(), name, originMethod.getReturnType(), parameterTypes);
+    }
+
+    private Method getMethod(ProceedingJoinPoint joinPoint) {
+        MethodSignature signature = (MethodSignature)joinPoint.getSignature();
+        return signature.getMethod();
+    }
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

- Add Sentinel annotation definition (in `sentinel-core`)
- Add AspectJ support for Sentinel annotation

### Does this pull request fix one issue?

Resolves #11 

### Describe how you did it

The `@SentinelResource` contains:

- resource name (required)
- resource entry type (optional)
- fallback method (optional)
- block handler method (optional)

We've implemented an aspect with the pointcut around any methods annotated with `@SentinelResource`, and wrap with Sentinel API.