### PR TITLE
fix HttpServerHandler body reading problem

### DIFF
--- a/sentinel-transport/sentinel-transport-netty-http/src/main/java/com/alibaba/csp/sentinel/transport/command/netty/HttpServerHandler.java
+++ b/sentinel-transport/sentinel-transport-netty-http/src/main/java/com/alibaba/csp/sentinel/transport/command/netty/HttpServerHandler.java
@@ -178,7 +178,9 @@ public class HttpServerHandler extends SimpleChannelInboundHandler<Object> {
         if (request.content().readableBytes() <= 0) {
             serverRequest.setBody(null);
         } else {
-            serverRequest.setBody(request.content().array());
+            byte[] body = new byte[request.content().readableBytes()];
+            request.content().getBytes(0, body);
+            serverRequest.setBody(body);
         }
         return serverRequest;
     }


### PR DESCRIPTION
### Describe what this PR does / why we need it
fix HttpServerHandler body reading problem.

When post data to netty-http an exception `UnsupportedOperationException` will occur.

### Does this pull request fix one issue?

Fixes #184

### Describe how you did it
Do a manual copying from unpooled direct buffer.

### Describe how to verify it
curl -d "something" "http://api_provided_by_command_center"
