### PR TITLE
Add try-with-resources support for Entry class

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Entry.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Entry.java
@@ -48,7 +48,7 @@ import com.alibaba.csp.sentinel.context.Context;
  * @see Context
  * @see ContextUtil
  */
-public abstract class Entry {
+public abstract class Entry implements AutoCloseable {
 
     private static final Object[] OBJECTS0 = new Object[0];
 
@@ -70,6 +70,11 @@ public abstract class Entry {
         return resourceWrapper;
     }
 
+    /**
+     * Complete the current resource entry and restore the entry stack in context.
+     *
+     * @throws ErrorEntryFreeException if entry in current context does not match current entry
+     */
     public void exit() throws ErrorEntryFreeException {
         exit(1, OBJECTS0);
     }
@@ -79,10 +84,20 @@ public abstract class Entry {
     }
 
     /**
+     * Equivalent to {@link #exit()}. Support try-with-resources since JDK 1.7.
+     *
+     * @since 1.5.0
+     */
+    @Override
+    public void close() {
+        exit();
+    }
+
+    /**
      * Exit this entry. This method should invoke if and only if once at the end of the resource protection.
      *
      * @param count tokens to release.
-     * @param args
+     * @param args extra parameters
      * @throws ErrorEntryFreeException, if {@link Context#getCurEntry()} is not this entry.
      */
     public abstract void exit(int count, Object... args) throws ErrorEntryFreeException;
@@ -91,7 +106,7 @@ public abstract class Entry {
      * Exit this entry.
      *
      * @param count tokens to release.
-     * @param args
+     * @param args extra parameters
      * @return next available entry after exit, that is the parent entry.
      * @throws ErrorEntryFreeException, if {@link Context#getCurEntry()} is not this entry.
      */


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Since 1.5.0 the min JDK version will be 1.7. We added *try-with-resources* support for `Entry` class so that it's easier to use Sentinel's API like this:

```java
try (Entry entry = SphU.entry("someResource")) {
    // Your own logic here.
} catch (BlockException ex) {
    // Your logic for handling rejection here.
}
```

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Resolves #233 

### Describe how you did it

The `Entry` class now implements JDK's `AutoCloseable` interface so it supports try-with-resources (`close` method adapts to `exit`)

### Describe how to verify it

Run the test cases.

### Special notes for reviews

NONE