### PR TITLE
Add logback dependency in sentinel-demo-nacos-datasource to avoid log ClassNotFoundException thrown by Nacos client

### DIFF
--- a/sentinel-demo/sentinel-demo-nacos-datasource/pom.xml
+++ b/sentinel-demo/sentinel-demo-nacos-datasource/pom.xml
@@ -29,6 +29,12 @@
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
### Describe what this PR does / why we need it

add pom dependency 

### Does this pull request fix one issue?
fix #437 

### Describe how you did it
add logback dependency 

### Describe how to verify it
used sentinel-demo-nacos-datasource NacosConfigSender.main  can return true/false

### Special notes for reviews
