### PR TITLE
Fix bug of calculating param size and amount in ParamFlowRequestDataWriter of Sentinel cluster

### DIFF
--- a/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/codec/data/ParamFlowRequestDataWriter.java
+++ b/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/codec/data/ParamFlowRequestDataWriter.java
@@ -21,6 +21,7 @@ import com.alibaba.csp.sentinel.cluster.ClusterConstants;
 import com.alibaba.csp.sentinel.cluster.codec.EntityWriter;
 import com.alibaba.csp.sentinel.cluster.request.data.ParamFlowRequestData;
 import com.alibaba.csp.sentinel.log.RecordLog;
+import com.alibaba.csp.sentinel.util.AssertUtil;
 
 import io.netty.buffer.ByteBuf;
 
@@ -30,6 +31,17 @@ import io.netty.buffer.ByteBuf;
  * @since 1.4.0
  */
 public class ParamFlowRequestDataWriter implements EntityWriter<ParamFlowRequestData, ByteBuf> {
+
+    private final int maxParamByteSize;
+
+    public ParamFlowRequestDataWriter() {
+        this(DEFAULT_PARAM_MAX_SIZE);
+    }
+
+    public ParamFlowRequestDataWriter(int maxParamByteSize) {
+        AssertUtil.isTrue(maxParamByteSize > 0, "maxParamByteSize should be positive");
+        this.maxParamByteSize = maxParamByteSize;
+    }
 
     @Override
     public void writeTo(ParamFlowRequestData entity, ByteBuf target) {
@@ -96,14 +108,15 @@ public class ParamFlowRequestDataWriter implements EntityWriter<ParamFlowRequest
         int length = 0;
         for (Object param : params) {
             int s = calculateParamTransportSize(param);
-            if (size + s > PARAM_MAX_SIZE) {
-                break;
-            }
             if (s <= 0) {
                 RecordLog.warn("[ParamFlowRequestDataWriter] WARN: Non-primitive type detected in params of "
                     + "cluster parameter flow control, which is not supported: " + param);
                 continue;
             }
+            if (size + s > maxParamByteSize) {
+                break;
+            }
+            size += s;
             length++;
         }
         return length;
@@ -140,5 +153,5 @@ public class ParamFlowRequestDataWriter implements EntityWriter<ParamFlowRequest
         }
     }
 
-    private static final int PARAM_MAX_SIZE = 1000;
+    private static final int DEFAULT_PARAM_MAX_SIZE = 1024;
 }

--- a/sentinel-cluster/sentinel-cluster-client-default/src/test/java/com/alibaba/csp/sentinel/cluster/client/codec/data/ParamFlowRequestDataWriterTest.java
+++ b/sentinel-cluster/sentinel-cluster-client-default/src/test/java/com/alibaba/csp/sentinel/cluster/client/codec/data/ParamFlowRequestDataWriterTest.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.*;
 public class ParamFlowRequestDataWriterTest {
 
     @Test
-    public void testCalculateParamAmount() {
+    public void testCalculateParamTransportSize() {
         ParamFlowRequestDataWriter writer = new ParamFlowRequestDataWriter();
         // POJO (non-primitive type) should not be regarded as a valid parameter.
         assertEquals(0, writer.calculateParamTransportSize(new SomePojo().setParam1("abc")));
@@ -27,7 +27,22 @@ public class ParamFlowRequestDataWriterTest {
     }
 
     @Test
-    public void testCalculateParamTransportSize() {
+    public void testCalculateParamAmountExceedsMaxSize() {
+        final int maxSize = 10;
+        ParamFlowRequestDataWriter writer = new ParamFlowRequestDataWriter(maxSize);
+        assertEquals(1, writer.calculateParamAmount(new ArrayList<Object>() {{
+            add(1);
+        }}));
+        assertEquals(2, writer.calculateParamAmount(new ArrayList<Object>() {{
+            add(1); add(64);
+        }}));
+        assertEquals(2, writer.calculateParamAmount(new ArrayList<Object>() {{
+            add(1); add(64); add(3);
+        }}));
+    }
+
+    @Test
+    public void testCalculateParamAmount() {
         ParamFlowRequestDataWriter writer = new ParamFlowRequestDataWriter();
         assertEquals(6, writer.calculateParamAmount(new ArrayList<Object>() {{
             add(1); add(1d); add(1f); add((byte) 1); add("123"); add(true);

--- a/sentinel-cluster/sentinel-cluster-client-default/src/test/java/com/alibaba/csp/sentinel/cluster/client/codec/data/ParamFlowRequestDataWriterTest.java
+++ b/sentinel-cluster/sentinel-cluster-client-default/src/test/java/com/alibaba/csp/sentinel/cluster/client/codec/data/ParamFlowRequestDataWriterTest.java
@@ -1,0 +1,63 @@
+package com.alibaba.csp.sentinel.cluster.client.codec.data;
+
+import java.util.ArrayList;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Eric Zhao
+ */
+public class ParamFlowRequestDataWriterTest {
+
+    @Test
+    public void testCalculateParamAmount() {
+        ParamFlowRequestDataWriter writer = new ParamFlowRequestDataWriter();
+        // POJO (non-primitive type) should not be regarded as a valid parameter.
+        assertEquals(0, writer.calculateParamTransportSize(new SomePojo().setParam1("abc")));
+
+        assertEquals(4 + 1, writer.calculateParamTransportSize(1));
+        assertEquals(1 + 1, writer.calculateParamTransportSize((byte) 1));
+        assertEquals(1 + 1, writer.calculateParamTransportSize(false));
+        assertEquals(8 + 1, writer.calculateParamTransportSize(2L));
+        assertEquals(8 + 1, writer.calculateParamTransportSize(4.0d));
+        final String paramStr = "Sentinel";
+        assertEquals(1 + 4 + paramStr.getBytes().length, writer.calculateParamTransportSize(paramStr));
+    }
+
+    @Test
+    public void testCalculateParamTransportSize() {
+        ParamFlowRequestDataWriter writer = new ParamFlowRequestDataWriter();
+        assertEquals(6, writer.calculateParamAmount(new ArrayList<Object>() {{
+            add(1); add(1d); add(1f); add((byte) 1); add("123"); add(true);
+        }}));
+        // POJO (non-primitive type) should not be regarded as a valid parameter.
+        assertEquals(0, writer.calculateParamAmount(new ArrayList<Object>() {{
+            add(new SomePojo());
+        }}));
+        assertEquals(1, writer.calculateParamAmount(new ArrayList<Object>() {{
+            add(new Object()); add(1);
+        }}));
+    }
+
+    private static class SomePojo {
+        private String param1;
+
+        public String getParam1() {
+            return param1;
+        }
+
+        public SomePojo setParam1(String param1) {
+            this.param1 = param1;
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return "SomePojo{" +
+                "param1='" + param1 + '\'' +
+                '}';
+        }
+    }
+}

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/ClusterParamFlowChecker.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/ClusterParamFlowChecker.java
@@ -51,6 +51,10 @@ public final class ClusterParamFlowChecker {
             // Unexpected state, return FAIL.
             return new TokenResult(TokenResultStatus.FAIL);
         }
+        if (values == null || values.isEmpty()) {
+            // Empty parameter list will always pass.
+            return new TokenResult(TokenResultStatus.OK);
+        }
         double remaining = -1;
         boolean hasPassed = true;
         Object blockObject = null;


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Fix bug of calculating param size and amount in ParamFlowRequestDataWriter of Sentinel cluster.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Pending

### Describe how you did it

Null object or non-primitive objects will not be calculated and transferred to the token server. And add warn log when there are non-primitive objects.

### Describe how to verify it

Run the test cases.

### Special notes for reviews

NONE.