### PR TITLE
Upgrade Dubbo version in sentinel-demo-dubbo

### DIFF
--- a/sentinel-demo/sentinel-demo-dubbo/pom.xml
+++ b/sentinel-demo/sentinel-demo-dubbo/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>dubbo</artifactId>
-            <version>2.6.2</version>
+            <version>2.6.5</version>
         </dependency>
         <dependency>
             <groupId>com.alibaba.csp</groupId>


### PR DESCRIPTION
dubbo version change ,old dubbo demo can't import DubboComponentScan on dubbo 2.6.2
I change the version to dubbo 2.6.5