### PR TITLE
Bug fix: fix wrong log file name checking

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/LogBase.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/LogBase.java
@@ -76,7 +76,7 @@ public class LogBase {
         String fileName = LogBase.getLogBaseDir() + logName + ".pid" + PidUtil.getPid();
         Handler handler = null;
         try {
-            handler = new DateFileLogHandler(fileName + ".%d", 1024 * 1024 * 200, 1, true);
+            handler = new DateFileLogHandler(fileName + ".%d", 1024 * 1024 * 200, 4, true);
             handler.setFormatter(formatter);
             handler.setEncoding(LOG_CHARSET);
         } catch (IOException e) {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
`DateFileLogHandler.logFileExits()` method uses a wrong log file name when checking log file exists, this will lead trying to  recreate the log file at every log writing, which will cause performance problem.

### Does this pull request fix one issue?
Fixes #181 

### Describe how you did it
Use the right log file name when exists checking.

### Describe how to verify it
1. Invoke `RecordLog.info()` in high concurrency;
2. Use `jstack pid` to see the stack trace of the current process, then we will see many threads *BLOCKED* `at com.alibaba.csp.sentinel.log.DateFileLogHandler.publish()`.
3. After merging this PR, `jstack pid`, then we will not see threads *BLOCKED* `at com.alibaba.csp.sentinel.log.DateFileLogHandler.publish()`.

### Special notes for reviews
None.