### PR TITLE
Increase padding-left value of G2.chart in sentinel-dashboard

### DIFF
--- a/sentinel-dashboard/src/main/webapp/resources/app/scripts/controllers/metric.js
+++ b/sentinel-dashboard/src/main/webapp/resources/app/scripts/controllers/metric.js
@@ -68,7 +68,7 @@ app.controller('MetricCtl', ['$scope', '$stateParams', 'MetricService', '$interv
           forceFit: true,
           width: 100,
           height: 250,
-          padding: ['auto']
+          padding: [10, 30, 70, 50]
         });
         var maxQps = 0;
         for (var i in metric.data) {

--- a/sentinel-dashboard/src/main/webapp/resources/app/scripts/controllers/metric.js
+++ b/sentinel-dashboard/src/main/webapp/resources/app/scripts/controllers/metric.js
@@ -68,7 +68,7 @@ app.controller('MetricCtl', ['$scope', '$stateParams', 'MetricService', '$interv
           forceFit: true,
           width: 100,
           height: 250,
-          padding: [10, 30, 70, 30]
+          padding: ['auto']
         });
         var maxQps = 0;
         for (var i in metric.data) {


### PR DESCRIPTION
### Describe what this PR does / why we need it

Fix the chart coordinate display in dashboard metric monitor page.

### Does this pull request fix one issue?

Fixes #251 

### Describe how you did it

Learned from the document in G2 official site,  found a value 'auto',
using the auto, the display is right, but the brower render time is slower obviously.

I tried modify the fixed value of padding property in metric.js, increasing padding-left value:
from padding: [10, 30, 70, 30] to padding: [10, 30, 70, 40]、[10, 30, 70, 50]...

Finally choose the padding-left value 50,  for most app pqs is blow 100,000. 

@see [https://www.yuque.com/antv/g2-docs/api-chart#xduocp](url)

### Describe how to verify it

I tried the app in production environment,  when the qps above 1000, the display is right.

Test browsers:
chrome(version 65.0.3325.146)、win10's system edge browser.

### Special notes for reviews

