### PR TITLE
Support extensible slot chain builder using SPI mechanism

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/CtSph.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/CtSph.java
@@ -28,6 +28,7 @@ import com.alibaba.csp.sentinel.slotchain.MethodResourceWrapper;
 import com.alibaba.csp.sentinel.slotchain.ProcessorSlot;
 import com.alibaba.csp.sentinel.slotchain.ProcessorSlotChain;
 import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
+import com.alibaba.csp.sentinel.slotchain.SlotChainProvider;
 import com.alibaba.csp.sentinel.slotchain.StringResourceWrapper;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
 import com.alibaba.csp.sentinel.slots.block.Rule;
@@ -133,7 +134,7 @@ public class CtSph implements Sph {
                         return null;
                     }
 
-                    chain = Env.slotsChainbuilder.build();
+                    chain = SlotChainProvider.newSlotChain();
                     Map<ResourceWrapper, ProcessorSlotChain> newMap = new HashMap<ResourceWrapper, ProcessorSlotChain>(
                         chainMap.size() + 1);
                     newMap.putAll(chainMap);

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Env.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Env.java
@@ -18,8 +18,6 @@ package com.alibaba.csp.sentinel;
 import com.alibaba.csp.sentinel.init.InitExecutor;
 import com.alibaba.csp.sentinel.node.DefaultNodeBuilder;
 import com.alibaba.csp.sentinel.node.NodeBuilder;
-import com.alibaba.csp.sentinel.slots.DefaultSlotChainBuilder;
-import com.alibaba.csp.sentinel.slotchain.SlotChainBuilder;
 
 /**
  * @author jialiang.linjl

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Env.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Env.java
@@ -18,15 +18,14 @@ package com.alibaba.csp.sentinel;
 import com.alibaba.csp.sentinel.init.InitExecutor;
 import com.alibaba.csp.sentinel.node.DefaultNodeBuilder;
 import com.alibaba.csp.sentinel.node.NodeBuilder;
-import com.alibaba.csp.sentinel.slots.DefaultSlotsChainBuilder;
-import com.alibaba.csp.sentinel.slots.SlotsChainBuilder;
+import com.alibaba.csp.sentinel.slots.DefaultSlotChainBuilder;
+import com.alibaba.csp.sentinel.slotchain.SlotChainBuilder;
 
 /**
  * @author jialiang.linjl
  */
 public class Env {
 
-    public static final SlotsChainBuilder slotsChainbuilder = new DefaultSlotsChainBuilder();
     public static final NodeBuilder nodeBuilder = new DefaultNodeBuilder();
     public static final Sph sph = new CtSph();
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slotchain/SlotChainBuilder.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slotchain/SlotChainBuilder.java
@@ -13,20 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alibaba.csp.sentinel.slots;
-
-import com.alibaba.csp.sentinel.slotchain.ProcessorSlotChain;
+package com.alibaba.csp.sentinel.slotchain;
 
 /**
+ * The builder for processor slot chain.
+ *
  * @author qinan.qn
  * @author leyou
+ * @author Eric Zhao
  */
-public interface SlotsChainBuilder {
+public interface SlotChainBuilder {
 
     /**
-     * Helper method to create processor slot chain.
+     * Build the processor slot chain.
      *
-     * @return a processor slot that chain some slots together.
+     * @return a processor slot that chain some slots together
      */
     ProcessorSlotChain build();
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slotchain/SlotChainProvider.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slotchain/SlotChainProvider.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.slotchain;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+
+import com.alibaba.csp.sentinel.log.RecordLog;
+import com.alibaba.csp.sentinel.slots.DefaultSlotChainBuilder;
+
+/**
+ * A provider for creating slot chains via resolved slot chain builder SPI.
+ *
+ * @author Eric Zhao
+ * @since 0.2.0
+ */
+public final class SlotChainProvider {
+
+    private static volatile SlotChainBuilder builder = null;
+
+    private static final ServiceLoader<SlotChainBuilder> LOADER = ServiceLoader.load(SlotChainBuilder.class);
+
+    /**
+     * The load and pick process is not thread-safe, but it's okay since the method should be only invoked
+     * via {@code lookProcessChain} in {@link com.alibaba.csp.sentinel.CtSph} under lock.
+     *
+     * @return new created slot chain
+     */
+    public static ProcessorSlotChain newSlotChain() {
+        if (builder != null) {
+            return builder.build();
+        }
+
+        resolveSlotChainBuilder();
+
+        if (builder == null) {
+            RecordLog.warn("[SlotChainProvider] Wrong state when resolving slot chain builder, using default");
+            builder = new DefaultSlotChainBuilder();
+        }
+        return builder.build();
+    }
+
+    private static void resolveSlotChainBuilder() {
+        List<SlotChainBuilder> list = new ArrayList<SlotChainBuilder>();
+        boolean hasOther = false;
+        for (SlotChainBuilder builder : LOADER) {
+            if (builder.getClass() != DefaultSlotChainBuilder.class) {
+                hasOther = true;
+                list.add(builder);
+            }
+        }
+        if (hasOther) {
+            builder = list.get(0);
+        } else {
+            // No custom builder, using default.
+            builder = new DefaultSlotChainBuilder();
+        }
+
+        RecordLog.info("[SlotChainProvider] Global slot chain builder resolved: "
+            + builder.getClass().getCanonicalName());
+    }
+
+    private SlotChainProvider() {}
+}

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/DefaultSlotChainBuilder.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/DefaultSlotChainBuilder.java
@@ -17,6 +17,7 @@ package com.alibaba.csp.sentinel.slots;
 
 import com.alibaba.csp.sentinel.slotchain.DefaultProcessorSlotChain;
 import com.alibaba.csp.sentinel.slotchain.ProcessorSlotChain;
+import com.alibaba.csp.sentinel.slotchain.SlotChainBuilder;
 import com.alibaba.csp.sentinel.slots.block.authority.AuthoritySlot;
 import com.alibaba.csp.sentinel.slots.block.degrade.DegradeSlot;
 import com.alibaba.csp.sentinel.slots.block.flow.FlowSlot;
@@ -32,7 +33,7 @@ import com.alibaba.csp.sentinel.slots.system.SystemSlot;
  * @author qinan.qn
  * @author leyou
  */
-public class DefaultSlotsChainBuilder implements SlotsChainBuilder {
+public class DefaultSlotChainBuilder implements SlotChainBuilder {
 
     @Override
     public ProcessorSlotChain build() {

--- a/sentinel-core/src/main/resources/META-INF/services/com.alibaba.csp.sentinel.slotchain.SlotChainBuilder
+++ b/sentinel-core/src/main/resources/META-INF/services/com.alibaba.csp.sentinel.slotchain.SlotChainBuilder
@@ -1,0 +1,2 @@
+# Default slot chain builder
+com.alibaba.csp.sentinel.slots.DefaultSlotChainBuilder


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Support extensible slot chain builder.

Due to the fact that the order between slots in slot chain is essential, we make the slot chain builder extensible so that users can implement their own builder, where they can arrange the order between slots.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Resolves #55 

### Describe how you did it

- The `SlotChainBuilder` is extensible now using Java SPI mechanism. `sentinel-core` provides the basic implementation `DefaultSlotChainBuilder`.
- Add a `SlotChainProvider` to load slot chain builder and create new slot chain. The rule:
    - If there is no user-defined `SlotChainBuilder`, then use the default builder
    - If user-defined `SlotChainBuilder` exists, the provider will pick the first loaded slot chain builder, then cache the builder.

### Describe how to verify it

Integration test between modules to verify the load order of multi slot chain builders.
