### PR TITLE
Dashboard: fix a request mapping issue of removing machines api

### DIFF
--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/AppController.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/AppController.java
@@ -77,7 +77,7 @@ public class AppController {
         return Result.ofSuccess(MachineInfoVo.fromMachineInfoList(list));
     }
     
-    @GetMapping(value = "/{app}/machine/remove.json")
+    @RequestMapping(value = "/{app}/machine/remove.json")
     public Result<String> removeMachineById(
             @PathVariable("app") String app,
             @RequestParam(name = "ip") String ip,


### PR DESCRIPTION
### Describe what this PR does / why we need it

The api `{app}/machine/remove.json` is called through GET in old version but it changed to POST now and definition of the mapping was not changed together.
