### PR TITLE
fix ratelimit bugs

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/controller/RateLimiterController.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/controller/RateLimiterController.java
@@ -44,6 +44,19 @@ public class RateLimiterController implements TrafficShapingController {
 
     @Override
     public boolean canPass(Node node, int acquireCount, boolean prioritized) {
+        //pass when acquire count is less or equal than 0
+        if (acquireCount <= 0) {
+            return true;
+        }
+
+        /*
+            Reject when count is less or equal than 0.O.Otherwise,the costTime will be max of long and waitTime will overflow in some cases.
+            This will lead to pass of following request.It's dangerous!!!
+         */
+        if (count <= 0) {
+            return false;
+        }
+
         long currentTime = TimeUtil.currentTimeMillis();
         // Calculate the interval between every two requests.
         long costTime = Math.round(1.0 * (acquireCount) / count * 1000);
@@ -57,13 +70,13 @@ public class RateLimiterController implements TrafficShapingController {
             return true;
         } else {
             // Calculate the time to wait.
-            long waitTime = costTime + latestPassedTime.get() - TimeUtil.currentTimeMillis();
+            long waitTime = costTime + latestPassedTime.get() - currentTime;
             if (waitTime > maxQueueingTimeMs) {
                 return false;
             } else {
                 long oldTime = latestPassedTime.addAndGet(costTime);
                 try {
-                    waitTime = oldTime - TimeUtil.currentTimeMillis();
+                    waitTime = oldTime - currentTime;
                     if (waitTime > maxQueueingTimeMs) {
                         latestPassedTime.addAndGet(-costTime);
                         return false;

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/controller/RateLimiterControllerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/controller/RateLimiterControllerTest.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.csp.sentinel.slots.block.flow.controller;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
@@ -25,7 +26,6 @@ import org.junit.Test;
 
 import com.alibaba.csp.sentinel.util.TimeUtil;
 import com.alibaba.csp.sentinel.node.Node;
-import com.alibaba.csp.sentinel.slots.block.flow.controller.RateLimiterController;
 
 /**
  * @author jialiang.linjl
@@ -85,4 +85,14 @@ public class RateLimiterControllerTest {
 
     }
 
+    @Test
+    public void testPaceController_zeroattack() throws InterruptedException {
+        RateLimiterController paceController = new RateLimiterController(500, 0d);
+        Node node = mock(Node.class);
+
+        for (int i = 0; i < 2; i++) {
+            assertFalse(paceController.canPass(node, 1));
+            assertTrue(paceController.canPass(node, 0));
+        }
+    }
 }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Fix bugs when count is zero.

when count is zero,the costTime value will be max of long.After some retries of canPass,the waitTime will overflow and permit any request (as it will return true)

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it



### Describe how to verify it

Test case in RateLimiterControllerTest.testPaceController_zeroattack

### Special notes for reviews
