### PR TITLE
Fix/list metric files

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/metric/MetricSearcher.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/metric/MetricSearcher.java
@@ -134,7 +134,7 @@ public class MetricSearcher {
                     MetricWriter.formIndexFileName(fileName), offsetInIndex);
             offsetInIndex = 0;
             if (offset != -1) {
-                return metricsReader.readMetricsByEndTime(fileNames, i, offset, endTimeMs, identity);
+                return metricsReader.readMetricsByEndTime(fileNames, i, offset, beginTimeMs, endTimeMs, identity);
             }
         }
         return null;

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/metric/MetricWriter.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/metric/MetricWriter.java
@@ -194,16 +194,18 @@ public class MetricWriter {
         File baseFile = new File(baseDir);
         DateFormat fileNameDf = new SimpleDateFormat("yyyy-MM-dd");
         String dateStr = fileNameDf.format(new Date(time));
+        String fileNameModel = baseFileName + "." + dateStr;
         for (File file : baseFile.listFiles()) {
-            if (file.getName().contains(baseFileName + "." + dateStr)
-                && !file.getName().endsWith(METRIC_FILE_INDEX_SUFFIX)
-                && !file.getName().endsWith(".lck")) {
+            String fileName = file.getName();
+            if (fileName.contains(fileNameModel)
+                && !fileName.endsWith(METRIC_FILE_INDEX_SUFFIX)
+                && !fileName.endsWith(".lck")) {
                 list.add(file.getAbsolutePath());
             }
         }
         Collections.sort(list, METRIC_FILE_NAME_CMP);
         if (list.isEmpty()) {
-            return baseDir + baseFileName + "." + dateStr;
+            return baseDir + fileNameModel;
         }
         String last = list.get(list.size() - 1);
         int n = 0;
@@ -211,7 +213,7 @@ public class MetricWriter {
         if (strs.length > 0 && strs[strs.length - 1].matches("[0-9]{1,10}")) {
             n = Integer.parseInt(strs[strs.length - 1]);
         }
-        return baseDir + baseFileName + "." + dateStr + "." + (n + 1);
+        return baseDir + fileNameModel + "." + (n + 1);
     }
 
     /**
@@ -244,7 +246,7 @@ public class MetricWriter {
             String name2 = new File(o2).getName();
             String dateStr1 = name1.split("\\.")[2];
             String dateStr2 = name2.split("\\.")[2];
-            // in case of file name contains pid, skip it
+            // in case of file name contains pid, skip it, like Sentinel-Admin-metrics.log.pid22568.2018-12-24
             if (dateStr1.startsWith(pid)) {
                 dateStr1 = name1.split("\\.")[3];
                 dateStr2 = name2.split("\\.")[3];
@@ -266,7 +268,10 @@ public class MetricWriter {
     }
 
     /**
-     * Get all metric files' name in {@code baseDir}. The file name must contain {@code baseFileName}
+     * Get all metric files' name in {@code baseDir}. The file name must like
+     * <pre>
+     * baseFileName + ".yyyy-MM-dd.number"
+     * </pre>
      * and not endsWith {@link #METRIC_FILE_INDEX_SUFFIX} or ".lck".
      *
      * @param baseDir      the directory to search.
@@ -282,15 +287,36 @@ public class MetricWriter {
             return list;
         }
         for (File file : files) {
+            String fileName = file.getName();
             if (file.isFile()
-                && file.getName().contains(baseFileName)
-                && !file.getName().endsWith(MetricWriter.METRIC_FILE_INDEX_SUFFIX)
-                && !file.getName().endsWith(".lck")) {
+                && fileNameMatches(fileName, baseFileName)
+                && !fileName.endsWith(MetricWriter.METRIC_FILE_INDEX_SUFFIX)
+                && !fileName.endsWith(".lck")) {
                 list.add(file.getAbsolutePath());
             }
         }
         Collections.sort(list, MetricWriter.METRIC_FILE_NAME_CMP);
         return list;
+    }
+
+    /**
+     * Test whether fileName matches baseFileName. fileName matches baseFileName when
+     * <pre>
+     * fileName = baseFileName + ".yyyy-MM-dd.number"
+     * </pre>
+     *
+     * @param fileName     file name
+     * @param baseFileName base file name.
+     * @return if fileName matches baseFileName return true, else return false.
+     */
+    public static boolean fileNameMatches(String fileName, String baseFileName) {
+        if (fileName.startsWith(baseFileName)) {
+            String part = fileName.substring(baseFileName.length());
+            // part is like: ".yyyy-MM-dd.number", eg. ".2018-12-24.11"
+            return part.matches("\\.[0-9]{4}-[0-9]{2}-[0-9]{2}(\\.[0-9]*)?");
+        } else {
+            return false;
+        }
     }
 
     private void removeMoreFiles() throws Exception {

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/node/metric/MetricWriterTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/node/metric/MetricWriterTest.java
@@ -6,8 +6,13 @@ import java.util.Collections;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+/**
+ * @author Carpenter Lee
+ */
 public class MetricWriterTest {
     @Test
     public void testFileNameCmp() {
@@ -50,5 +55,25 @@ public class MetricWriterTest {
         Collections.sort(list, MetricWriter.METRIC_FILE_NAME_CMP);
         assertEquals(Arrays.asList(key), list);
     }
+
+    @Test
+    public void testFileNameMatches(){
+        String baseFileName = "Sentinel-SDK-Demo-metrics.log";
+        String fileName = "Sentinel-SDK-Demo-metrics.log.2018-03-06";
+        assertTrue(MetricWriter.fileNameMatches(fileName, baseFileName));
+
+        String baseFileName2 = "Sentinel-Admin-metrics.log.pid22568";
+        String fileName2 = "Sentinel-Admin-metrics.log.pid22568.2018-12-24";
+        assertTrue(MetricWriter.fileNameMatches(fileName2, baseFileName2));
+
+        String baseFileName3 = "Sentinel-SDK-Demo-metrics.log";
+        String fileName3 = "Sentinel-SDK-Demo-metrics.log.2018-03-06.11";
+        assertTrue(MetricWriter.fileNameMatches(fileName3, baseFileName3));
+
+        String baseFileName4 = "Sentinel-SDK-Demo-metrics.log";
+        String fileName4 = "Sentinel-SDK-Demo-metrics.log.XXX.2018-03-06.11";
+        assertFalse(MetricWriter.fileNameMatches(fileName4, baseFileName4));
+    }
+
 
 }

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/node/metric/MetricWriterTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/node/metric/MetricWriterTest.java
@@ -73,6 +73,10 @@ public class MetricWriterTest {
         String baseFileName4 = "Sentinel-SDK-Demo-metrics.log";
         String fileName4 = "Sentinel-SDK-Demo-metrics.log.XXX.2018-03-06.11";
         assertFalse(MetricWriter.fileNameMatches(fileName4, baseFileName4));
+
+        String baseFileName5 = "Sentinel-SDK-Demo-metrics.log";
+        String fileName5 = "Sentinel-SDK-Demo-metrics.log.2018-03-06.11XXX";
+        assertFalse(MetricWriter.fileNameMatches(fileName5, baseFileName5));
     }
 
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

`MetricWriter#listMetricFiles()` method is used for listing all metric files of the specific app. It uses `String.contains()` to search the metric file name instead of whole matching, this will lead wrong file reading when appName contains some other one, for example one appName is *simple-Sentinel-SDK-Demo*, the other is *Sentinel-SDK-Demo*, the former app's metric file will appearing in the latter metric files list.

`MetricWriter#listMetricFiles()` should return right metric files name list. 

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #330 

### Describe how you did it
Use  whole string matching instead of `String.contains()` to filter app metric file name.

### Describe how to verify it
Run test cases.

### Special notes for reviews
