### PR TITLE
When click the first-level menu, don't jump to the home page

### DIFF
--- a/sentinel-dashboard/src/main/webapp/resources/app/scripts/directives/sidebar/sidebar.html
+++ b/sentinel-dashboard/src/main/webapp/resources/app/scripts/directives/sidebar/sidebar.html
@@ -16,7 +16,7 @@
       </li>
 
       <li ng-class="{active: true}" ng-repeat="entry in apps | filter: { app: searchApp }">{{dropDown}}
-        <a href="#" ng-click="click($event)" collapse="{{collpaseall == 1}}" style="font-size: 16px;word-break: break-word;">
+        <a href="javascript:void(0);" ng-click="click($event)" collapse="{{collpaseall == 1}}" style="font-size: 16px;word-break: break-word;">
           &nbsp;{{entry.app}}
           <span class="fa arrow"></span>
           <span class="arrow">({{entry.heathCount}}/{{entry.machines.length}})</span>


### PR DESCRIPTION
### Describe what this PR does / why we need it

Make the sidebar menu more convenient to use.

### Does this pull request fix one issue?

Fixes #421 

### Describe how you did it

Change the `<a href="#">` to `<a href="javascript:void(0);">` 

### Describe how to verify it

Click one menu then click the first-level menu, the page will not jumped.

### Special notes for reviews
