### PR TITLE
Support degrade by exception count

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/RuleConstant.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/RuleConstant.java
@@ -25,7 +25,8 @@ public final class RuleConstant {
     public static final int FLOW_GRADE_QPS = 1;
 
     public static final int DEGRADE_GRADE_RT = 0;
-    public static final int DEGRADE_GRADE_EXCEPTION = 1;
+    public static final int DEGRADE_GRADE_EXCEPTION_RATIO = 1;
+    public static final int DEGRADE_GRADE_EXCEPTION_COUNT = 2;
 
     public static final int AUTHORITY_WHITE = 0;
     public static final int AUTHORITY_BLACK = 1;

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/RuleConstant.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/RuleConstant.java
@@ -15,6 +15,8 @@
  */
 package com.alibaba.csp.sentinel.slots.block;
 
+import com.alibaba.csp.sentinel.node.IntervalProperty;
+
 /***
  * @author youji.zj
  * @author jialiang.linjl
@@ -25,7 +27,13 @@ public final class RuleConstant {
     public static final int FLOW_GRADE_QPS = 1;
 
     public static final int DEGRADE_GRADE_RT = 0;
+    /**
+     * Degrade by biz exception ratio in the current {@link IntervalProperty#INTERVAL} second(s).
+     */
     public static final int DEGRADE_GRADE_EXCEPTION_RATIO = 1;
+    /**
+     * Degrade by biz exception count in the last 60 seconds.
+     */
     public static final int DEGRADE_GRADE_EXCEPTION_COUNT = 2;
 
     public static final int AUTHORITY_WHITE = 0;

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeRule.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeRule.java
@@ -173,7 +173,7 @@ public class DegradeRule extends AbstractRule {
             if (passCount.incrementAndGet() < RT_MAX_EXCEED_N) {
                 return true;
             }
-        } else {
+        } else if (grade == RuleConstant.DEGRADE_GRADE_EXCEPTION_RATIO) {
             double exception = clusterNode.exceptionQps();
             double success = clusterNode.successQps();
             long total = clusterNode.totalQps();
@@ -188,6 +188,11 @@ public class DegradeRule extends AbstractRule {
             }
 
             if (exception / success < count) {
+                return true;
+            }
+        } else if (grade == RuleConstant.DEGRADE_GRADE_EXCEPTION_COUNT) {
+            double exception = clusterNode.totalException();
+            if (exception < count) {
                 return true;
             }
         }

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeTest.java
@@ -82,7 +82,7 @@ public class DegradeTest {
         rule.setCount(0.15);
         rule.setResource(key);
         rule.setTimeWindow(5);
-        rule.setGrade(RuleConstant.DEGRADE_GRADE_EXCEPTION);
+        rule.setGrade(RuleConstant.DEGRADE_GRADE_EXCEPTION_RATIO);
 
         when(cn.successQps()).thenReturn(8L);
 
@@ -93,6 +93,36 @@ public class DegradeTest {
         TimeUnit.SECONDS.sleep(6);
 
         when(cn.successQps()).thenReturn(20L);
+        // Will pass.
+        assertTrue(rule.passCheck(context, node, 1));
+    }
+
+    @Test
+    public void testExceptionCountModeDegrade() throws Throwable {
+        String key = "test_degrade_exception_count";
+        ClusterNode cn = mock(ClusterNode.class);
+        when(cn.totalException()).thenReturn(10L);
+        ClusterBuilderSlot.getClusterNodeMap().put(new StringResourceWrapper(key, EntryType.IN), cn);
+
+        Context context = mock(Context.class);
+        DefaultNode node = mock(DefaultNode.class);
+        when(node.getClusterNode()).thenReturn(cn);
+
+        DegradeRule rule = new DegradeRule();
+        rule.setCount(4);
+        rule.setResource(key);
+        rule.setTimeWindow(2);
+        rule.setGrade(RuleConstant.DEGRADE_GRADE_EXCEPTION_COUNT);
+
+        when(cn.totalException()).thenReturn(4L);
+
+        // Will fail.
+        assertFalse(rule.passCheck(context, node, 1));
+
+        // Restore from the degrade timeout.
+        TimeUnit.SECONDS.sleep(3);
+
+        when(cn.totalException()).thenReturn(0L);
         // Will pass.
         assertTrue(rule.passCheck(context, node, 1));
     }

--- a/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/degrade/ExceptionCountDegradeDemo.java
+++ b/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/degrade/ExceptionCountDegradeDemo.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 1999-2018 Alibaba Group Holding Ltd.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.alibaba.csp.sentinel.demo.degrade;
 
 import java.util.ArrayList;
@@ -36,12 +21,12 @@ import com.alibaba.csp.sentinel.util.TimeUtil;
  * measure whether a resource is stable or not:
  * <ul>
  * <li>
- * Exception ratio: When the ratio of exception count per second and the success
- * qps greats than or equals to the threshold, access to the resource will be blocked
- * in the coming time window.
+ * Exception count: When the exception count in the last 60 seconds greats than
+ * or equals to the threshold, access to the resource will be blocked in the
+ * coming time window.
  * </li>
  * <li>
- * Exception Count, see {@link ExceptionCountDegradeDemo}.
+ * Exception ratio, see {@link ExceptionRatioDegradeDemo}.
  * </li>
  * <li>
  * For average response time, see {@link RtDegradeDemo}.
@@ -49,10 +34,9 @@ import com.alibaba.csp.sentinel.util.TimeUtil;
  * </ul>
  * </p>
  *
- * @author jialiang.linjl
+ * @author Carpenter Lee
  */
-public class ExceptionRatioDegradeDemo {
-
+public class ExceptionCountDegradeDemo {
     private static final String KEY = "abc";
 
     private static AtomicInteger total = new AtomicInteger();
@@ -111,9 +95,9 @@ public class ExceptionRatioDegradeDemo {
         List<DegradeRule> rules = new ArrayList<DegradeRule>();
         DegradeRule rule = new DegradeRule();
         rule.setResource(KEY);
-        // set limit exception ratio to 0.1
-        rule.setCount(0.1);
-        rule.setGrade(RuleConstant.DEGRADE_GRADE_EXCEPTION_RATIO);
+        // set limit exception count to 4
+        rule.setCount(4);
+        rule.setGrade(RuleConstant.DEGRADE_GRADE_EXCEPTION_COUNT);
         rule.setTimeWindow(10);
         rules.add(rule);
         DegradeRuleManager.loadRules(rules);

--- a/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/degrade/ExceptionCountDegradeDemo.java
+++ b/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/degrade/ExceptionCountDegradeDemo.java
@@ -33,6 +33,12 @@ import com.alibaba.csp.sentinel.util.TimeUtil;
  * </li>
  * </ul>
  * </p>
+ * <p>
+ * Note: When degrading by {@link RuleConstant#DEGRADE_GRADE_EXCEPTION_COUNT}, time window
+ * less than 60 seconds will not work as expected. Because the exception count is
+ * summed by minute, when a short time window elapsed, the degradation condition
+ * may still be satisfied.
+ * </p>
  *
  * @author Carpenter Lee
  */
@@ -98,6 +104,12 @@ public class ExceptionCountDegradeDemo {
         // set limit exception count to 4
         rule.setCount(4);
         rule.setGrade(RuleConstant.DEGRADE_GRADE_EXCEPTION_COUNT);
+        /**
+         * When degrading by {@link RuleConstant#DEGRADE_GRADE_EXCEPTION_COUNT}, time window
+         * less than 60 seconds will not work as expected. Because the exception count is
+         * summed by minute, when a short time window elapsed, the degradation condition
+         * may still be satisfied.
+         */
         rule.setTimeWindow(10);
         rules.add(rule);
         DegradeRuleManager.loadRules(rules);

--- a/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/degrade/RtDegradeDemo.java
+++ b/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/degrade/RtDegradeDemo.java
@@ -35,14 +35,17 @@ import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRuleManager;
  * <ul>
  * <li>
  * Average Response Time ('DegradeRule.Grade=RuleContants.DEGRADE_GRADE_RT'): When the
- * average RT exceeds the threshold ('count' in 'DegradeRule', ms), the resource
- * enters a quasi-degraded state. If the RT of next coming five requests still
+ * average RT greats than or equals to the threshold ('count' in 'DegradeRule', ms), the
+ * resource enters a quasi-degraded state. If the RT of next coming five requests still
  * exceed this threshold, this resource will be downgraded, which means that in
  * the next time window(Defined in 'timeWindow', s units) all the access to this
  * resource will be blocked.
  * </li>
  * <li>
  * Exception ratio, see {@link ExceptionRatioDegradeDemo}.
+ * </li>
+ * <li>
+ * Exception Count, see {@link ExceptionCountDegradeDemo}.
  * </li>
  * </ul>
  *


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

DegradeRule only have two type now, one is by *RT*, the other is by *exception ratio*. Degrade by exception count is not supported, which is necessary in the real case.

### Does this pull request fix one issue?

Fixes #173 

### Describe how you did it

Add a new DegradeRule type, degrade by *exception count* in the last minute. Degradation will be triggered if exception count in the last 60 seconds greats than or equals to the threshold.

### Describe how to verify it

See test cases.

### Special notes for reviews

None