### PR TITLE
Allow negative paramIndex in ParamFlowRule

### DIFF
--- a/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowChecker.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowChecker.java
@@ -67,7 +67,7 @@ final class ParamFlowChecker {
     private static Object valueAt(Object[] args, int paramIdx) {
         Object value = null;
         if (paramIdx < 0) {
-            if(-paramIdx <= args.length){
+            if (-paramIdx <= args.length) {
                 return args[args.length + paramIdx];
             }
         } else {
@@ -124,7 +124,7 @@ final class ParamFlowChecker {
                 int itemThreshold = rule.getParsedHotItems().get(value);
                 return ++threadCount <= itemThreshold;
             }
-            long threshold = (long) rule.getCount();
+            long threshold = (long)rule.getCount();
             return ++threadCount <= threshold;
         }
 

--- a/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowChecker.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowChecker.java
@@ -52,7 +52,7 @@ final class ParamFlowChecker {
         }
 
         // Get parameter value. If value is null, then pass.
-        Object value = args[paramIdx];
+        Object value = valueAt(args, paramIdx);
         if (value == null) {
             return true;
         }
@@ -62,6 +62,18 @@ final class ParamFlowChecker {
         }
 
         return passLocalCheck(resourceWrapper, rule, count, value);
+    }
+
+    private static Object valueAt(Object[] args, int paramIdx) {
+        Object value = null;
+        if (paramIdx < 0) {
+            if(-paramIdx <= args.length){
+                return args[args.length + paramIdx];
+            }
+        } else {
+            value = args[paramIdx];
+        }
+        return value;
     }
 
     private static boolean passLocalCheck(ResourceWrapper resourceWrapper, ParamFlowRule rule, int count,

--- a/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowRuleUtil.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowRuleUtil.java
@@ -31,7 +31,7 @@ public final class ParamFlowRuleUtil {
 
     public static boolean isValidRule(ParamFlowRule rule) {
         return rule != null && !StringUtil.isBlank(rule.getResource()) && rule.getCount() >= 0
-            && rule.getGrade() >= 0 && rule.getParamIdx() != null && rule.getParamIdx() >= 0 && checkCluster(rule);
+            && rule.getGrade() >= 0 && rule.getParamIdx() != null && checkCluster(rule);
     }
 
     private static boolean checkCluster(/*@PreChecked*/ ParamFlowRule rule) {

--- a/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowRuleUtilTest.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowRuleUtilTest.java
@@ -35,7 +35,7 @@ public class ParamFlowRuleUtilTest {
             .setCount(1)
             .setParamIdx(-1);
         assertFalse(ParamFlowRuleUtil.isValidRule(rule4));
-        assertFalse(ParamFlowRuleUtil.isValidRule(rule5));
+        assertTrue(ParamFlowRuleUtil.isValidRule(rule5));
 
         ParamFlowRule goodRule = new ParamFlowRule("abc")
             .setCount(10)


### PR DESCRIPTION
Signed-off-by: Carpenter Lee <hooleeucas@163.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Negative paramIndex in `ParamFlowRule` is useful in some case, eg when we want to count params from the opposite direction.  But Sentinel does not allow negative paramIndex in `ParamFlowRule` now.

### Does this pull request fix one issue?

NONE

### Describe how you did it

Change `ParamFlowRuleUtil` and `ParamFlowChecker` to allow negative paramIndex in ParamFlowRule

### Describe how to verify it

Run unit test cases

### Special notes for reviews
