### PR TITLE
Fix internal bug when amount of context exceeds the threshold

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Constants.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Constants.java
@@ -31,7 +31,7 @@ public class Constants {
     public final static int MAX_CONTEXT_NAME_SIZE = 2000;
     public final static int MAX_SLOT_CHAIN_SIZE = 6000;
     public final static String ROOT_ID = "machine-root";
-    public final static String CONTEXT_DEFAULT_NAME = "default_context_name";
+    public final static String CONTEXT_DEFAULT_NAME = "sentinel_default_context";
 
     public final static DefaultNode ROOT = new EntranceNode(new StringResourceWrapper(ROOT_ID, EntryType.IN),
         Env.nodeBuilder.buildClusterNode());

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/CtEntry.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/CtEntry.java
@@ -17,6 +17,7 @@ package com.alibaba.csp.sentinel;
 
 import com.alibaba.csp.sentinel.context.Context;
 import com.alibaba.csp.sentinel.context.ContextUtil;
+import com.alibaba.csp.sentinel.context.NullContext;
 import com.alibaba.csp.sentinel.node.Node;
 import com.alibaba.csp.sentinel.slotchain.ProcessorSlot;
 import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
@@ -59,13 +60,16 @@ class CtEntry extends Entry {
     protected void exitForContext(Context context, int count, Object... args) throws ErrorEntryFreeException {
         if (context != null) {
             if (context.getCurEntry() != this) {
+                String curEntryNameInContext = context.getCurEntry() == null ? null : context.getCurEntry().getResourceWrapper().getName();
                 // Clean previous call stack.
                 CtEntry e = (CtEntry)context.getCurEntry();
                 while (e != null) {
                     e.exit(count, args);
                     e = (CtEntry)e.parent;
                 }
-                throw new ErrorEntryFreeException("The order of entry free is can't be paired with the order of entry");
+                String errorMessage = String.format("The order of entry exit can't be paired with the order of entry"
+                    + ", current entry in context: <%s>, but expected: <%s>", curEntryNameInContext, resourceWrapper.getName());
+                throw new ErrorEntryFreeException(errorMessage);
             } else {
                 if (chain != null) {
                     chain.exit(context, resourceWrapper, count, args);
@@ -75,8 +79,9 @@ class CtEntry extends Entry {
                 if (parent != null) {
                     ((CtEntry)parent).child = null;
                 }
-                if (parent == null) {
-                    // Auto-created entry indicates immediate exit.
+                if (parent == null && !(context instanceof NullContext)) {
+                    // Default context (auto entered) will be exited automatically.
+                    // Note: NullContext won't be exited automatically.
                     ContextUtil.exit();
                 }
                 // Clean the reference of context in current entry to avoid duplicate exit.

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/CtEntry.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/CtEntry.java
@@ -45,6 +45,10 @@ class CtEntry extends Entry {
     }
 
     private void setUpEntryFor(Context context) {
+        // The entry should not be associated to NullContext.
+        if (context instanceof NullContext) {
+            return;
+        }
         this.parent = context.getCurEntry();
         if (parent != null) {
             ((CtEntry)parent).child = this;
@@ -59,6 +63,10 @@ class CtEntry extends Entry {
 
     protected void exitForContext(Context context, int count, Object... args) throws ErrorEntryFreeException {
         if (context != null) {
+            // Null context should exit without clean-up.
+            if (context instanceof NullContext) {
+                return;
+            }
             if (context.getCurEntry() != this) {
                 String curEntryNameInContext = context.getCurEntry() == null ? null : context.getCurEntry().getResourceWrapper().getName();
                 // Clean previous call stack.
@@ -79,7 +87,7 @@ class CtEntry extends Entry {
                 if (parent != null) {
                     ((CtEntry)parent).child = null;
                 }
-                if (parent == null && !(context instanceof NullContext)) {
+                if (parent == null) {
                     // Default context (auto entered) will be exited automatically.
                     // Note: NullContext won't be exited automatically.
                     ContextUtil.exit();

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/CtSph.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/CtSph.java
@@ -56,7 +56,8 @@ public class CtSph implements Sph {
     private AsyncEntry asyncEntryInternal(ResourceWrapper resourceWrapper, int count, Object... args) throws BlockException {
         Context context = ContextUtil.getContext();
         if (context instanceof NullContext) {
-            // Init the entry only. No rule checking will occur.
+            // The {@link NullContext} indicates that the amount of context has exceeded the threshold,
+            // so here init the entry only. No rule checking will be done.
             return new AsyncEntry(resourceWrapper, null, context);
         }
         if (context == null) {
@@ -112,7 +113,8 @@ public class CtSph implements Sph {
     public Entry entry(ResourceWrapper resourceWrapper, int count, Object... args) throws BlockException {
         Context context = ContextUtil.getContext();
         if (context instanceof NullContext) {
-            // Init the entry only. No rule checking will occur.
+            // The {@link NullContext} indicates that the amount of context has exceeded the threshold,
+            // so here init the entry only. No rule checking will be done.
             return new CtEntry(resourceWrapper, null, context);
         }
 
@@ -142,6 +144,7 @@ public class CtSph implements Sph {
             e.exit(count, args);
             throw e1;
         } catch (Throwable e1) {
+            // This should not happen, unless there are errors existing in Sentinel internal.
             RecordLog.info("Sentinel unexpected exception", e1);
         }
         return e;

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/context/Context.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/context/Context.java
@@ -187,4 +187,15 @@ public class Context {
     public Node getOriginNode() {
         return curEntry == null ? null : curEntry.getOriginNode();
     }
+
+    @Override
+    public String toString() {
+        return "Context{" +
+            "name='" + name + '\'' +
+            ", entranceNode=" + entranceNode +
+            ", curEntry=" + curEntry +
+            ", origin='" + origin + '\'' +
+            ", async=" + async +
+            '}';
+    }
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/context/ContextUtil.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/context/ContextUtil.java
@@ -49,7 +49,7 @@ public class ContextUtil {
     private static ThreadLocal<Context> contextHolder = new ThreadLocal<Context>();
 
     /**
-     * Holds all {@link EntranceNode}
+     * Holds all {@link EntranceNode}.
      */
     private static volatile Map<String, DefaultNode> contextNameNodeMap = new HashMap<String, DefaultNode>();
 
@@ -58,8 +58,22 @@ public class ContextUtil {
 
     static {
         // Cache the entrance node for default context.
+        initDefaultContext();
+    }
+
+    private static void initDefaultContext() {
         contextNameNodeMap.put(Constants.CONTEXT_DEFAULT_NAME, new EntranceNode(
             new StringResourceWrapper(Constants.CONTEXT_DEFAULT_NAME, EntryType.IN), null));
+    }
+
+    /**
+     * Not thread-safe, only for test.
+     */
+    static void resetContextMap() {
+        if (contextNameNodeMap != null) {
+            contextNameNodeMap.clear();
+            initDefaultContext();
+        }
     }
 
     /**
@@ -104,7 +118,7 @@ public class ContextUtil {
             Map<String, DefaultNode> localCacheNameMap = contextNameNodeMap;
             DefaultNode node = localCacheNameMap.get(name);
             if (node == null) {
-                if (localCacheNameMap.size() >= Constants.MAX_CONTEXT_NAME_SIZE) {
+                if (localCacheNameMap.size() > Constants.MAX_CONTEXT_NAME_SIZE) {
                     contextHolder.set(NULL_CONTEXT);
                     return NULL_CONTEXT;
                 } else {
@@ -112,7 +126,7 @@ public class ContextUtil {
                         LOCK.lock();
                         node = contextNameNodeMap.get(name);
                         if (node == null) {
-                            if (contextNameNodeMap.size() >= Constants.MAX_CONTEXT_NAME_SIZE) {
+                            if (contextNameNodeMap.size() > Constants.MAX_CONTEXT_NAME_SIZE) {
                                 contextHolder.set(NULL_CONTEXT);
                                 return NULL_CONTEXT;
                             } else {

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/context/ContextUtil.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/context/ContextUtil.java
@@ -62,8 +62,10 @@ public class ContextUtil {
     }
 
     private static void initDefaultContext() {
-        contextNameNodeMap.put(Constants.CONTEXT_DEFAULT_NAME, new EntranceNode(
-            new StringResourceWrapper(Constants.CONTEXT_DEFAULT_NAME, EntryType.IN), null));
+        String defaultContextName = Constants.CONTEXT_DEFAULT_NAME;
+        EntranceNode node = new EntranceNode(new StringResourceWrapper(defaultContextName, EntryType.IN), null);
+        Constants.ROOT.addChild(node);
+        contextNameNodeMap.put(defaultContextName, node);
     }
 
     /**

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/context/ContextUtil.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/context/ContextUtil.java
@@ -56,6 +56,12 @@ public class ContextUtil {
     private static final ReentrantLock LOCK = new ReentrantLock();
     private static final Context NULL_CONTEXT = new NullContext();
 
+    static {
+        // Cache the entrance node for default context.
+        contextNameNodeMap.put(Constants.CONTEXT_DEFAULT_NAME, new EntranceNode(
+            new StringResourceWrapper(Constants.CONTEXT_DEFAULT_NAME, EntryType.IN), null));
+    }
+
     /**
      * <p>
      * Enter the invocation context. The context is ThreadLocal, meaning that
@@ -98,14 +104,16 @@ public class ContextUtil {
             Map<String, DefaultNode> localCacheNameMap = contextNameNodeMap;
             DefaultNode node = localCacheNameMap.get(name);
             if (node == null) {
-                if (localCacheNameMap.size() > Constants.MAX_CONTEXT_NAME_SIZE) {
+                if (localCacheNameMap.size() >= Constants.MAX_CONTEXT_NAME_SIZE) {
+                    contextHolder.set(NULL_CONTEXT);
                     return NULL_CONTEXT;
                 } else {
                     try {
                         LOCK.lock();
                         node = contextNameNodeMap.get(name);
                         if (node == null) {
-                            if (contextNameNodeMap.size() > Constants.MAX_CONTEXT_NAME_SIZE) {
+                            if (contextNameNodeMap.size() >= Constants.MAX_CONTEXT_NAME_SIZE) {
+                                contextHolder.set(NULL_CONTEXT);
                                 return NULL_CONTEXT;
                             } else {
                                 node = new EntranceNode(new StringResourceWrapper(name, EntryType.IN), null);

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/context/NullContext.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/context/NullContext.java
@@ -27,7 +27,6 @@ import com.alibaba.csp.sentinel.Constants;
 public class NullContext extends Context {
 
     public NullContext() {
-        super(null, null);
+        super(null, "null_context_internal");
     }
-
 }

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/context/ContextTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/context/ContextTest.java
@@ -81,6 +81,7 @@ public class ContextTest {
 
     private void resetContextMap() {
         ContextUtil.resetContextMap();
+        Constants.ROOT.removeChildList();
     }
 
     @Test


### PR DESCRIPTION
### Describe what this PR does / why we need it

Fix internal bug when amount of context exceeds the threshold.

### Does this pull request fix one issue?

Fixes #151 

### Describe how you did it

- When amount of context exceeds the threshold, the `NullContext` will be set to current thread local. Thus, when checking context in `CtSph#entry`, once `NullContext` detected, the entry will not do rule checking on the slot chain.
- Cache the default context during initialization. Then when amount of context exceeds the threshold, entries under default context can do rule checking under default context.
- Enhance the error message.

### Describe how to verify it

See test cases.
