### PR TITLE
Save total inbound traffic in metric file

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Constants.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Constants.java
@@ -38,6 +38,8 @@ public final class Constants {
     public final static String ROOT_ID = "machine-root";
     public final static String CONTEXT_DEFAULT_NAME = "sentinel_default_context";
 
+    public final static String TOTAL_IN_RESOURCE_NAME = "__total_inbound_traffic__";
+
     public final static DefaultNode ROOT = new EntranceNode(new StringResourceWrapper(ROOT_ID, EntryType.IN),
         Env.nodeBuilder.buildClusterNode());
 


### PR DESCRIPTION
Signed-off-by: Carpenter Lee <hooleeucas@163.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Basically, invocation can be inbound or outbound, and total inbound traffic is an important system overall indicator. Sentinel `Constants.ENTRY_NODE` has counted all inbound traffics for `SystemRule`, it will be useful to save it out to metric file.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how you did it

 Sentinel `Constants.ENTRY_NODE` has counted all inbound traffics for `SystemRule`. We write out the metric every one second to metric file.

### Describe how to verify it

Run test cases.

### Special notes for reviews
