### PR TITLE
 Add a CommandCenterProvider to resolve CommandCenter API and cache the instance

### DIFF
--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/command/CommandCenterProvider.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/command/CommandCenterProvider.java
@@ -1,0 +1,37 @@
+package com.alibaba.csp.sentinel.command;
+
+import com.alibaba.csp.sentinel.log.RecordLog;
+import com.alibaba.csp.sentinel.transport.CommandCenter;
+import com.alibaba.csp.sentinel.util.SpiLoader;
+
+/**
+ * Provider for a universal {@link CommandCenter} instance.
+ *
+ * @author cdfive
+ * @date 2019-01-11
+ */
+public class CommandCenterProvider {
+
+    private static CommandCenter commandCenter = null;
+
+    static {
+        resolveInstance();
+    }
+
+    private static void resolveInstance() {
+        CommandCenter resolveCommandCenter = SpiLoader.loadFirstInstance(CommandCenter.class);
+
+        if (resolveCommandCenter == null) {
+            RecordLog.warn("[CommandCenterProvider] No existing CommandCenter, resolve failed");
+        } else {
+            commandCenter = resolveCommandCenter;
+            RecordLog.info("[CommandCenterProvider] CommandCenter resolved: " + resolveCommandCenter.getClass().getCanonicalName());
+        }
+    }
+
+    public static CommandCenter getCommandCenter() {
+        return commandCenter;
+    }
+
+    private CommandCenterProvider() {}
+}

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/init/CommandCenterInitFunc.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/init/CommandCenterInitFunc.java
@@ -15,9 +15,7 @@
  */
 package com.alibaba.csp.sentinel.transport.init;
 
-import java.util.Iterator;
-import java.util.ServiceLoader;
-
+import com.alibaba.csp.sentinel.command.CommandCenterProvider;
 import com.alibaba.csp.sentinel.init.InitFunc;
 import com.alibaba.csp.sentinel.init.InitOrder;
 import com.alibaba.csp.sentinel.log.RecordLog;
@@ -31,18 +29,16 @@ public class CommandCenterInitFunc implements InitFunc {
 
     @Override
     public void init() throws Exception {
-        ServiceLoader<CommandCenter> loader = ServiceLoader.load(CommandCenter.class);
-        Iterator<CommandCenter> iterator = loader.iterator();
-        if (iterator.hasNext()) {
-            CommandCenter commandCenter = iterator.next();
-            if (iterator.hasNext()) {
-                throw new IllegalStateException("Only single command center can be started");
-            } else {
-                commandCenter.beforeStart();
-                commandCenter.start();
-                RecordLog.info("[CommandCenterInit] Starting command center: "
-                    + commandCenter.getClass().getCanonicalName());
-            }
+        CommandCenter commandCenter = CommandCenterProvider.getCommandCenter();
+
+        if (commandCenter == null) {
+            RecordLog.warn("[CommandCenterInitFunc] Cannot resolve CommandCenter");
+            return;
         }
+
+        commandCenter.beforeStart();
+        commandCenter.start();
+        RecordLog.info("[CommandCenterInit] Starting command center: "
+                + commandCenter.getClass().getCanonicalName());
     }
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it

Cache the CommandCenter instance so that we can invoke any methods with it when needed.

### Does this pull request fix one issue?

Fixes #345 

### Describe how you did it

Add a Class `CommandCenterProvider` which hold a CommandCenter instance, resolve the instance 
by SPI and add a `getCommandCenter()` method to get the instance.

### Describe how to verify it

Run sentinel-dashboard and make a breakpoint to test if CommandCenter loaded as expected.

### Special notes for reviews

I found a useful method `SpiLoader.loadFirstInstance(CommandCenter.class);` to get the API，
which only get the first API instance, 
but previous `CommandCenterInitFunc` checked "Only single command center can be started",
I think it's okay not to check the unique, since load first API can worked and user can also
check in sentinel-record.log.
