### PR TITLE
Add total QPS limit control for specific namespace in cluster flow control

### DIFF
--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/ClusterFlowChecker.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/ClusterFlowChecker.java
@@ -19,6 +19,7 @@ import com.alibaba.csp.sentinel.cluster.TokenResultStatus;
 import com.alibaba.csp.sentinel.cluster.TokenResult;
 import com.alibaba.csp.sentinel.cluster.flow.rule.ClusterFlowRuleManager;
 import com.alibaba.csp.sentinel.cluster.flow.statistic.ClusterMetricStatistics;
+import com.alibaba.csp.sentinel.cluster.flow.statistic.limit.GlobalRequestLimiter;
 import com.alibaba.csp.sentinel.cluster.server.config.ClusterServerConfigManager;
 import com.alibaba.csp.sentinel.cluster.flow.statistic.data.ClusterFlowEvent;
 import com.alibaba.csp.sentinel.cluster.flow.statistic.metric.ClusterMetric;
@@ -46,8 +47,18 @@ final class ClusterFlowChecker {
         }
     }
 
+    static boolean allowProceed(long flowId) {
+        String namespace = ClusterFlowRuleManager.getNamespace(flowId);
+        return GlobalRequestLimiter.tryPass(namespace);
+    }
+
     static TokenResult acquireClusterToken(/*@Valid*/ FlowRule rule, int acquireCount, boolean prioritized) {
         Long id = rule.getClusterConfig().getFlowId();
+
+        if (!allowProceed(id)) {
+            return new TokenResult(TokenResultStatus.TOO_MANY_REQUEST);
+        }
+
         ClusterMetric metric = ClusterMetricStatistics.getMetric(id);
         if (metric == null) {
             return new TokenResult(TokenResultStatus.FAIL);

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/ClusterParamFlowChecker.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/ClusterParamFlowChecker.java
@@ -21,6 +21,7 @@ import com.alibaba.csp.sentinel.cluster.TokenResult;
 import com.alibaba.csp.sentinel.cluster.TokenResultStatus;
 import com.alibaba.csp.sentinel.cluster.flow.rule.ClusterParamFlowRuleManager;
 import com.alibaba.csp.sentinel.cluster.flow.statistic.ClusterParamMetricStatistics;
+import com.alibaba.csp.sentinel.cluster.flow.statistic.limit.GlobalRequestLimiter;
 import com.alibaba.csp.sentinel.cluster.flow.statistic.metric.ClusterParamMetric;
 import com.alibaba.csp.sentinel.cluster.server.log.ClusterServerStatLogUtil;
 import com.alibaba.csp.sentinel.slots.block.ClusterRuleConstant;
@@ -33,8 +34,18 @@ import com.alibaba.csp.sentinel.slots.block.flow.param.ParamFlowRule;
  */
 public final class ClusterParamFlowChecker {
 
+    static boolean allowProceed(long flowId) {
+        String namespace = ClusterParamFlowRuleManager.getNamespace(flowId);
+        return GlobalRequestLimiter.tryPass(namespace);
+    }
+
     static TokenResult acquireClusterToken(ParamFlowRule rule, int count, Collection<Object> values) {
         Long id = rule.getClusterConfig().getFlowId();
+
+        if (!allowProceed(id)) {
+            return new TokenResult(TokenResultStatus.TOO_MANY_REQUEST);
+        }
+
         ClusterParamMetric metric = ClusterParamMetricStatistics.getMetric(id);
         if (metric == null) {
             // Unexpected state, return FAIL.

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/rule/ClusterFlowRuleManager.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/rule/ClusterFlowRuleManager.java
@@ -33,6 +33,7 @@ import com.alibaba.csp.sentinel.property.DynamicSentinelProperty;
 import com.alibaba.csp.sentinel.property.PropertyListener;
 import com.alibaba.csp.sentinel.property.SentinelProperty;
 import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+import com.alibaba.csp.sentinel.slots.block.flow.ClusterFlowConfig;
 import com.alibaba.csp.sentinel.slots.block.flow.FlowRule;
 import com.alibaba.csp.sentinel.slots.block.flow.FlowRuleUtil;
 import com.alibaba.csp.sentinel.util.AssertUtil;
@@ -208,6 +209,17 @@ public final class ClusterFlowRuleManager {
         return FLOW_RULES.get(id);
     }
 
+    public static Set<Long> getFlowIdSet(String namespace) {
+        if (StringUtil.isEmpty(namespace)) {
+            return new HashSet<>();
+        }
+        Set<Long> set = NAMESPACE_FLOW_ID_MAP.get(namespace);
+        if (set == null) {
+            return new HashSet<>();
+        }
+        return new HashSet<>(set);
+    }
+
     public static List<FlowRule> getAllFlowRules() {
         return new ArrayList<>(FLOW_RULES.values());
     }
@@ -303,6 +315,10 @@ public final class ClusterFlowRuleManager {
         return ConnectionManager.getConnectedCount(namespace);
     }
 
+    public static String getNamespace(long flowId) {
+        return FLOW_NAMESPACE_MAP.get(flowId);
+    }
+
     private static void applyClusterFlowRule(List<FlowRule> list, /*@Valid*/ String namespace) {
         if (list == null || list.isEmpty()) {
             clearAndResetRulesFor(namespace);
@@ -326,7 +342,8 @@ public final class ClusterFlowRuleManager {
             }
 
             // Flow id should not be null after filtered.
-            Long flowId = rule.getClusterConfig().getFlowId();
+            ClusterFlowConfig clusterConfig = rule.getClusterConfig();
+            Long flowId = clusterConfig.getFlowId();
             if (flowId == null) {
                 continue;
             }
@@ -336,8 +353,7 @@ public final class ClusterFlowRuleManager {
 
             // Prepare cluster metric from valid flow ID.
             ClusterMetricStatistics.putMetricIfAbsent(flowId,
-                new ClusterMetric(ClusterServerConfigManager.getSampleCount(),
-                    ClusterServerConfigManager.getIntervalMs()));
+                new ClusterMetric(clusterConfig.getSampleCount(), clusterConfig.getWindowIntervalMs()));
         }
 
         // Cleanup unused cluster metrics.

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/statistic/limit/GlobalRequestLimiter.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/statistic/limit/GlobalRequestLimiter.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.cluster.flow.statistic.limit;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.alibaba.csp.sentinel.cluster.server.config.ClusterServerConfigManager;
+import com.alibaba.csp.sentinel.util.AssertUtil;
+
+/**
+ * @author Eric Zhao
+ * @since 1.4.1
+ */
+public final class GlobalRequestLimiter {
+
+    private static final Map<String, RequestLimiter> GLOBAL_QPS_LIMITER_MAP = new ConcurrentHashMap<>();
+
+    public static void initIfAbsent(String namespace) {
+        AssertUtil.notEmpty(namespace, "namespace cannot be empty");
+        if (!GLOBAL_QPS_LIMITER_MAP.containsKey(namespace)) {
+            GLOBAL_QPS_LIMITER_MAP.put(namespace, new RequestLimiter(ClusterServerConfigManager.getMaxAllowedQps(namespace)));
+        }
+    }
+
+    public static RequestLimiter getRequestLimiter(String namespace) {
+        if (namespace == null) {
+            return null;
+        }
+        return GLOBAL_QPS_LIMITER_MAP.get(namespace);
+    }
+
+    public static boolean tryPass(String namespace) {
+        if (namespace == null) {
+            return false;
+        }
+        RequestLimiter limiter = GLOBAL_QPS_LIMITER_MAP.get(namespace);
+        if (limiter == null) {
+            return true;
+        }
+        return limiter.tryPass();
+    }
+
+    public static double getCurrentQps(String namespace) {
+        RequestLimiter limiter = getRequestLimiter(namespace);
+        if (limiter == null) {
+            return 0;
+        }
+        return limiter.getQps();
+    }
+
+    public static double getMaxAllowedQps(String namespace) {
+        RequestLimiter limiter = getRequestLimiter(namespace);
+        if (limiter == null) {
+            return 0;
+        }
+        return limiter.getQpsAllowed();
+    }
+
+    public static void applyMaxQpsChange(double maxAllowedQps) {
+        AssertUtil.isTrue(maxAllowedQps >= 0, "max allowed QPS should > 0");
+        for (RequestLimiter limiter : GLOBAL_QPS_LIMITER_MAP.values()) {
+            if (limiter != null) {
+                limiter.setQpsAllowed(maxAllowedQps);
+            }
+        }
+    }
+
+    private GlobalRequestLimiter() {}
+}

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/statistic/limit/RequestLimiter.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/statistic/limit/RequestLimiter.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.cluster.flow.statistic.limit;
+
+import java.util.List;
+
+import com.alibaba.csp.sentinel.slots.statistic.base.LeapArray;
+import com.alibaba.csp.sentinel.slots.statistic.base.LongAdder;
+import com.alibaba.csp.sentinel.slots.statistic.base.UnaryLeapArray;
+import com.alibaba.csp.sentinel.util.AssertUtil;
+
+/**
+ * @author Eric Zhao
+ * @since 1.4.1
+ */
+public class RequestLimiter {
+
+    private double qpsAllowed;
+
+    private final LeapArray<LongAdder> data;
+
+    public RequestLimiter(double qpsAllowed) {
+        this(new UnaryLeapArray(10, 1000), qpsAllowed);
+    }
+
+    RequestLimiter(LeapArray<LongAdder> data, double qpsAllowed) {
+        AssertUtil.isTrue(qpsAllowed >= 0, "max allowed QPS should > 0");
+        this.data = data;
+        this.qpsAllowed = qpsAllowed;
+    }
+
+    public void increment() {
+        data.currentWindow().value().increment();
+    }
+
+    public void add(int x) {
+        data.currentWindow().value().add(x);
+    }
+
+    public long getSum() {
+        data.currentWindow();
+        long success = 0;
+
+        List<LongAdder> list = data.values();
+        for (LongAdder window : list) {
+            success += window.sum();
+        }
+        return success;
+    }
+
+    public double getQps() {
+        return getSum() / data.getIntervalInSecond();
+    }
+
+    public double getQpsAllowed() {
+        return qpsAllowed;
+    }
+
+    public boolean canPass() {
+        return getQps() + 1 <= qpsAllowed;
+    }
+
+    public RequestLimiter setQpsAllowed(double qpsAllowed) {
+        this.qpsAllowed = qpsAllowed;
+        return this;
+    }
+
+    public boolean tryPass() {
+        if (canPass()) {
+            add(1);
+            return true;
+        }
+        return false;
+    }
+}

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/command/handler/ModifyClusterServerFlowConfigHandler.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/command/handler/ModifyClusterServerFlowConfigHandler.java
@@ -48,10 +48,16 @@ public class ModifyClusterServerFlowConfigHandler implements CommandHandler<Stri
             if (StringUtil.isEmpty(namespace)) {
                 RecordLog.info("[ModifyClusterServerFlowConfigHandler] Receiving cluster server global flow config: " + data);
                 ServerFlowConfig config = JSON.parseObject(data, ServerFlowConfig.class);
+                if (!ClusterServerConfigManager.isValidFlowConfig(config)) {
+                    CommandResponse.ofFailure(new IllegalArgumentException("Bad flow config"));
+                }
                 ClusterServerConfigManager.loadGlobalFlowConfig(config);
             } else {
                 RecordLog.info("[ModifyClusterServerFlowConfigHandler] Receiving cluster server flow config for namespace <{0}>: {1}", namespace, data);
                 ServerFlowConfig config = JSON.parseObject(data, ServerFlowConfig.class);
+                if (!ClusterServerConfigManager.isValidFlowConfig(config)) {
+                    CommandResponse.ofFailure(new IllegalArgumentException("Bad flow config"));
+                }
                 ClusterServerConfigManager.loadFlowConfig(namespace, config);
             }
 

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/config/ServerFlowConfig.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/config/ServerFlowConfig.java
@@ -28,6 +28,7 @@ public class ServerFlowConfig {
 
     public static final int DEFAULT_INTERVAL_MS = 1000;
     public static final int DEFAULT_SAMPLE_COUNT= 10;
+    public static final double DEFAULT_MAX_ALLOWED_QPS= 30000;
 
     private final String namespace;
 
@@ -35,6 +36,8 @@ public class ServerFlowConfig {
     private double maxOccupyRatio = DEFAULT_MAX_OCCUPY_RATIO;
     private int intervalMs = DEFAULT_INTERVAL_MS;
     private int sampleCount = DEFAULT_SAMPLE_COUNT;
+
+    private double maxAllowedQps = DEFAULT_MAX_ALLOWED_QPS;
 
     public ServerFlowConfig() {
         this(ServerConstants.DEFAULT_NAMESPACE);
@@ -84,6 +87,15 @@ public class ServerFlowConfig {
         return this;
     }
 
+    public double getMaxAllowedQps() {
+        return maxAllowedQps;
+    }
+
+    public ServerFlowConfig setMaxAllowedQps(double maxAllowedQps) {
+        this.maxAllowedQps = maxAllowedQps;
+        return this;
+    }
+
     @Override
     public String toString() {
         return "ServerFlowConfig{" +
@@ -92,6 +104,7 @@ public class ServerFlowConfig {
             ", maxOccupyRatio=" + maxOccupyRatio +
             ", intervalMs=" + intervalMs +
             ", sampleCount=" + sampleCount +
+            ", maxAllowedQps=" + maxAllowedQps +
             '}';
     }
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/cluster/TokenResultStatus.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/cluster/TokenResultStatus.java
@@ -26,6 +26,10 @@ public final class TokenResultStatus {
      */
     public static final int BAD_REQUEST = -4;
     /**
+     * Too many request in server.
+     */
+    public static final int TOO_MANY_REQUEST = -2;
+    /**
      * Server or client unexpected failure (due to transport or serialization failure).
      */
     public static final int FAIL = -1;

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleChecker.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleChecker.java
@@ -178,6 +178,7 @@ final class FlowRuleChecker {
             case TokenResultStatus.NO_RULE_EXISTS:
             case TokenResultStatus.BAD_REQUEST:
             case TokenResultStatus.FAIL:
+            case TokenResultStatus.TOO_MANY_REQUEST:
                 return fallbackToLocalOrPass(rule, context, node, acquireCount, prioritized);
             case TokenResultStatus.BLOCKED:
             default:

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/base/UnaryLeapArray.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/base/UnaryLeapArray.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.slots.statistic.base;
+
+/**
+ * @author Eric Zhao
+ */
+public class UnaryLeapArray extends LeapArray<LongAdder> {
+
+    public UnaryLeapArray(int sampleCount, int intervalInMs) {
+        super(sampleCount, intervalInMs);
+    }
+
+    @Override
+    public LongAdder newEmptyBucket() {
+        return new LongAdder();
+    }
+
+    @Override
+    protected WindowWrap<LongAdder> resetWindowTo(WindowWrap<LongAdder> windowWrap, long startTime) {
+        windowWrap.resetTo(startTime);
+        windowWrap.value().reset();
+        return windowWrap;
+    }
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Add total QPS limit control for specific namespace in cluster flow control, so that it won't surge indefinitely and affect user's service itself in embedded server mode.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Resolves #381

### Describe how you did it

- Add `UnaryLeapArray` and `RequestLimiter` to enable simple QPS limit
- Improve cluster rule manager and server config manager to support request limiter
- Support `TOO_MANY_REQUEST` status in client side
- Also improve the automatic namespace register of embedded server mode

### Describe how to verify it

See test cases.

### Special notes for reviews

NONE