### PR TITLE
Make fallbackToLocalWhenFail be configurable in dashboard and fix edit rule issue when cancel 

### DIFF
--- a/sentinel-dashboard/src/main/webapp/resources/app/scripts/controllers/authority.js
+++ b/sentinel-dashboard/src/main/webapp/resources/app/scripts/controllers/authority.js
@@ -55,7 +55,7 @@ angular.module('sentinelDashboardApp').controller('AuthorityRuleController', ['$
         var authorityRuleDialog;
 
         $scope.editRule = function (rule) {
-            $scope.currentRule = rule;
+            $scope.currentRule = angular.copy(rule);
             $scope.authorityRuleDialog = {
                 title: '编辑授权规则',
                 type: 'edit',

--- a/sentinel-dashboard/src/main/webapp/resources/app/scripts/controllers/degrade.js
+++ b/sentinel-dashboard/src/main/webapp/resources/app/scripts/controllers/degrade.js
@@ -45,7 +45,7 @@ app.controller('DegradeCtl', ['$scope', '$stateParams', 'DegradeService', 'ngDia
 
     var degradeRuleDialog;
     $scope.editRule = function (rule) {
-      $scope.currentRule = rule;
+      $scope.currentRule = angular.copy(rule);
       $scope.degradeRuleDialog = {
         title: '编辑降级规则',
         type: 'edit',

--- a/sentinel-dashboard/src/main/webapp/resources/app/scripts/controllers/flow_v1.js
+++ b/sentinel-dashboard/src/main/webapp/resources/app/scripts/controllers/flow_v1.js
@@ -61,7 +61,7 @@ app.controller('FlowControllerV1', ['$scope', '$stateParams', 'FlowServiceV1', '
 
     var flowRuleDialog;
     $scope.editRule = function (rule) {
-      $scope.currentRule = rule;
+      $scope.currentRule = angular.copy(rule);
       $scope.flowRuleDialog = {
         title: '编辑流控规则',
         type: 'edit',

--- a/sentinel-dashboard/src/main/webapp/resources/app/scripts/controllers/flow_v2.js
+++ b/sentinel-dashboard/src/main/webapp/resources/app/scripts/controllers/flow_v2.js
@@ -61,7 +61,7 @@ app.controller('FlowControllerV2', ['$scope', '$stateParams', 'FlowServiceV2', '
 
     var flowRuleDialog;
     $scope.editRule = function (rule) {
-      $scope.currentRule = rule;
+      $scope.currentRule = angular.copy(rule);
       $scope.flowRuleDialog = {
         title: '编辑流控规则',
         type: 'edit',
@@ -88,7 +88,8 @@ app.controller('FlowControllerV2', ['$scope', '$stateParams', 'FlowServiceV2', '
         limitApp: 'default',
         clusterMode: false,
         clusterConfig: {
-          thresholdType: 0
+          thresholdType: 0,
+          fallbackToLocalWhenFail: true
         }
       };
       $scope.flowRuleDialog = {

--- a/sentinel-dashboard/src/main/webapp/resources/app/scripts/controllers/param_flow.js
+++ b/sentinel-dashboard/src/main/webapp/resources/app/scripts/controllers/param_flow.js
@@ -129,7 +129,7 @@ angular.module('sentinelDashboardApp').controller('ParamFlowController', ['$scop
     var paramFlowRuleDialog;
 
     $scope.editRule = function (rule) {
-      $scope.currentRule = rule;
+      $scope.currentRule = angular.copy(rule);
       $scope.paramFlowRuleDialog = {
         title: '编辑热点规则',
         type: 'edit',

--- a/sentinel-dashboard/src/main/webapp/resources/app/scripts/controllers/system.js
+++ b/sentinel-dashboard/src/main/webapp/resources/app/scripts/controllers/system.js
@@ -58,7 +58,7 @@ app.controller('SystemCtl', ['$scope', '$stateParams', 'SystemService', 'ngDialo
     $scope.getMachineRules = getMachineRules;
     var systemRuleDialog;
     $scope.editRule = function (rule) {
-      $scope.currentRule = rule;
+      $scope.currentRule = angular.copy(rule);
       $scope.systemRuleDialog = {
         title: '编辑系统保护规则',
         type: 'edit',

--- a/sentinel-dashboard/src/main/webapp/resources/app/views/dialog/flow-rule-dialog.html
+++ b/sentinel-dashboard/src/main/webapp/resources/app/views/dialog/flow-rule-dialog.html
@@ -53,7 +53,9 @@
           <div class="form-group">
             <label class="col-sm-2 control-label">是否集群</label>
             <div class="col-sm-2">
+              <label class="checkbox-inline">
                 <input type="checkbox" name="clusterMode" ng-model="currentRule.clusterMode">
+              </label>
             </div>
             <div ng-if="currentRule.clusterMode">
               <label class="col-sm-3 control-label">集群阈值模式</label>
@@ -63,6 +65,16 @@
                   <input type="radio" name="clusterThresholdType" value="1" ng-model='currentRule.clusterConfig.thresholdType' />&nbsp;总体阈值
                 </div>
               </div>
+            </div>
+          </div>
+
+          <div class="form-group" ng-if="currentRule.clusterMode">
+            <label class="col-sm-2 control-label">失败退化</label>
+            <div class="col-sm-8">
+              <label class="checkbox-inline">
+                <input type="checkbox" name="clusterMode" ng-model="currentRule.clusterConfig.fallbackToLocalWhenFail">
+                <i class="glyphicon glyphicon-info-sign"></i>如果集群限流失败是否退化到单机限流
+              </label>
             </div>
           </div>
 

--- a/sentinel-dashboard/src/main/webapp/resources/app/views/metric.html
+++ b/sentinel-dashboard/src/main/webapp/resources/app/views/metric.html
@@ -51,9 +51,9 @@
                           <thead>
                             <tr style="font-size: 13px;text-align:center;font-weight: bold;">
                               <td style="word-wrap:break-word;word-break:break-all;">时间</td>
-                              <td style="word-wrap:break-word;word-break:break-all;">p_qps</td>
-                              <td style="word-wrap:break-word;word-break:break-all;">b_qps</td>
-                              <td style="word-wrap:break-word;word-break:break-all;">rt(ms)</td>
+                              <td style="word-wrap:break-word;word-break:break-all;" title="passQps: 通过的qps">p_qps</td>
+                              <td style="word-wrap:break-word;word-break:break-all;" title="blockQps: 拦截的qps">b_qps</td>
+                              <td style="word-wrap:break-word;word-break:break-all;" title="responseTime: 响应时间(毫秒)">rt(ms)</td>
                             </tr>
                           </thead>
                           <!-- thead -->


### PR DESCRIPTION
### Describe what this PR does / why we need it

1. 集群限流失败是否退化到单机限流在界面可配置；
2. 解决规则编辑页面点击取消按钮问题；
3. 实时监控页面的表格头增加title鼠标hover提示；

### Does this pull request fix one issue?

Fixes #343, resolves #95, #365

### Describe how you did it

1.在是否集群的复选框下面一行，增加失败退化复选框，

在#343 跟@sczyh30 讨论了下文案和描述，有**是否**两字确实体现出true/false的语义，
但是考虑到复选框本身就有是否的语义，最终写的是**失败退化**；
这样首先4个字，跟上面的是否集群字数一致便于对齐，
其次跟变量fallbackToLocalWhenFail翻译过来很贴近，感觉这样能突出失败后才退化的含义；
icon+balloon的提示确实节约空间，但考虑到这一行右边很空，直接给出文字提示更加直观
于是右边加了个info图标，文字提示跟wiki上说明一致=>**如果集群限流失败是否退化到单机限流**

ps：有点强迫症见笑了，确实对这个文字提示也很纠结，如果有更好的建议请说下哈我去修正。

还有个小改进是，之前的**是否集群**文字和复选框，没有水平对齐，
通过复选框外加`<label class="checkbox-inline">...</labal>`解决。

最终效果如图：
> ![image](https://user-images.githubusercontent.com/31885791/50547227-171b1780-0c71-11e9-823f-b14f4f0da198.png)

flow.js里currentRule模型增加`fallbackToLocalWhenFail`字段，跟java变量默认值一致为true
在flow_old.js里没有加这个，因为看它整个clusterConfig都没有，可能是旧版不需要；
这样有个小问题是在旧版界面因为**是否集群**是可见的，勾选后**失败退化**是没有打勾的；
以后可以考虑旧版界面*是否集群*不可见，根据区分旧版、新版隐藏暂时没找到好的方法...

暂时没有把**失败退化**加到列表页，考虑到
它本身可能是个不常编辑的参数，大部分情况可能用默认值就好；
**集群阈值模式**也没有在列表显示，如果要显示的话它可能还重要点；
列表页列太多了会占空间；
未来可考虑用动态列表格可以用户可以选择哪些列显示，这需要表格组件支持；

2.百度查了一些资料，发现也有人遇到同样问题
[http://www.cnblogs.com/daiyonghui/p/9878930.html](http://www.cnblogs.com/daiyonghui/p/9878930.html)
[https://segmentfault.com/q/1010000006726302](https://segmentfault.com/q/1010000006726302)
[https://segmentfault.com/q/1010000004371274](https://segmentfault.com/q/1010000004371274)
 
#95 @CarpenterLee的评论提到`they share the same model`，于是在想能否不共用，取消双向绑定；
在这篇[https://www.jb51.net/article/98266.htm](https://www.jb51.net/article/98266.htm)
找到了`angular.copy`方法，于是尝试了下`$scope.currentRule = angular.copy(rule);`
然后点取消，发现列表值没有被修改了；而保存因为之后调用了getMachineRules()方法，也没问题。

这样修改很简单，没有参考文章里那么繁琐；
只是有点担心`angular.copy`这种复制方式会否有内存泄露，记得以前jQuery时代几乎没有手动释放js变量，也百度了下暂时没发现有内存方面的影响。

本机遇到：改了js后build工程界面点没生效，发现是浏览器缓存的问题，Ctrl+F5刷新几次或者F12 disable cache就好了。

文档参考：
[https://code.angularjs.org/1.4.8/docs/api/ng/function/angular.copy](https://code.angularjs.org/1.4.8/docs/api/ng/function/angular.copy)

ps：有个小问题就是咱们用的angular1.4.8版本有点老，最新是angular7；
老版本查资料不方便，建议以后考虑升级到主流版本。

3.钉钉群里有新同学提到b_pqs等不知道含义，顺便就加上了
通过<td>加title的方式简单修改的，鼠标移到整个td区域都有hover提示

`<td title="passQps: 通过的qps">p_qps</td>`

这里`<td>`内文字没有加任何图标，因为加了看上去就不简洁了；
title的信息提示为：英文+冒号+空格+中文，感觉这样理解很直观；
记得自己第一次看到RT时也不知道意思，当时还去百度了下(哈哈)

### Describe how to verify it

在控制台界面新增、编辑规则，点击取消、保存测试，观察界面显示结果；
通过`http://localhost:8719/getRules?type=flow`查看规则保存情况

### Special notes for reviews

因为代码改动很小，且flow.js都会改到，所以就提到一个PR里了。

ps：感谢Sentinel官方团队提供了对学习、工作都这么实用的组件，提前祝元旦快乐！明年发展更好~