### PR TITLE
Optimizing the click sensitivity of dashboard's side bar menu 

### DIFF
--- a/sentinel-dashboard/src/main/webapp/resources/app/scripts/controllers/metric.js
+++ b/sentinel-dashboard/src/main/webapp/resources/app/scripts/controllers/metric.js
@@ -68,7 +68,7 @@ app.controller('MetricCtl', ['$scope', '$stateParams', 'MetricService', '$interv
           forceFit: true,
           width: 100,
           height: 250,
-          padding: ['auto']
+          padding: [10, 30, 70, 50]
         });
         var maxQps = 0;
         for (var i in metric.data) {

--- a/sentinel-dashboard/src/main/webapp/resources/app/scripts/controllers/metric.js
+++ b/sentinel-dashboard/src/main/webapp/resources/app/scripts/controllers/metric.js
@@ -68,7 +68,7 @@ app.controller('MetricCtl', ['$scope', '$stateParams', 'MetricService', '$interv
           forceFit: true,
           width: 100,
           height: 250,
-          padding: [10, 30, 70, 30]
+          padding: ['auto']
         });
         var maxQps = 0;
         for (var i in metric.data) {

--- a/sentinel-dashboard/src/main/webapp/resources/app/scripts/directives/sidebar/sidebar.js
+++ b/sentinel-dashboard/src/main/webapp/resources/app/scripts/directives/sidebar/sidebar.js
@@ -33,16 +33,14 @@ angular.module('sentinelDashboardApp')
 
         // toggle side bar
         $scope.click = function ($event) {
-          let element = angular.element($event.target);
           let entry = angular.element($event.target).scope().entry;
-          entry.active = !entry.active;
+          entry.active = !entry.active;// toggle this clicked app bar
 
-          if (entry.active === false) {
-            element.parent().children('ul').hide();
-          } else {
-            element.parent().parent().children('li').children('ul').hide();
-            element.parent().children('ul').show();
-          }
+          $scope.apps.forEach(function (item) {// collapse other app bars
+            if (item != entry) {
+              item.active = false;
+            }
+          });
         };
 
         /**


### PR DESCRIPTION
### Describe what this PR does / why we need it

经测试，控制台左边菜单有不灵敏问题，偶尔出现点击2次才能展开；
复现步骤：
启动控制台，在左边菜单栏点击某个应用，单击中间文字展开，再单击折叠；
然后对准文字右边的向下箭头单击，可能多单击几次，会出现菜单无法展开的情况；
如果有多个应用，点击文字或者箭头展开折叠，多次点击如果点到了箭头也现该情况，
导致主观感觉上有时需要点一下，有时点两下。

### Does this pull request fix one issue?

Fixes #245 

### Describe how you did it

查看sidebar.js的代码，发现里面折叠其它应用菜单的时候，用了element jquery语法，
element.parent().children('ul').hide()
而sidebar.html中向下箭头<span class="fa arrow"></span>，<span>相对于菜单文字多了一个层级，如果用parent()加判断不方便；
经向前端同学咨询并查阅了些资料，angular支持数据双向绑定，不推荐直接操作dom；
尝试修改代码，直接遍历修改item.active的值。

参考：
AngularJS折叠菜单实现方法示例 [https://www.jb51.net/article/114004.htm](https://www.jb51.net/article/114004.htm)
Angular中直接操作DOM [https://www.jianshu.com/p/fddd81926e5d](https://www.jb51.net/article/114004.htm)

### Describe how to verify it

本机启动应用以及在开发、生产环境、按复现步骤多次点击菜单，展开折叠没有出现点两次的情况。

### Special notes for reviews