### PR TITLE
Make the default max RT value TIME_DROP_VALVE configurable

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Constants.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Constants.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.csp.sentinel;
 
+import com.alibaba.csp.sentinel.config.SentinelConfig;
 import com.alibaba.csp.sentinel.node.ClusterNode;
 import com.alibaba.csp.sentinel.node.DefaultNode;
 import com.alibaba.csp.sentinel.node.EntranceNode;
@@ -47,8 +48,11 @@ public final class Constants {
 
     /**
      * Response time that exceeds TIME_DROP_VALVE will be calculated as TIME_DROP_VALVE.
+     * Default value is 4900 ms
+     * It can be configured by property file or JVM parameter -Dcsp.sentinel.statistic.max.rt=xxx
+     * See {@link SentinelConfig#statisticMaxRt()}
      */
-    public final static int TIME_DROP_VALVE = 4900;
+    public static int TIME_DROP_VALVE = SentinelConfig.statisticMaxRt();
 
     /**
      * The global switch for Sentinel.

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/config/SentinelConfig.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/config/SentinelConfig.java
@@ -25,7 +25,6 @@ import com.alibaba.csp.sentinel.log.LogBase;
 import com.alibaba.csp.sentinel.log.RecordLog;
 import com.alibaba.csp.sentinel.util.AppNameUtil;
 import com.alibaba.csp.sentinel.util.AssertUtil;
-import com.alibaba.csp.sentinel.util.StringUtil;
 
 /**
  * The universal config of Courier. The config is retrieved from
@@ -41,9 +40,13 @@ public class SentinelConfig {
     public static final String SINGLE_METRIC_FILE_SIZE = "csp.sentinel.metric.file.single.size";
     public static final String TOTAL_METRIC_FILE_COUNT = "csp.sentinel.metric.file.total.count";
     public static final String COLD_FACTOR = "csp.sentinel.flow.cold.factor";
+    public static final String STATISTIC_MAX_RT = "csp.sentinel.statistic.max.rt";
 
+    static final String DEFAULT_CHARSET = "UTF-8";
     static final long DEFAULT_SINGLE_METRIC_FILE_SIZE = 1024 * 1024 * 50;
     static final int DEFAULT_TOTAL_METRIC_FILE_COUNT = 6;
+    static final int DEFAULT_COLD_FACTOR = 3;
+    static final int DEFAULT_STATISTIC_MAX_RT = 4900;
 
     static {
         initialize();
@@ -52,10 +55,11 @@ public class SentinelConfig {
 
     private static void initialize() {
         // Init default properties.
-        SentinelConfig.setConfig(CHARSET, "UTF-8");
+        SentinelConfig.setConfig(CHARSET, DEFAULT_CHARSET);
         SentinelConfig.setConfig(SINGLE_METRIC_FILE_SIZE, String.valueOf(DEFAULT_SINGLE_METRIC_FILE_SIZE));
         SentinelConfig.setConfig(TOTAL_METRIC_FILE_COUNT, String.valueOf(DEFAULT_TOTAL_METRIC_FILE_COUNT));
-        SentinelConfig.setConfig(COLD_FACTOR, String.valueOf(3));
+        SentinelConfig.setConfig(COLD_FACTOR, String.valueOf(DEFAULT_COLD_FACTOR));
+        SentinelConfig.setConfig(STATISTIC_MAX_RT, String.valueOf(DEFAULT_STATISTIC_MAX_RT));
     }
 
     private static void loadProps() {
@@ -139,7 +143,7 @@ public class SentinelConfig {
         try {
             return Long.parseLong(props.get(SINGLE_METRIC_FILE_SIZE));
         } catch (Throwable throwable) {
-            RecordLog.info("[SentinelConfig] Parse singleMetricFileSize fail, use default value: "
+            RecordLog.warn("[SentinelConfig] Parse singleMetricFileSize fail, use default value: "
                 + DEFAULT_SINGLE_METRIC_FILE_SIZE, throwable);
             return DEFAULT_SINGLE_METRIC_FILE_SIZE;
         }
@@ -149,9 +153,35 @@ public class SentinelConfig {
         try {
             return Integer.parseInt(props.get(TOTAL_METRIC_FILE_COUNT));
         } catch (Throwable throwable) {
-            RecordLog.info("[SentinelConfig] Parse totalMetricFileCount fail, use default value: "
+            RecordLog.warn("[SentinelConfig] Parse totalMetricFileCount fail, use default value: "
                 + DEFAULT_TOTAL_METRIC_FILE_COUNT, throwable);
             return DEFAULT_TOTAL_METRIC_FILE_COUNT;
+        }
+    }
+
+    public static int coldFactor() {
+        try {
+            int coldFactor = Integer.parseInt(props.get(COLD_FACTOR));
+            if (coldFactor <= 1) {// check the cold factor larger than 1
+                coldFactor = DEFAULT_COLD_FACTOR;
+                RecordLog.warn("cold factor=" + coldFactor + ", should be larger than 1, use default value: "
+                        + DEFAULT_COLD_FACTOR);
+            }
+            return coldFactor;
+        } catch (Throwable throwable) {
+            RecordLog.warn("[SentinelConfig] Parse coldFactor fail, use default value: "
+                    + DEFAULT_COLD_FACTOR, throwable);
+            return DEFAULT_COLD_FACTOR;
+        }
+    }
+
+    public static int statisticMaxRt() {
+        try {
+            return Integer.parseInt(props.get(STATISTIC_MAX_RT));
+        } catch (Throwable throwable) {
+            RecordLog.warn("[SentinelConfig] Parse statisticMaxRt fail, use default value: "
+                    + DEFAULT_STATISTIC_MAX_RT, throwable);
+            return DEFAULT_STATISTIC_MAX_RT;
         }
     }
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/ColdFactorProperty.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/ColdFactorProperty.java
@@ -16,30 +16,11 @@
 package com.alibaba.csp.sentinel.slots.block.flow;
 
 import com.alibaba.csp.sentinel.config.SentinelConfig;
-import com.alibaba.csp.sentinel.log.RecordLog;
-import com.alibaba.csp.sentinel.util.StringUtil;
 
 /**
  * @author jialiang.linjl
  */
 class ColdFactorProperty {
-    public static volatile int coldFactor = 3;
 
-    static {
-        String strConfig = SentinelConfig.getConfig(SentinelConfig.COLD_FACTOR);
-        if (StringUtil.isBlank(strConfig)) {
-            coldFactor = 3;
-        } else {
-            try {
-                coldFactor = Integer.valueOf(strConfig);
-            } catch (NumberFormatException e) {
-                RecordLog.info(e.getMessage(), e);
-            }
-
-            if (coldFactor <= 1) {
-                coldFactor = 3;
-                RecordLog.info("cold factor should be larger than 3");
-            }
-        }
-    }
+    public static volatile int coldFactor = SentinelConfig.coldFactor();
 }

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/ConstantsTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/ConstantsTest.java
@@ -1,0 +1,25 @@
+package com.alibaba.csp.sentinel;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test cases for {@link Constants}.
+ *
+ * @author cdfive
+ */
+public class ConstantsTest {
+
+    @Test
+    public void testDefaultTimeDropValue() {
+        assertEquals(4900, Constants.TIME_DROP_VALVE);
+    }
+
+//    add JVM parameter
+//    -Dcsp.sentinel.statistic.max.rt=10000
+//    @Test
+    public void testCustomTimeDropValue() {
+        assertEquals(10000, Constants.TIME_DROP_VALVE);
+    }
+}

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/config/SentinelConfigTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/config/SentinelConfigTest.java
@@ -1,0 +1,61 @@
+package com.alibaba.csp.sentinel.config;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test cases for {@link SentinelConfig}.
+ *
+ * @author cdfive
+ */
+public class SentinelConfigTest {
+
+    @Test
+    public void testDefaultConfig() {
+        assertEquals(SentinelConfig.DEFAULT_CHARSET, SentinelConfig.charset());
+        assertEquals(SentinelConfig.DEFAULT_SINGLE_METRIC_FILE_SIZE, SentinelConfig.singleMetricFileSize());
+        assertEquals(SentinelConfig.DEFAULT_TOTAL_METRIC_FILE_COUNT, SentinelConfig.totalMetricFileCount());
+        assertEquals(SentinelConfig.DEFAULT_COLD_FACTOR, SentinelConfig.coldFactor());
+        assertEquals(SentinelConfig.DEFAULT_STATISTIC_MAX_RT, SentinelConfig.statisticMaxRt());
+    }
+
+//    add JVM parameter
+//    -Dcsp.sentinel.charset=gbk
+//    -Dcsp.sentinel.metric.file.single.size=104857600
+//    -Dcsp.sentinel.metric.file.total.count=10
+//    -Dcsp.sentinel.flow.cold.factor=5
+//    -Dcsp.sentinel.statistic.max.rt=10000
+//    @Test
+    public void testCustomConfig() {
+        assertEquals("gbk", SentinelConfig.charset());
+        assertEquals(104857600L, SentinelConfig.singleMetricFileSize());
+        assertEquals(10, SentinelConfig.totalMetricFileCount());
+        assertEquals(5, SentinelConfig.coldFactor());
+        assertEquals(10000, SentinelConfig.statisticMaxRt());
+    }
+
+
+    /**
+     * when set code factor alue equal or smaller than 1, get value
+     * in SentinelConfig.coldFactor() will return DEFAULT_COLD_FACTOR
+     * see {@link SentinelConfig#coldFactor()}
+     */
+    @Test
+    public void testColdFactorEqualOrSmallerThanOne() {
+        SentinelConfig.setConfig(SentinelConfig.COLD_FACTOR, "0.5");
+        assertEquals(SentinelConfig.DEFAULT_COLD_FACTOR, SentinelConfig.coldFactor());
+
+        SentinelConfig.setConfig(SentinelConfig.COLD_FACTOR, "1");
+        assertEquals(SentinelConfig.DEFAULT_COLD_FACTOR, SentinelConfig.coldFactor());
+    }
+
+    @Test
+    public void testColdFactoryLargerThanOne() {
+        SentinelConfig.setConfig(SentinelConfig.COLD_FACTOR, "2");
+        assertEquals(2, SentinelConfig.coldFactor());
+
+        SentinelConfig.setConfig(SentinelConfig.COLD_FACTOR, "4");
+        assertEquals(4, SentinelConfig.coldFactor());
+    }
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

根据应用实际RT情况以及监控数据准确性需求，让MAX RT(即TIME_DROP_VALUE)可配置。

### Does this pull request fix one issue?

Fixes #276 

### Describe how you did it

在SentinelConfig中增加了1个参数配置项csp.sentinel.statistic.max.rt，增加默认值和读取方法

### Describe how to verify it

add unit test

### Special notes for reviews

1.把CHARSET、COLD_FACTOR的默认值也修改为用常量定义（感觉这样看着一致些）;
2.读取某个特定参数值方法catch里RecordLog.info改为了warn(因为在catch里打印)；
3.cold_factor之前在ColdFactorProperty类读取的，因为默认值在SentinelConfig定义，
改为了用SentinelConfig.coldFactor()读取，其中：
if (coldFactor <= 1) {
    coldFactor = 3;
    RecordLog.info("cold factor should be larger than 3");
}
判断的是<=1，打印的却是大于3，信息不一致；
这段放到了SentinelConfig.coldFactor()方法里，
判断<=1没变，把信息内容改了下；
4.Constants中的TIME_DROP_VALVE，final修饰去掉了
跟下面那个ON开关一样，便于运行时可以修改，比如以后考虑通过CommandHandler方式。