### PR TITLE
Bug fix: NPE when adding event count in ParamMapBucket

### DIFF
--- a/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/statistic/data/ParamMapBucket.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/statistic/data/ParamMapBucket.java
@@ -59,9 +59,16 @@ public class ParamMapBucket {
     }
 
     public ParamMapBucket add(RollingParamEvent event, int count, Object value) {
-        data[event.ordinal()].putIfAbsent(value, new AtomicInteger());
         AtomicInteger counter = data[event.ordinal()].get(value);
-        counter.addAndGet(count);
+        // Note: not strictly concise.
+        if (counter == null) {
+            AtomicInteger old = data[event.ordinal()].putIfAbsent(value, new AtomicInteger(count));
+            if (old != null) {
+                old.addAndGet(count);
+            }
+        } else {
+            counter.addAndGet(count);
+        }
         return this;
     }
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

Fix the bug that NPE may occur when adding event count in ParamMapBucket. This is due to the concurrent operation for different values, causing old value eviction in LRU map.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Fixes #493 

### Describe how you did it

Try to get the exact counter (though not strictly concise).

### Describe how to verify it

Rerun the code snippet in #493. No NPE should occur.

### Special notes for reviews

NONE