### PR TITLE
Fix dubbo maven dependency in sentinel-dubbo-demo

### DIFF
--- a/sentinel-demo/sentinel-demo-dubbo/pom.xml
+++ b/sentinel-demo/sentinel-demo-dubbo/pom.xml
@@ -13,14 +13,19 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-            <version>5.0.7.RELEASE</version>
-        </dependency>
-        <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>dubbo</artifactId>
             <version>2.6.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+            <version>4.1.31.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba.spring</groupId>
+            <artifactId>spring-context-support</artifactId>
+            <version>1.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.alibaba.csp</groupId>

--- a/sentinel-demo/sentinel-demo-dubbo/pom.xml
+++ b/sentinel-demo/sentinel-demo-dubbo/pom.xml
@@ -28,8 +28,8 @@
             <version>4.1.31.Final</version>
         </dependency>
 
-        <!-- As demo use @DubboComponentScan to config, which is implemented in dubbo-config module -->
-        <!-- The dubbo-config module is optional and it depends spring-context-support, so add it explicitly-->
+        <!-- As demo use @DubboComponentScan to config, which is implemented in dubbo-config-spring module -->
+        <!-- The dubbo-config-spring module is optional and it depends spring-context-support, so add it explicitly-->
         <!-- @see https://github.com/apache/incubator-dubbo/issues/2869 -->
         <dependency>
             <groupId>com.alibaba.spring</groupId>

--- a/sentinel-demo/sentinel-demo-dubbo/pom.xml
+++ b/sentinel-demo/sentinel-demo-dubbo/pom.xml
@@ -12,21 +12,32 @@
     <artifactId>sentinel-demo-dubbo</artifactId>
 
     <dependencies>
+        <!-- Demo use dubbo 2.6.5, since it supports jdk1.6 -->
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>dubbo</artifactId>
             <version>2.6.5</version>
         </dependency>
+
+        <!-- As dubbo provide qos plugin since 2.5.8 and is enable by default -->
+        <!-- The dubbo-qos module is optional and it depends netty4, so add it explicitly -->
+        <!-- @see http://dubbo.apache.org/zh-cn/docs/user/references/qos.html -->
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
             <version>4.1.31.Final</version>
         </dependency>
+
+        <!-- As demo use @DubboComponentScan to config, which is implemented in dubbo-config module -->
+        <!-- The dubbo-config module is optional and it depends spring-context-support, so add it explicitly-->
+        <!-- @see https://github.com/apache/incubator-dubbo/issues/2869 -->
         <dependency>
             <groupId>com.alibaba.spring</groupId>
             <artifactId>spring-context-support</artifactId>
             <version>1.0.2</version>
         </dependency>
+
+        <!-- sentinel adapter and transport -->
         <dependency>
             <groupId>com.alibaba.csp</groupId>
             <artifactId>sentinel-dubbo-adapter</artifactId>


### PR DESCRIPTION
### Describe what this PR does / why we need it

Dubbo demo run failure.

### Does this pull request fix one issue?

Fixes #530

### Describe how you did it

Add dependency that needed for dubbo 2.6.5:
`spring-context-support` 1.0.2 for `AnnotationInjectedBeanPostProcessor`, in `dubbo-config-spring` which is optional.
`netty-all` 4.1.31.Final for dubbo-qos, in `dubbo-qos` which is optional.

Remove `spring-context` as dubbo.jar depends it.

@See 
https://github.com/apache/incubator-dubbo/issues/2869

### Describe how to verify it

Run demo, start FooProviderBootstrap and FooConsumerBootstrap.

### Special notes for reviews

Dubbo 2.6.6 may released next week, waiting it release,  we can upgrade from 2.6.5 to 2.6.6,
as it fixes `UndeclaredThrowableException` issue in consumer side when catch Exception.

@see
https://github.com/apache/incubator-dubbo/issues/3386

As Dubbo 2.7.0 need JDK1.8, another demo module may be considered in the future.
