### PR TITLE
Add Sentinel Spring WebFlux adapter module

### DIFF
--- a/sentinel-adapter/pom.xml
+++ b/sentinel-adapter/pom.xml
@@ -20,6 +20,7 @@
         <module>sentinel-grpc-adapter</module>
         <module>sentinel-zuul-adapter</module>
         <module>sentinel-reactor-adapter</module>
+        <module>sentinel-spring-webflux-adapter</module>
     </modules>
 
     <dependencyManagement>
@@ -37,6 +38,11 @@
             <dependency>
                 <groupId>com.alibaba.csp</groupId>
                 <artifactId>sentinel-web-servlet</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.alibaba.csp</groupId>
+                <artifactId>sentinel-reactor-adapter</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/sentinel-adapter/sentinel-spring-webflux-adapter/pom.xml
+++ b/sentinel-adapter/sentinel-spring-webflux-adapter/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sentinel-adapter</artifactId>
+        <groupId>com.alibaba.csp</groupId>
+        <version>1.5.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>sentinel-spring-webflux-adapter</artifactId>
+
+    <properties>
+        <java.source.version>1.8</java.source.version>
+        <java.target.version>1.8</java.target.version>
+        <spring.version>5.1.5.RELEASE</spring.version>
+        <spring.boot.version>2.1.3.RELEASE</spring.boot.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-reactor-adapter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webflux</artifactId>
+            <version>${spring.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/SentinelWebFluxFilter.java
+++ b/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/SentinelWebFluxFilter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.spring.webflux;
+
+import java.util.Optional;
+
+import com.alibaba.csp.sentinel.EntryType;
+import com.alibaba.csp.sentinel.adapter.reactor.ContextConfig;
+import com.alibaba.csp.sentinel.adapter.reactor.EntryConfig;
+import com.alibaba.csp.sentinel.adapter.reactor.SentinelReactorTransformer;
+import com.alibaba.csp.sentinel.adapter.spring.webflux.callback.WebFluxCallbackManager;
+
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Eric Zhao
+ * @since 1.5.0
+ */
+public class SentinelWebFluxFilter implements WebFilter {
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        return chain.filter(exchange)
+            .transform(buildSentinelTransformer(exchange));
+    }
+
+    private SentinelReactorTransformer<Void> buildSentinelTransformer(ServerWebExchange exchange) {
+        // Maybe we can get the URL pattern elsewhere via:
+        // exchange.getAttributeOrDefault(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE, path)
+
+        String path = exchange.getRequest().getPath().value();
+        String finalPath = Optional.ofNullable(WebFluxCallbackManager.getUrlCleaner())
+            .map(f -> f.apply(exchange, path))
+            .orElse(path);
+        String origin = Optional.ofNullable(WebFluxCallbackManager.getRequestOriginParser())
+            .map(f -> f.apply(exchange))
+            .orElse(EMPTY_ORIGIN);
+
+        return new SentinelReactorTransformer<>(
+            new EntryConfig(finalPath, EntryType.IN, new ContextConfig(finalPath, origin)));
+    }
+
+    private static final String EMPTY_ORIGIN = "";
+}

--- a/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/callback/BlockRequestHandler.java
+++ b/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/callback/BlockRequestHandler.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.spring.webflux.callback;
+
+import org.springframework.web.reactive.function.server.ServerResponse;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+/**
+ * Reactive handler for the blocked request.
+ *
+ * @author Eric Zhao
+ * @since 1.5.0
+ */
+@FunctionalInterface
+public interface BlockRequestHandler {
+
+    /**
+     * Handle the blocked request.
+     *
+     * @param exchange server exchange object
+     * @param t block exception
+     * @return server response to return
+     */
+    Mono<ServerResponse> handleRequest(ServerWebExchange exchange, Throwable t);
+}

--- a/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/callback/DefaultBlockRequestHandler.java
+++ b/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/callback/DefaultBlockRequestHandler.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.spring.webflux.callback;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.InvalidMediaTypeException;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import static org.springframework.web.reactive.function.BodyInserters.fromObject;
+
+/**
+ * The default implementation of {@link BlockRequestHandler}.
+ *
+ * @author Eric Zhao
+ * @since 1.5.0
+ */
+public class DefaultBlockRequestHandler implements BlockRequestHandler {
+
+    private static final String DEFAULT_BLOCK_MSG_PREFIX = "Blocked by Sentinel: ";
+
+    @Override
+    public Mono<ServerResponse> handleRequest(ServerWebExchange exchange, Throwable ex) {
+        if (acceptsHtml(exchange)) {
+            return htmlErrorResponse(ex);
+        }
+        // JSON result by default.
+        return ServerResponse.status(HttpStatus.TOO_MANY_REQUESTS)
+            .contentType(MediaType.APPLICATION_JSON_UTF8)
+            .body(fromObject(buildErrorResult(ex)));
+    }
+
+    private Mono<ServerResponse> htmlErrorResponse(Throwable ex) {
+        return ServerResponse.status(HttpStatus.TOO_MANY_REQUESTS)
+            .contentType(MediaType.TEXT_PLAIN)
+            .syncBody(DEFAULT_BLOCK_MSG_PREFIX + ex.getClass().getSimpleName());
+    }
+
+    private ErrorResult buildErrorResult(Throwable ex) {
+        return new ErrorResult(HttpStatus.TOO_MANY_REQUESTS.value(),
+            DEFAULT_BLOCK_MSG_PREFIX + ex.getClass().getSimpleName());
+    }
+
+    /**
+     * Reference from {@code DefaultErrorWebExceptionHandler} of Spring Boot.
+     */
+    private boolean acceptsHtml(ServerWebExchange exchange) {
+        try {
+            List<MediaType> acceptedMediaTypes = exchange.getRequest().getHeaders().getAccept();
+            acceptedMediaTypes.remove(MediaType.ALL);
+            MediaType.sortBySpecificityAndQuality(acceptedMediaTypes);
+            return acceptedMediaTypes.stream()
+                .anyMatch(MediaType.TEXT_HTML::isCompatibleWith);
+        } catch (InvalidMediaTypeException ex) {
+            return false;
+        }
+    }
+
+    private static class ErrorResult {
+        private final int code;
+        private final String message;
+
+        ErrorResult(int code, String message) {
+            this.code = code;
+            this.message = message;
+        }
+
+        public int getCode() {
+            return code;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
+}

--- a/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/callback/WebFluxCallbackManager.java
+++ b/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/callback/WebFluxCallbackManager.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.spring.webflux.callback;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import com.alibaba.csp.sentinel.util.AssertUtil;
+
+import org.springframework.web.server.ServerWebExchange;
+
+/**
+ * @author Eric Zhao
+ * @since 1.5.0
+ */
+public final class WebFluxCallbackManager {
+
+    private static final BiFunction<ServerWebExchange, String, String> DEFAULT_URL_CLEANER = (w, url) -> url;
+    private static final Function<ServerWebExchange, String> DEFAULT_ORIGIN_PARSER = (w) -> "";
+
+    /**
+     * BlockRequestHandler: (serverExchange, exception) -> response
+     */
+    private static volatile BlockRequestHandler blockHandler = new DefaultBlockRequestHandler();
+    /**
+     * UrlCleaner: (serverExchange, originalUrl) -> finalUrl
+     */
+    private static volatile BiFunction<ServerWebExchange, String, String> urlCleaner = DEFAULT_URL_CLEANER;
+    /**
+     * RequestOriginParser: (serverExchange) -> origin
+     */
+    private static volatile Function<ServerWebExchange, String> requestOriginParser = DEFAULT_ORIGIN_PARSER;
+
+    public static /*@NonNull*/ BlockRequestHandler getBlockHandler() {
+        return blockHandler;
+    }
+
+    public static void resetBlockHandler() {
+        WebFluxCallbackManager.blockHandler = new DefaultBlockRequestHandler();
+    }
+
+    public static void setBlockHandler(BlockRequestHandler blockHandler) {
+        AssertUtil.notNull(blockHandler, "blockHandler cannot be null");
+        WebFluxCallbackManager.blockHandler = blockHandler;
+    }
+
+    public static /*@NonNull*/ BiFunction<ServerWebExchange, String, String> getUrlCleaner() {
+        return urlCleaner;
+    }
+
+    public static void resetUrlCleaner() {
+        WebFluxCallbackManager.urlCleaner = DEFAULT_URL_CLEANER;
+    }
+
+    public static void setUrlCleaner(BiFunction<ServerWebExchange, String, String> urlCleaner) {
+        AssertUtil.notNull(urlCleaner, "urlCleaner cannot be null");
+        WebFluxCallbackManager.urlCleaner = urlCleaner;
+    }
+
+    public static /*@NonNull*/ Function<ServerWebExchange, String> getRequestOriginParser() {
+        return requestOriginParser;
+    }
+
+    public static void resetRequestOriginParser() {
+        WebFluxCallbackManager.requestOriginParser = DEFAULT_ORIGIN_PARSER;
+    }
+
+    public static void setRequestOriginParser(Function<ServerWebExchange, String> requestOriginParser) {
+        AssertUtil.notNull(requestOriginParser, "requestOriginParser cannot be null");
+        WebFluxCallbackManager.requestOriginParser = requestOriginParser;
+    }
+
+    private WebFluxCallbackManager() {}
+}

--- a/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/exception/SentinelBlockExceptionHandler.java
+++ b/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/exception/SentinelBlockExceptionHandler.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.spring.webflux.exception;
+
+import java.util.List;
+
+import com.alibaba.csp.sentinel.adapter.spring.webflux.callback.WebFluxCallbackManager;
+import com.alibaba.csp.sentinel.slots.block.BlockException;
+import com.alibaba.csp.sentinel.util.function.Supplier;
+
+import org.springframework.http.codec.HttpMessageWriter;
+import org.springframework.http.codec.ServerCodecConfigurer;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import org.springframework.web.reactive.result.view.ViewResolver;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebExceptionHandler;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Eric Zhao
+ * @since 1.5.0
+ */
+public class SentinelBlockExceptionHandler implements WebExceptionHandler {
+
+    private List<ViewResolver> viewResolvers;
+    private List<HttpMessageWriter<?>> messageWriters;
+
+    public SentinelBlockExceptionHandler(List<ViewResolver> viewResolvers, ServerCodecConfigurer serverCodecConfigurer) {
+        this.viewResolvers = viewResolvers;
+        this.messageWriters = serverCodecConfigurer.getWriters();
+    }
+
+    private Mono<Void> writeResponse(ServerResponse response, ServerWebExchange exchange) {
+        return response.writeTo(exchange, contextSupplier.get());
+    }
+
+    @Override
+    public Mono<Void> handle(ServerWebExchange exchange, Throwable ex) {
+        if (exchange.getResponse().isCommitted()) {
+            return Mono.error(ex);
+        }
+        // This exception handler only handles rejection by Sentinel.
+        if (!BlockException.isBlockException(ex)) {
+            return Mono.error(ex);
+        }
+        return handleBlockedRequest(exchange, ex)
+            .flatMap(response -> writeResponse(response, exchange));
+    }
+
+    private Mono<ServerResponse> handleBlockedRequest(ServerWebExchange exchange, Throwable throwable) {
+        return WebFluxCallbackManager.getBlockHandler().handleRequest(exchange, throwable);
+    }
+
+    private final Supplier<ServerResponse.Context> contextSupplier = () -> new ServerResponse.Context() {
+        @Override
+        public List<HttpMessageWriter<?>> messageWriters() {
+            return SentinelBlockExceptionHandler.this.messageWriters;
+        }
+
+        @Override
+        public List<ViewResolver> viewResolvers() {
+            return SentinelBlockExceptionHandler.this.viewResolvers;
+        }
+    };
+}

--- a/sentinel-adapter/sentinel-spring-webflux-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/spring/webflux/SentinelWebFluxIntegrationTest.java
+++ b/sentinel-adapter/sentinel-spring-webflux-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/spring/webflux/SentinelWebFluxIntegrationTest.java
@@ -1,0 +1,169 @@
+package com.alibaba.csp.sentinel.adapter.spring.webflux;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import com.alibaba.csp.sentinel.adapter.spring.webflux.callback.WebFluxCallbackManager;
+import com.alibaba.csp.sentinel.adapter.spring.webflux.test.WebFluxTestApplication;
+import com.alibaba.csp.sentinel.node.ClusterNode;
+import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+import com.alibaba.csp.sentinel.slots.block.flow.FlowRule;
+import com.alibaba.csp.sentinel.slots.block.flow.FlowRuleManager;
+import com.alibaba.csp.sentinel.slots.clusterbuilder.ClusterBuilderSlot;
+import com.alibaba.csp.sentinel.util.StringUtil;
+
+import org.hamcrest.core.StringContains;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Eric Zhao
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = WebFluxTestApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT)
+public class SentinelWebFluxIntegrationTest {
+
+    private static final String HELLO_STR = "Hello!";
+    private static final String BLOCK_MSG_PREFIX = "Blocked by Sentinel: ";
+
+    @Autowired
+    private WebTestClient webClient;
+
+    private void configureRulesFor(String resource, int count) {
+        configureRulesFor(resource, count, "default");
+    }
+
+    private void configureRulesFor(String resource, int count, String limitApp) {
+        FlowRule rule = new FlowRule()
+            .setCount(count)
+            .setGrade(RuleConstant.FLOW_GRADE_QPS);
+        rule.setResource(resource);
+        if (StringUtil.isNotBlank(limitApp)) {
+            rule.setLimitApp(limitApp);
+        }
+        FlowRuleManager.loadRules(Collections.singletonList(rule));
+    }
+
+    @Test
+    public void testWebFluxFilterBasic() throws Exception {
+        String url = "/hello";
+        this.webClient.get()
+            .uri(url)
+            .accept(MediaType.TEXT_PLAIN)
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody(String.class).isEqualTo(HELLO_STR);
+
+        ClusterNode cn = ClusterBuilderSlot.getClusterNode(url);
+        assertNotNull(cn);
+        assertEquals(1, cn.passQps());
+    }
+
+    @Test
+    public void testCustomizedUrlCleaner() throws Exception {
+        final String fooPrefix = "/foo/";
+        String url1 = fooPrefix + 1;
+        String url2 = fooPrefix + 2;
+        WebFluxCallbackManager.setUrlCleaner(((exchange, originUrl) -> {
+            if (originUrl.startsWith(fooPrefix)) {
+                return "/foo/*";
+            }
+            return originUrl;
+        }));
+        this.webClient.get()
+            .uri(url1)
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody(String.class).isEqualTo("Hello 1");
+        this.webClient.get()
+            .uri(url2)
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody(String.class).isEqualTo("Hello 2");
+
+        ClusterNode cn = ClusterBuilderSlot.getClusterNode(fooPrefix + "*");
+        assertEquals(2, cn.passQps());
+        assertNull(ClusterBuilderSlot.getClusterNode(url1));
+        assertNull(ClusterBuilderSlot.getClusterNode(url2));
+
+        WebFluxCallbackManager.resetUrlCleaner();
+    }
+
+    @Test
+    public void testCustomizedBlockRequestHandler() throws Exception {
+        String url = "/error";
+        String prefix = "blocked: ";
+        WebFluxCallbackManager.setBlockHandler((exchange, t) -> ServerResponse.ok()
+            .contentType(MediaType.TEXT_PLAIN)
+            .syncBody(prefix + t.getMessage()));
+
+        this.webClient.get()
+            .uri(url)
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody(String.class).value(StringContains.containsString(prefix));
+
+        WebFluxCallbackManager.resetBlockHandler();
+    }
+
+    @Test
+    public void testCustomizedRequestOriginParser() throws Exception {
+        String url = "/hello";
+        String limitOrigin = "userA";
+        final String headerName = "S-User";
+        configureRulesFor(url, 0, limitOrigin);
+
+        WebFluxCallbackManager.setRequestOriginParser(exchange -> {
+            String origin = exchange.getRequest().getHeaders().getFirst(headerName);
+            return origin != null ? origin : "";
+        });
+
+        this.webClient.get()
+            .uri(url)
+            .accept(MediaType.TEXT_PLAIN)
+            .header(headerName, "userB")
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody(String.class).isEqualTo(HELLO_STR);
+        // This will be blocked.
+        this.webClient.get()
+            .uri(url)
+            .accept(MediaType.TEXT_PLAIN)
+            .header(headerName, limitOrigin)
+            .exchange()
+            .expectStatus().isEqualTo(HttpStatus.TOO_MANY_REQUESTS)
+            .expectBody(String.class).value(StringContains.containsString(BLOCK_MSG_PREFIX));
+        this.webClient.get()
+            .uri(url)
+            .accept(MediaType.TEXT_PLAIN)
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody(String.class).isEqualTo(HELLO_STR);
+
+        WebFluxCallbackManager.resetRequestOriginParser();
+    }
+
+    @Before
+    public void setUp() {
+        FlowRuleManager.loadRules(new ArrayList<>());
+        ClusterBuilderSlot.resetClusterNodes();
+    }
+
+    @After
+    public void cleanUp() {
+        FlowRuleManager.loadRules(new ArrayList<>());
+        ClusterBuilderSlot.resetClusterNodes();
+    }
+}

--- a/sentinel-adapter/sentinel-spring-webflux-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/spring/webflux/test/WebFluxTestApplication.java
+++ b/sentinel-adapter/sentinel-spring-webflux-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/spring/webflux/test/WebFluxTestApplication.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.spring.webflux.test;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * @author Eric Zhao
+ */
+@SpringBootApplication
+public class WebFluxTestApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(WebFluxTestApplication.class, args);
+    }
+}

--- a/sentinel-adapter/sentinel-spring-webflux-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/spring/webflux/test/WebFluxTestConfig.java
+++ b/sentinel-adapter/sentinel-spring-webflux-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/spring/webflux/test/WebFluxTestConfig.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.spring.webflux.test;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.alibaba.csp.sentinel.adapter.spring.webflux.SentinelWebFluxFilter;
+import com.alibaba.csp.sentinel.adapter.spring.webflux.exception.SentinelBlockExceptionHandler;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.codec.ServerCodecConfigurer;
+import org.springframework.web.reactive.result.view.ViewResolver;
+
+/**
+ * @author Eric Zhao
+ */
+@Configuration
+public class WebFluxTestConfig {
+
+    private final List<ViewResolver> viewResolvers;
+    private final ServerCodecConfigurer serverCodecConfigurer;
+
+    public WebFluxTestConfig(ObjectProvider<List<ViewResolver>> viewResolversProvider,
+                         ServerCodecConfigurer serverCodecConfigurer) {
+        this.viewResolvers = viewResolversProvider.getIfAvailable(Collections::emptyList);
+        this.serverCodecConfigurer = serverCodecConfigurer;
+    }
+
+    @Bean
+    @Order(-1)
+    public SentinelBlockExceptionHandler sentinelBlockExceptionHandler() {
+        // Register the block exception handler for Spring WebFlux.
+        return new SentinelBlockExceptionHandler(viewResolvers, serverCodecConfigurer);
+    }
+
+    @Bean
+    @Order(-1)
+    public SentinelWebFluxFilter sentinelWebFluxFilter() {
+        // Register the Sentinel WebFlux filter.
+        return new SentinelWebFluxFilter();
+    }
+}

--- a/sentinel-adapter/sentinel-spring-webflux-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/spring/webflux/test/WebFluxTestController.java
+++ b/sentinel-adapter/sentinel-spring-webflux-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/spring/webflux/test/WebFluxTestController.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.spring.webflux.test;
+
+import com.alibaba.csp.sentinel.slots.block.flow.FlowException;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Eric Zhao
+ */
+@RestController
+public class WebFluxTestController {
+
+    @GetMapping("/hello")
+    public String apiHello() {
+        return "Hello!";
+    }
+
+    @GetMapping("/flux")
+    public Flux<Integer> apiFlux() {
+        return Flux.range(0, 5);
+    }
+
+    @GetMapping("/error")
+    public Mono<?> apiError() {
+        return Mono.error(new FlowException("testWebFluxError"));
+    }
+
+    @GetMapping("/foo/{id}")
+    public String apiFoo(@PathVariable("id") Long id) {
+        return "Hello " + id;
+    }
+}

--- a/sentinel-demo/pom.xml
+++ b/sentinel-demo/pom.xml
@@ -30,6 +30,7 @@
         <module>sentinel-demo-slot-chain-spi</module>
         <module>sentinel-demo-cluster</module>
         <module>sentinel-demo-command-handler</module>
+        <module>sentinel-demo-spring-webflux</module>
     </modules>
 
     <dependencies>

--- a/sentinel-demo/sentinel-demo-spring-webflux/pom.xml
+++ b/sentinel-demo/sentinel-demo-spring-webflux/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sentinel-demo</artifactId>
+        <groupId>com.alibaba.csp</groupId>
+        <version>1.5.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>sentinel-demo-spring-webflux</artifactId>
+
+    <properties>
+        <spring.boot.version>2.1.3.RELEASE</spring.boot.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-transport-simple-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-spring-webflux-adapter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis-reactive</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/sentinel-demo/sentinel-demo-spring-webflux/src/main/java/com/alibaba/csp/sentinel/demo/spring/webflux/WebFluxDemoApplication.java
+++ b/sentinel-demo/sentinel-demo-spring-webflux/src/main/java/com/alibaba/csp/sentinel/demo/spring/webflux/WebFluxDemoApplication.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.demo.spring.webflux;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * <p>A demo for Spring WebFlux reactive application.</p>
+ *
+ * <p>To integrate with Sentinel dashboard, you can run the demo with the parameters (an example):
+ * <code>-Dproject.name=WebFluxDemoApplication -Dcsp.sentinel.dashboard.server=localhost:8080
+ * -Dcsp.sentinel.api.port=8720
+ * </code>
+ * </p>
+ *
+ * @author Eric Zhao
+ */
+@SpringBootApplication
+public class WebFluxDemoApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(WebFluxDemoApplication.class, args);
+    }
+}

--- a/sentinel-demo/sentinel-demo-spring-webflux/src/main/java/com/alibaba/csp/sentinel/demo/spring/webflux/config/RedisConfig.java
+++ b/sentinel-demo/sentinel-demo-spring-webflux/src/main/java/com/alibaba/csp/sentinel/demo/spring/webflux/config/RedisConfig.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.demo.spring.webflux.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+/**
+ * @author Eric Zhao
+ */
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public ReactiveRedisTemplate<String, String> stringReactiveRedisTemplate(ReactiveRedisConnectionFactory connectionFactory){
+        RedisSerializationContext<String, String> serializationContext = RedisSerializationContext
+            .<String, String>newSerializationContext(new StringRedisSerializer())
+            .hashKey(new StringRedisSerializer())
+            .hashValue(new StringRedisSerializer())
+            .build();
+        return new ReactiveRedisTemplate<>(connectionFactory, serializationContext);
+    }
+}

--- a/sentinel-demo/sentinel-demo-spring-webflux/src/main/java/com/alibaba/csp/sentinel/demo/spring/webflux/config/WebFluxConfig.java
+++ b/sentinel-demo/sentinel-demo-spring-webflux/src/main/java/com/alibaba/csp/sentinel/demo/spring/webflux/config/WebFluxConfig.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.demo.spring.webflux.config;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.alibaba.csp.sentinel.adapter.spring.webflux.SentinelWebFluxFilter;
+import com.alibaba.csp.sentinel.adapter.spring.webflux.exception.SentinelBlockExceptionHandler;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.codec.ServerCodecConfigurer;
+import org.springframework.web.reactive.result.view.ViewResolver;
+
+/**
+ * @author Eric Zhao
+ */
+@Configuration
+public class WebFluxConfig {
+
+    private final List<ViewResolver> viewResolvers;
+    private final ServerCodecConfigurer serverCodecConfigurer;
+
+    public WebFluxConfig(ObjectProvider<List<ViewResolver>> viewResolversProvider,
+                         ServerCodecConfigurer serverCodecConfigurer) {
+        this.viewResolvers = viewResolversProvider.getIfAvailable(Collections::emptyList);
+        this.serverCodecConfigurer = serverCodecConfigurer;
+    }
+
+    @Bean
+    @Order(-1)
+    public SentinelBlockExceptionHandler sentinelBlockExceptionHandler() {
+        // Register the block exception handler for Spring WebFlux.
+        return new SentinelBlockExceptionHandler(viewResolvers, serverCodecConfigurer);
+    }
+
+    @Bean
+    @Order(-1)
+    public SentinelWebFluxFilter sentinelWebFluxFilter() {
+        // Register the Sentinel WebFlux filter.
+        return new SentinelWebFluxFilter();
+    }
+}

--- a/sentinel-demo/sentinel-demo-spring-webflux/src/main/java/com/alibaba/csp/sentinel/demo/spring/webflux/controller/BazController.java
+++ b/sentinel-demo/sentinel-demo-spring-webflux/src/main/java/com/alibaba/csp/sentinel/demo/spring/webflux/controller/BazController.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.demo.spring.webflux.controller;
+
+import com.alibaba.csp.sentinel.adapter.reactor.SentinelReactorTransformer;
+import com.alibaba.csp.sentinel.demo.spring.webflux.service.BazService;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Eric Zhao
+ */
+@RestController
+@RequestMapping(value = "/baz")
+public class BazController {
+
+    @Autowired
+    private BazService bazService;
+
+    @GetMapping("/{id}")
+    public Mono<String> apiGetValue(@PathVariable("id") Long id) {
+        return bazService.getById(id)
+            .transform(new SentinelReactorTransformer<>("BazService:getById"));
+    }
+
+    @PostMapping("/{id}")
+    public Mono<Boolean> apiSetValue(@PathVariable("id") Long id, @RequestBody String value) {
+        return bazService.setValue(id, value)
+            .transform(new SentinelReactorTransformer<>("BazService:setValue"));
+    }
+}

--- a/sentinel-demo/sentinel-demo-spring-webflux/src/main/java/com/alibaba/csp/sentinel/demo/spring/webflux/controller/FooController.java
+++ b/sentinel-demo/sentinel-demo-spring-webflux/src/main/java/com/alibaba/csp/sentinel/demo/spring/webflux/controller/FooController.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.demo.spring.webflux.controller;
+
+import com.alibaba.csp.sentinel.adapter.reactor.SentinelReactorTransformer;
+import com.alibaba.csp.sentinel.demo.spring.webflux.service.FooService;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Eric Zhao
+ */
+@RestController
+@RequestMapping(value = "/foo")
+public class FooController {
+
+    @Autowired
+    private FooService fooService;
+
+    @GetMapping("/single")
+    public Mono<String> apiNormalSingle() {
+        return fooService.emitSingle()
+            // transform the publisher here.
+            .transform(new SentinelReactorTransformer<>("demo_foo_normal_single"));
+    }
+
+    @GetMapping("/flux")
+    public Flux<Integer> apiNormalFlux() {
+        return fooService.emitMultiple()
+            .transform(new SentinelReactorTransformer<>("demo_foo_normal_flux"));
+    }
+
+    @GetMapping("/slow")
+    public Mono<String> apiDoSomethingSlow(ServerHttpResponse response) {
+        return fooService.doSomethingSlow();
+    }
+}

--- a/sentinel-demo/sentinel-demo-spring-webflux/src/main/java/com/alibaba/csp/sentinel/demo/spring/webflux/service/BazService.java
+++ b/sentinel-demo/sentinel-demo-spring-webflux/src/main/java/com/alibaba/csp/sentinel/demo/spring/webflux/service/BazService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.demo.spring.webflux.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+/**
+ * <p>A sample service for interacting with Redis via reactive Redis client.</p>
+ * <p>To play this service, you need a Redis instance running in local.</p>
+ *
+ * @author Eric Zhao
+ */
+@Service
+public class BazService {
+
+    @Autowired
+    private ReactiveRedisTemplate<String, String> template;
+
+    public Mono<String> getById(Long id) {
+        if (id == null || id <= 0) {
+            return Mono.error(new IllegalArgumentException("invalid id: " + id));
+        }
+        return template.opsForValue()
+            .get(KEY_PREFIX + id)
+            .switchIfEmpty(Mono.just("not_found"));
+    }
+
+    public Mono<Boolean> setValue(Long id, String value) {
+        if (id == null || id <= 0 || value == null) {
+            return Mono.error(new IllegalArgumentException("invalid parameters"));
+        }
+        return template.opsForValue()
+            .set(KEY_PREFIX + id, value);
+    }
+
+    private static final String KEY_PREFIX = "sentinel-reactor-test:";
+}

--- a/sentinel-demo/sentinel-demo-spring-webflux/src/main/java/com/alibaba/csp/sentinel/demo/spring/webflux/service/FooService.java
+++ b/sentinel-demo/sentinel-demo-spring-webflux/src/main/java/com/alibaba/csp/sentinel/demo/spring/webflux/service/FooService.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.demo.spring.webflux.service;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * @author Eric Zhao
+ */
+@Service
+public class FooService {
+
+    private final ExecutorService pool = Executors.newFixedThreadPool(8);
+    private final Scheduler scheduler = Schedulers.fromExecutor(pool);
+
+    public Mono<String> emitSingle() {
+        return Mono.just(ThreadLocalRandom.current().nextInt(0, 2000))
+            .map(e -> e + "d");
+    }
+
+    public Flux<Integer> emitMultiple() {
+        int start = ThreadLocalRandom.current().nextInt(0, 6000);
+        return Flux.range(start, 10);
+    }
+
+    public Mono<String> doSomethingSlow() {
+        return Mono.fromCallable(() -> {
+            Thread.sleep(2000);
+            System.out.println("doSomethingSlow: " + Thread.currentThread().getName());
+            return "ok";
+        }).publishOn(scheduler);
+    }
+}

--- a/sentinel-demo/sentinel-demo-spring-webflux/src/main/resources/application.properties
+++ b/sentinel-demo/sentinel-demo-spring-webflux/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+spring.application.name=sentinel-webflux-demo-application
+server.port=8081


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Add Sentinel Spring WebFlux adapter to support integration with Spring WebFlux (reactive). I've also provided a demo for it.

### Does this pull request fix one issue?

Resolves #230 

### Describe how you did it

- Add a `SentinelWebFluxFilter` to intercept the request and wrap with Sentinel using Sentinel Reactor transformer.
- Implement a `SentinelBlockExceptionHandler` that will handle the `BlockException` and return a default message body by default.

Default message body resembles:

```json
{"code":429,"message":"Blocked by Sentinel: FlowException"}
```

### Describe how to verify it

Run the test cases.

### Special notes for reviews

Plz run the demo in local to see whether it works correctly.
