### PR TITLE
Carry the triggered rule in subclasses of BlockException

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/BlockException.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/BlockException.java
@@ -16,7 +16,8 @@
 package com.alibaba.csp.sentinel.slots.block;
 
 /***
- * Abstract exception indicating blocked by Sentinel due to flow control, degraded or system guard.
+ * Abstract exception indicating blocked by Sentinel due to flow control,
+ * circuit breaking or system protection triggered.
  *
  * @author youji.zj
  */

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/authority/AuthorityException.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/authority/AuthorityException.java
@@ -17,14 +17,23 @@ package com.alibaba.csp.sentinel.slots.block.authority;
 
 import com.alibaba.csp.sentinel.slots.block.BlockException;
 
-/***
+/**
+ * Block exception for request origin access (authority) control.
  *
  * @author youji.zj
+ * @author Eric Zhao
  */
 public class AuthorityException extends BlockException {
 
+    private AuthorityRule rule;
+
     public AuthorityException(String ruleLimitApp) {
         super(ruleLimitApp);
+    }
+
+    public AuthorityException(String ruleLimitApp, AuthorityRule rule) {
+        this(ruleLimitApp);
+        this.rule = rule;
     }
 
     public AuthorityException(String message, Throwable cause) {
@@ -40,4 +49,14 @@ public class AuthorityException extends BlockException {
         return this;
     }
 
+    /**
+     * Get triggered rule.
+     * Note: the rule result is a reference to rule map and SHOULD NOT be modified.
+     *
+     * @return triggered rule
+     * @since 1.4.2
+     */
+    public AuthorityRule getRule() {
+        return rule;
+    }
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/authority/AuthoritySlot.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/authority/AuthoritySlot.java
@@ -58,7 +58,7 @@ public class AuthoritySlot extends AbstractLinkedProcessorSlot<DefaultNode> {
 
         for (AuthorityRule rule : rules) {
             if (!AuthorityRuleChecker.passCheck(rule, context)) {
-                throw new AuthorityException(context.getOrigin());
+                throw new AuthorityException(context.getOrigin(), rule);
             }
         }
     }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeException.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeException.java
@@ -22,8 +22,15 @@ import com.alibaba.csp.sentinel.slots.block.BlockException;
  */
 public class DegradeException extends BlockException {
 
+    private DegradeRule rule;
+
     public DegradeException(String ruleLimitApp) {
         super(ruleLimitApp);
+    }
+
+    public DegradeException(String ruleLimitApp, DegradeRule rule) {
+        super(ruleLimitApp);
+        this.rule = rule;
     }
 
     public DegradeException(String message, Throwable cause) {
@@ -37,5 +44,16 @@ public class DegradeException extends BlockException {
     @Override
     public Throwable fillInStackTrace() {
         return this;
+    }
+
+    /**
+     * Get triggered rule.
+     * Note: the rule result is a reference to rule map and SHOULD NOT be modified.
+     *
+     * @return triggered rule
+     * @since 1.4.2
+     */
+    public DegradeRule getRule() {
+        return rule;
     }
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeRuleManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeRuleManager.java
@@ -76,7 +76,7 @@ public class DegradeRuleManager {
 
         for (DegradeRule rule : rules) {
             if (!rule.passCheck(context, node, count)) {
-                throw new DegradeException(rule.getLimitApp());
+                throw new DegradeException(rule.getLimitApp(), rule);
             }
         }
     }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowException.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowException.java
@@ -22,9 +22,15 @@ import com.alibaba.csp.sentinel.slots.block.BlockException;
  */
 public class FlowException extends BlockException {
 
-    public FlowException(String ruleLimitApp) {
+    private FlowRule rule;
 
+    public FlowException(String ruleLimitApp) {
         super(ruleLimitApp);
+    }
+
+    public FlowException(String ruleLimitApp, FlowRule rule) {
+        super(ruleLimitApp);
+        this.rule = rule;
     }
 
     public FlowException(String message, Throwable cause) {
@@ -40,4 +46,14 @@ public class FlowException extends BlockException {
         return this;
     }
 
+    /**
+     * Get triggered rule.
+     * Note: the rule result is a reference to rule map and SHOULD NOT be modified.
+     *
+     * @return triggered rule
+     * @since 1.4.2
+     */
+    public FlowRule getRule() {
+        return rule;
+    }
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowSlot.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowSlot.java
@@ -151,7 +151,7 @@ public class FlowSlot extends AbstractLinkedProcessorSlot<DefaultNode> {
         if (rules != null) {
             for (FlowRule rule : rules) {
                 if (!canPassCheck(rule, context, node, count, prioritized)) {
-                    throw new FlowException(rule.getLimitApp());
+                    throw new FlowException(rule.getLimitApp(), rule);
                 }
             }
         }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/system/SystemBlockException.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/system/SystemBlockException.java
@@ -22,20 +22,20 @@ import com.alibaba.csp.sentinel.slots.block.BlockException;
  */
 public class SystemBlockException extends BlockException {
 
-    String resourceName;
-
-    public String getResourceName() {
-        return resourceName;
-    }
+    private final String resourceName;
 
     public SystemBlockException(String resourceName, String message, Throwable cause) {
         super(message, cause);
         this.resourceName = resourceName;
     }
 
-    public SystemBlockException(String resourceName, String ruleLimitApp) {
-        super(ruleLimitApp);
+    public SystemBlockException(String resourceName, String limitType) {
+        super(limitType);
         this.resourceName = resourceName;
+    }
+
+    public String getResourceName() {
+        return resourceName;
     }
 
     @Override
@@ -43,4 +43,13 @@ public class SystemBlockException extends BlockException {
         return this;
     }
 
+    /**
+     * Return the limit type of system rule.
+     *
+     * @return the limit type
+     * @since 1.4.2
+     */
+    public String getLimitType() {
+        return getRuleLimitApp();
+    }
 }

--- a/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowException.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowException.java
@@ -27,14 +27,22 @@ public class ParamFlowException extends BlockException {
 
     private final String resourceName;
 
+    private ParamFlowRule rule;
+
     public ParamFlowException(String resourceName, String message, Throwable cause) {
         super(message, cause);
         this.resourceName = resourceName;
     }
 
-    public ParamFlowException(String resourceName, String message) {
-        super(message, message);
+    public ParamFlowException(String resourceName, String param) {
+        super(param, param);
         this.resourceName = resourceName;
+    }
+
+    public ParamFlowException(String resourceName, String param, ParamFlowRule rule) {
+        super(param, param);
+        this.resourceName = resourceName;
+        this.rule = rule;
     }
 
     public String getResourceName() {
@@ -44,5 +52,26 @@ public class ParamFlowException extends BlockException {
     @Override
     public Throwable fillInStackTrace() {
         return this;
+    }
+
+    /**
+     * Get the parameter value that triggered the parameter flow control.
+     *
+     * @return the parameter value
+     * @since 1.4.2
+     */
+    public String getLimitParam() {
+        return getMessage();
+    }
+
+    /**
+     * Get triggered rule.
+     * Note: the rule result is a reference to rule map and SHOULD NOT be modified.
+     *
+     * @return triggered rule
+     * @since 1.4.2
+     */
+    public ParamFlowRule getRule() {
+        return rule;
     }
 }

--- a/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowSlot.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowSlot.java
@@ -81,12 +81,12 @@ public class ParamFlowSlot extends AbstractLinkedProcessorSlot<DefaultNode> {
                     // Here we add the block count.
                     addBlockCount(resourceWrapper, count, args);
 
-                    String message = "";
+                    String triggeredParam = "";
                     if (args.length > rule.getParamIdx()) {
                         Object value = args[rule.getParamIdx()];
-                        message = String.valueOf(value);
+                        triggeredParam = String.valueOf(value);
                     }
-                    throw new ParamFlowException(resourceWrapper.getName(), message);
+                    throw new ParamFlowException(resourceWrapper.getName(), triggeredParam, rule);
                 }
             }
         }


### PR DESCRIPTION
### Describe what this PR does / why we need it

Carry the triggered rule in subclasses of BlockException. See #424 for more information.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Resolves #424 

### Describe how you did it

Refactor each subclass of `BlockException` and add a `rule` field to carry the triggered rule (except the `SystemRule`). Users can get the trigger rule from the `getRule()` method.

### Describe how to verify it

It's a compatible change. The CI should pass.

### Special notes for reviews

NONE