### PR TITLE
Automatically de-duplicate rules when loading rules

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/authority/AuthoritySlot.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/authority/AuthoritySlot.java
@@ -15,8 +15,8 @@
  */
 package com.alibaba.csp.sentinel.slots.block.authority;
 
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.alibaba.csp.sentinel.context.Context;
 import com.alibaba.csp.sentinel.node.DefaultNode;
@@ -45,13 +45,13 @@ public class AuthoritySlot extends AbstractLinkedProcessorSlot<DefaultNode> {
     }
 
     void checkBlackWhiteAuthority(ResourceWrapper resource, Context context) throws AuthorityException {
-        Map<String, List<AuthorityRule>> authorityRules = AuthorityRuleManager.getAuthorityRules();
+        Map<String, Set<AuthorityRule>> authorityRules = AuthorityRuleManager.getAuthorityRules();
 
         if (authorityRules == null) {
             return;
         }
 
-        List<AuthorityRule> rules = authorityRules.get(resource.getName());
+        Set<AuthorityRule> rules = authorityRules.get(resource.getName());
         if (rules == null) {
             return;
         }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeRuleManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeRuleManager.java
@@ -60,6 +60,7 @@ public final class DegradeRuleManager {
      * @param property the property to listen.
      */
     public static void register2Property(SentinelProperty<List<DegradeRule>> property) {
+        AssertUtil.notNull(property, "property cannot be null");
         synchronized (LISTENER) {
             RecordLog.info("[DegradeRuleManager] Registering new property to degrade rule manager");
             currentProperty.removeListener(LISTENER);

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeRuleManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeRuleManager.java
@@ -16,10 +16,14 @@
 package com.alibaba.csp.sentinel.slots.block.degrade;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.alibaba.csp.sentinel.Constants;
 import com.alibaba.csp.sentinel.context.Context;
 import com.alibaba.csp.sentinel.log.RecordLog;
 import com.alibaba.csp.sentinel.node.DefaultNode;
@@ -29,23 +33,24 @@ import com.alibaba.csp.sentinel.property.SentinelProperty;
 import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
 import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+import com.alibaba.csp.sentinel.util.AssertUtil;
 import com.alibaba.csp.sentinel.util.StringUtil;
 
-/***
+/**
  * @author youji.zj
  * @author jialiang.linjl
+ * @author Eric Zhao
  */
-public class DegradeRuleManager {
+public final class DegradeRuleManager {
 
-    private static volatile Map<String, List<DegradeRule>> degradeRules
-        = new ConcurrentHashMap<String, List<DegradeRule>>();
+    private static final Map<String, Set<DegradeRule>> degradeRules = new ConcurrentHashMap<>();
 
-    final static RulePropertyListener listener = new RulePropertyListener();
+    private static final RulePropertyListener LISTENER = new RulePropertyListener();
     private static SentinelProperty<List<DegradeRule>> currentProperty
-        = new DynamicSentinelProperty<List<DegradeRule>>();
+        = new DynamicSentinelProperty<>();
 
     static {
-        currentProperty.addListener(listener);
+        currentProperty.addListener(LISTENER);
     }
 
     /**
@@ -55,21 +60,18 @@ public class DegradeRuleManager {
      * @param property the property to listen.
      */
     public static void register2Property(SentinelProperty<List<DegradeRule>> property) {
-        synchronized (listener) {
+        synchronized (LISTENER) {
             RecordLog.info("[DegradeRuleManager] Registering new property to degrade rule manager");
-            currentProperty.removeListener(listener);
-            property.addListener(listener);
+            currentProperty.removeListener(LISTENER);
+            property.addListener(LISTENER);
             currentProperty = property;
         }
     }
 
     public static void checkDegrade(ResourceWrapper resource, Context context, DefaultNode node, int count)
         throws BlockException {
-        if (degradeRules == null) {
-            return;
-        }
 
-        List<DegradeRule> rules = degradeRules.get(resource.getName());
+        Set<DegradeRule> rules = degradeRules.get(resource.getName());
         if (rules == null) {
             return;
         }
@@ -82,6 +84,9 @@ public class DegradeRuleManager {
     }
 
     public static boolean hasConfig(String resource) {
+        if (resource == null) {
+            return false;
+        }
         return degradeRules.containsKey(resource);
     }
 
@@ -91,11 +96,8 @@ public class DegradeRuleManager {
      * @return a new copy of the rules.
      */
     public static List<DegradeRule> getRules() {
-        List<DegradeRule> rules = new ArrayList<DegradeRule>();
-        if (degradeRules == null) {
-            return rules;
-        }
-        for (Map.Entry<String, List<DegradeRule>> entry : degradeRules.entrySet()) {
+        List<DegradeRule> rules = new ArrayList<>();
+        for (Map.Entry<String, Set<DegradeRule>> entry : degradeRules.entrySet()) {
             rules.addAll(entry.getValue());
         }
         return rules;
@@ -110,7 +112,42 @@ public class DegradeRuleManager {
         try {
             currentProperty.updateValue(rules);
         } catch (Throwable e) {
-            RecordLog.info(e.getMessage(), e);
+            RecordLog.warn("[DegradeRuleManager] Unexpected error when loading degrade rules", e);
+        }
+    }
+
+    /**
+     * Set degrade rules for provided resource. Former rules of the resource will be replaced.
+     *
+     * @param resourceName valid resource name
+     * @param rules        new rule set to load
+     * @return whether the rules has actually been updated
+     * @since 1.5.0
+     */
+    public static boolean setRulesForResource(String resourceName, Set<DegradeRule> rules) {
+        AssertUtil.notEmpty(resourceName, "resourceName cannot be empty");
+        try {
+            Map<String, Set<DegradeRule>> newRuleMap = new HashMap<>(degradeRules);
+            if (rules == null) {
+                newRuleMap.remove(resourceName);
+            } else {
+                Set<DegradeRule> newSet = new HashSet<>();
+                for (DegradeRule rule : rules) {
+                    if (isValidRule(rule) && resourceName.equals(rule.getResource())) {
+                        newSet.add(rule);
+                    }
+                }
+                newRuleMap.put(resourceName, newSet);
+            }
+            List<DegradeRule> allRules = new ArrayList<>();
+            for (Set<DegradeRule> set : newRuleMap.values()) {
+                allRules.addAll(set);
+            }
+            return currentProperty.updateValue(allRules);
+        } catch (Throwable e) {
+            RecordLog.warn(
+                "[DegradeRuleManager] Unexpected error when setting degrade rules for resource: " + resourceName, e);
+            return false;
         }
     }
 
@@ -118,7 +155,7 @@ public class DegradeRuleManager {
 
         @Override
         public void configUpdate(List<DegradeRule> conf) {
-            Map<String, List<DegradeRule>> rules = loadDegradeConf(conf);
+            Map<String, Set<DegradeRule>> rules = loadDegradeConf(conf);
             if (rules != null) {
                 degradeRules.clear();
                 degradeRules.putAll(rules);
@@ -128,7 +165,7 @@ public class DegradeRuleManager {
 
         @Override
         public void configLoad(List<DegradeRule> conf) {
-            Map<String, List<DegradeRule>> rules = loadDegradeConf(conf);
+            Map<String, Set<DegradeRule>> rules = loadDegradeConf(conf);
             if (rules != null) {
                 degradeRules.clear();
                 degradeRules.putAll(rules);
@@ -136,8 +173,8 @@ public class DegradeRuleManager {
             RecordLog.info("[DegradeRuleManager] Degrade rules loaded: " + degradeRules);
         }
 
-        private Map<String, List<DegradeRule>> loadDegradeConf(List<DegradeRule> list) {
-            Map<String, List<DegradeRule>> newRuleMap = new ConcurrentHashMap<String, List<DegradeRule>>();
+        private Map<String, Set<DegradeRule>> loadDegradeConf(List<DegradeRule> list) {
+            Map<String, Set<DegradeRule>> newRuleMap = new ConcurrentHashMap<>();
 
             if (list == null || list.isEmpty()) {
                 return newRuleMap;
@@ -145,7 +182,8 @@ public class DegradeRuleManager {
 
             for (DegradeRule rule : list) {
                 if (!isValidRule(rule)) {
-                    RecordLog.warn("[DegradeRuleManager] Ignoring invalid degrade rule when loading new rules: " + rule);
+                    RecordLog.warn(
+                        "[DegradeRuleManager] Ignoring invalid degrade rule when loading new rules: " + rule);
                     continue;
                 }
 
@@ -154,17 +192,16 @@ public class DegradeRuleManager {
                 }
 
                 String identity = rule.getResource();
-                List<DegradeRule> ruleM = newRuleMap.get(identity);
-                if (ruleM == null) {
-                    ruleM = new ArrayList<DegradeRule>();
-                    newRuleMap.put(identity, ruleM);
+                Set<DegradeRule> ruleSet = newRuleMap.get(identity);
+                if (ruleSet == null) {
+                    ruleSet = new HashSet<>();
+                    newRuleMap.put(identity, ruleSet);
                 }
-                ruleM.add(rule);
+                ruleSet.add(rule);
             }
 
             return newRuleMap;
         }
-
     }
 
     public static boolean isValidRule(DegradeRule rule) {
@@ -172,6 +209,13 @@ public class DegradeRuleManager {
             && rule.getCount() >= 0 && rule.getTimeWindow() > 0;
         if (!baseValid) {
             return false;
+        }
+        // Warn for RT mode that exceeds the {@code TIME_DROP_VALVE}.
+        int maxAllowedRt = Constants.TIME_DROP_VALVE;
+        if (rule.getGrade() == RuleConstant.DEGRADE_GRADE_RT && rule.getCount() > maxAllowedRt) {
+            RecordLog.warn(String.format("[DegradeRuleManager] WARN: setting large RT threshold (%.1f ms) in RT mode"
+                    + " will not take effect since it exceeds the max allowed value (%d ms)", rule.getCount(),
+                maxAllowedRt));
         }
         // Check exception ratio mode.
         if (rule.getGrade() == RuleConstant.DEGRADE_GRADE_EXCEPTION_RATIO && rule.getCount() > 1) {

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManager.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 
 import com.alibaba.csp.sentinel.concurrent.NamedThreadFactory;
 import com.alibaba.csp.sentinel.log.RecordLog;
+import com.alibaba.csp.sentinel.util.AssertUtil;
 import com.alibaba.csp.sentinel.util.StringUtil;
 import com.alibaba.csp.sentinel.node.metric.MetricTimerListener;
 import com.alibaba.csp.sentinel.property.DynamicSentinelProperty;
@@ -65,6 +66,7 @@ public class FlowRuleManager {
      * @param property the property to listen.
      */
     public static void register2Property(SentinelProperty<List<FlowRule>> property) {
+        AssertUtil.notNull(property, "property cannot be null");
         synchronized (LISTENER) {
             RecordLog.info("[FlowRuleManager] Registering new property to flow rule manager");
             currentProperty.removeListener(LISTENER);


### PR DESCRIPTION
### Describe what this PR does / why we need it

Automatically de-duplicate rules when loading rules. When there are duplicate `FlowRule` or `DegradeRule`, it might not work as expected.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

NONE

### Describe how you did it

This PR does not contain breaking changes for public methods or interfaces.

- De-duplicate rules when resolving from new rule list. For compatibility, we did not modify the original `loadRules` and `register2Property` method. We only de-duplicate the rules internally.
- Add `setRulesForResource` to support replace rules for a specific resource, while others remain unchanged.
- Log enhancement

### Describe how to verify it

Run the test cases.

### Special notes for reviews

NONE
