### PR TITLE
Add exceptionsToTrace configuration support in @SentinelResource annotation

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/annotation/SentinelResource.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/annotation/SentinelResource.java
@@ -15,13 +15,9 @@
  */
 package com.alibaba.csp.sentinel.annotation;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
 import com.alibaba.csp.sentinel.EntryType;
+
+import java.lang.annotation.*;
 
 /**
  * The annotation indicates a definition of Sentinel resource.
@@ -63,4 +59,9 @@ public @interface SentinelResource {
      * @return name of the fallback function, empty by default
      */
     String fallback() default "";
+
+    /**
+     * @return the exception classes to trace, Throwable.class by default
+     */
+    Class<? extends Throwable>[] exceptionClasses() default {Throwable.class};
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/annotation/SentinelResource.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/annotation/SentinelResource.java
@@ -63,5 +63,5 @@ public @interface SentinelResource {
     /**
      * @return the exception classes to trace, Throwable.class by default
      */
-    Class<? extends Throwable>[] exceptionClasses() default {Throwable.class};
+    Class<? extends Throwable>[] exceptionsToTrace() default {Throwable.class};
 }

--- a/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/SentinelResourceAspect.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/SentinelResourceAspect.java
@@ -59,12 +59,33 @@ public class SentinelResourceAspect extends AbstractSentinelAspectSupport {
         } catch (BlockException ex) {
             return handleBlockException(pjp, annotation, ex);
         } catch (Throwable ex) {
-            Tracer.trace(ex);
+            if(isTrackedException(ex, annotation.exceptionClasses())){
+                Tracer.trace(ex);
+            }
             throw ex;
         } finally {
             if (entry != null) {
                 entry.exit();
             }
         }
+    }
+
+    /**
+     * whether the exception is in tracked list of exception classes
+     *
+     * @param ex
+     * @param exceptionClasses
+     * @return
+     */
+    private boolean isTrackedException(Throwable ex, Class<? extends Throwable>[] exceptionClasses){
+        if(exceptionClasses == null){
+            return false;
+        }
+        for (Class exceptionClass : exceptionClasses){
+            if(ex.getClass().isAssignableFrom(exceptionClass)){
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/SentinelResourceAspect.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/SentinelResourceAspect.java
@@ -82,7 +82,7 @@ public class SentinelResourceAspect extends AbstractSentinelAspectSupport {
             return false;
         }
         for (Class exceptionToTrace : exceptionsToTrace) {
-            if (ex.getClass().isAssignableFrom(exceptionToTrace)) {
+            if (exceptionToTrace.isAssignableFrom(ex.getClass())) {
                 return true;
             }
         }

--- a/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/SentinelResourceAspect.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/SentinelResourceAspect.java
@@ -59,7 +59,7 @@ public class SentinelResourceAspect extends AbstractSentinelAspectSupport {
         } catch (BlockException ex) {
             return handleBlockException(pjp, annotation, ex);
         } catch (Throwable ex) {
-            if(isTrackedException(ex, annotation.exceptionClasses())){
+            if (isTrackedException(ex, annotation.exceptionsToTrace())) {
                 Tracer.trace(ex);
             }
             throw ex;
@@ -74,15 +74,15 @@ public class SentinelResourceAspect extends AbstractSentinelAspectSupport {
      * whether the exception is in tracked list of exception classes
      *
      * @param ex
-     * @param exceptionClasses
+     * @param exceptionsToTrace
      * @return
      */
-    private boolean isTrackedException(Throwable ex, Class<? extends Throwable>[] exceptionClasses){
-        if(exceptionClasses == null){
+    private boolean isTrackedException(Throwable ex, Class<? extends Throwable>[] exceptionsToTrace) {
+        if (exceptionsToTrace == null) {
             return false;
         }
-        for (Class exceptionClass : exceptionClasses){
-            if(ex.getClass().isAssignableFrom(exceptionClass)){
+        for (Class exceptionToTrace : exceptionsToTrace) {
+            if (ex.getClass().isAssignableFrom(exceptionToTrace)) {
                 return true;
             }
         }


### PR DESCRIPTION
### Describe what this PR does / why we need it
In some scenarios，this resource will be degraded when it throws a specific exception.
So the configuration of exception class that should be traced (blocked), is needed.

### Does this pull request fix one issue?
Fixes #540 

### Describe how you did it
Add the configuration of exception classes that would be traced.

### Describe how to verify it
None

### Special notes for reviews
None