### PR TITLE
[Feature] Add CPU usage checking support in system protection rule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,8 @@
 
         <!-- Build -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.source.version>1.6</java.source.version>
-        <java.target.version>1.6</java.target.version>
+        <java.source.version>1.7</java.source.version>
+        <java.target.version>1.7</java.target.version>
         <java.encoding>UTF-8</java.encoding>
         <maven.compiler.version>3.8.0</maven.compiler.version>
         <maven.surefire.version>2.22.1</maven.surefire.version>

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/system/SystemRule.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/system/SystemRule.java
@@ -34,6 +34,7 @@ import com.alibaba.csp.sentinel.slots.block.AbstractRule;
  * </p>
  *
  * @author jialiang.linjl
+ * @author Carpenter Lee
  * @see SystemRuleManager
  */
 public class SystemRule extends AbstractRule {
@@ -42,6 +43,10 @@ public class SystemRule extends AbstractRule {
      * negative value means no threshold checking.
      */
     private double highestSystemLoad = -1;
+    /**
+     * cpu usage, between [0, 1]
+     */
+    private double highestCpuUsage = -1;
     private double qps = -1;
     private long avgRt = -1;
     private long maxThread = -1;
@@ -110,6 +115,24 @@ public class SystemRule extends AbstractRule {
         this.highestSystemLoad = highestSystemLoad;
     }
 
+    /**
+     * Get highest cpu usage. Cpu usage is between [0, 1]
+     *
+     * @return highest cpu usage
+     */
+    public double getHighestCpuUsage() {
+        return highestCpuUsage;
+    }
+
+    /**
+     * set highest cpu usage. Cpu usage is between [0, 1]
+     *
+     * @param highestCpuUsage the value to set.
+     */
+    public void setHighestCpuUsage(double highestCpuUsage) {
+        this.highestCpuUsage = highestCpuUsage;
+    }
+
     @Override
     public boolean passCheck(Context context, DefaultNode node, int count, Object... args) {
         return true;
@@ -132,6 +155,9 @@ public class SystemRule extends AbstractRule {
         if (Double.compare(that.highestSystemLoad, highestSystemLoad) != 0) {
             return false;
         }
+        if (Double.compare(that.highestCpuUsage, highestCpuUsage) != 0) {
+            return false;
+        }
 
         if (Double.compare(that.qps, qps) != 0) {
             return false;
@@ -150,6 +176,9 @@ public class SystemRule extends AbstractRule {
         temp = Double.doubleToLongBits(highestSystemLoad);
         result = 31 * result + (int)(temp ^ (temp >>> 32));
 
+        temp = Double.doubleToLongBits(highestCpuUsage);
+        result = 31 * result + (int)(temp ^ (temp >>> 32));
+
         temp = Double.doubleToLongBits(qps);
         result = 31 * result + (int)(temp ^ (temp >>> 32));
 
@@ -162,6 +191,7 @@ public class SystemRule extends AbstractRule {
     public String toString() {
         return "SystemRule{" +
             "highestSystemLoad=" + highestSystemLoad +
+            ", highestCpuUsage=" + highestCpuUsage +
             ", qps=" + qps +
             ", avgRt=" + avgRt +
             ", maxThread=" + maxThread +

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/system/SystemStatusListener.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/system/SystemStatusListener.java
@@ -16,11 +16,12 @@
 package com.alibaba.csp.sentinel.slots.system;
 
 import java.lang.management.ManagementFactory;
-import java.lang.management.OperatingSystemMXBean;
 
+import com.alibaba.csp.sentinel.Constants;
 import com.alibaba.csp.sentinel.log.RecordLog;
 import com.alibaba.csp.sentinel.util.StringUtil;
-import com.alibaba.csp.sentinel.Constants;
+
+import com.sun.management.OperatingSystemMXBean;
 
 /**
  * @author jialiang.linjl
@@ -28,6 +29,7 @@ import com.alibaba.csp.sentinel.Constants;
 public class SystemStatusListener implements Runnable {
 
     volatile double currentLoad = -1;
+    volatile double currentCpuUsage = -1;
 
     volatile String reason = StringUtil.EMPTY;
 
@@ -37,6 +39,10 @@ public class SystemStatusListener implements Runnable {
         return currentLoad;
     }
 
+    public double getCpuUsage() {
+        return currentCpuUsage;
+    }
+
     @Override
     public void run() {
         try {
@@ -44,13 +50,22 @@ public class SystemStatusListener implements Runnable {
                 return;
             }
 
-            // system average load
-            OperatingSystemMXBean operatingSystemMXBean = ManagementFactory.getOperatingSystemMXBean();
-            currentLoad = operatingSystemMXBean.getSystemLoadAverage();
+            OperatingSystemMXBean osBean = ManagementFactory.getPlatformMXBean(OperatingSystemMXBean.class);
+            currentLoad = osBean.getSystemLoadAverage();
+            /**
+             * Java Doc copied from {@link OperatingSystemMXBean#getSystemCpuLoad()}:</br>
+             * Returns the "recent cpu usage" for the whole system. This value is a double in the [0.0,1.0] interval.
+             * A value of 0.0 means that all CPUs were idle during the recent period of time observed, while a value
+             * of 1.0 means that all CPUs were actively running 100% of the time during the recent period being
+             * observed. All values betweens 0.0 and 1.0 are possible depending of the activities going on in the
+             * system. If the system recent cpu usage is not available, the method returns a negative value.
+             */
+            currentCpuUsage = osBean.getSystemCpuLoad();
 
             StringBuilder sb = new StringBuilder();
             if (currentLoad > SystemRuleManager.getHighestSystemLoad()) {
                 sb.append("load:").append(currentLoad).append(";");
+                sb.append("cpu:").append(currentCpuUsage).append(";");
                 sb.append("qps:").append(Constants.ENTRY_NODE.passQps()).append(";");
                 sb.append("rt:").append(Constants.ENTRY_NODE.avgRt()).append(";");
                 sb.append("thread:").append(Constants.ENTRY_NODE.curThreadNum()).append(";");

--- a/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/system/SystemGuardDemo.java
+++ b/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/system/SystemGuardDemo.java
@@ -91,6 +91,8 @@ public class SystemGuardDemo {
         SystemRule rule = new SystemRule();
         // max load is 3
         rule.setHighestSystemLoad(3.0);
+        // max cpu usage is 60%
+        rule.setHighestCpuUsage(0.6);
         // max avg rt of all request is 10 ms
         rule.setAvgRt(10);
         // max total qps is 20


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Sentinel System Guard takes average RT, QPS, thread count and system load into account, but does not consider CPU usage. Comparing to system load, CPU usage is more sensitive, which is useful when vast requests coming in sudden.

### Does this pull request fix one issue?

Resolves #450 

### Describe how you did it

Add CPU usage threshold into system rule, and when current CPU usage reaches the threshold, a BBR likely checking will be done.

### Describe how to verify it

Rule SystemGuardDemo.