### PR TITLE
Update Dubbo version to 2.6.x in sentinel-dubbo-adapter and demo

### DIFF
--- a/sentinel-adapter/sentinel-dubbo-adapter/pom.xml
+++ b/sentinel-adapter/sentinel-dubbo-adapter/pom.xml
@@ -13,7 +13,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <dubbo.version>2.5.8</dubbo.version>
+        <dubbo.version>2.6.6</dubbo.version>
     </properties>
 
     <dependencies>

--- a/sentinel-demo/sentinel-demo-dubbo/pom.xml
+++ b/sentinel-demo/sentinel-demo-dubbo/pom.xml
@@ -12,15 +12,15 @@
     <artifactId>sentinel-demo-dubbo</artifactId>
 
     <dependencies>
-        <!-- Demo use dubbo 2.6.5, since it supports jdk1.6 -->
+        <!-- Demo use Dubbo 2.6.x, since it supports JDK 1.7 -->
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>dubbo</artifactId>
-            <version>2.6.5</version>
+            <version>2.6.6</version>
         </dependency>
 
-        <!-- As dubbo provide qos plugin since 2.5.8 and is enable by default -->
-        <!-- The dubbo-qos module is optional and it depends netty4, so add it explicitly -->
+        <!-- Dubbo provides qos plugin since 2.5.8 and is enable by default. -->
+        <!-- The dubbo-qos module is optional and it depends Netty 4.x, so add it explicitly -->
         <!-- @see http://dubbo.apache.org/zh-cn/docs/user/references/qos.html -->
         <dependency>
             <groupId>io.netty</groupId>
@@ -37,7 +37,7 @@
             <version>1.0.2</version>
         </dependency>
 
-        <!-- sentinel adapter and transport -->
+        <!-- Sentinel adapter and transport -->
         <dependency>
             <groupId>com.alibaba.csp</groupId>
             <artifactId>sentinel-dubbo-adapter</artifactId>


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Update Dubbo version to 2.6.x in `sentinel-dubbo-adapter` and demo, since Dubbo 2.5.x will be end-of-life soon.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

NONE

### Describe how you did it

Simply update the Dubbo version to 2.6.6.

### Describe how to verify it

Run the demo.

### Special notes for reviews

Plz also test for using Dubbo 2.5.x with the adapter.