### PR TITLE
Support passing acquireCount and parameters to entry via SentinelReactorSubscriber

### DIFF
--- a/sentinel-adapter/sentinel-reactor-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/reactor/EntryConfig.java
+++ b/sentinel-adapter/sentinel-reactor-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/reactor/EntryConfig.java
@@ -15,6 +15,8 @@
  */
 package com.alibaba.csp.sentinel.adapter.reactor;
 
+import java.util.Arrays;
+
 import com.alibaba.csp.sentinel.EntryType;
 import com.alibaba.csp.sentinel.util.AssertUtil;
 
@@ -26,6 +28,8 @@ public class EntryConfig {
 
     private final String resourceName;
     private final EntryType entryType;
+    private final int acquireCount;
+    private final Object[] args;
     private final ContextConfig contextConfig;
 
     public EntryConfig(String resourceName) {
@@ -37,9 +41,18 @@ public class EntryConfig {
     }
 
     public EntryConfig(String resourceName, EntryType entryType, ContextConfig contextConfig) {
-        checkParams(resourceName, entryType);
+        this(resourceName, entryType, 1, new Object[0], contextConfig);
+    }
+
+    public EntryConfig(String resourceName, EntryType entryType, int acquireCount, Object[] args,
+                       ContextConfig contextConfig) {
+        AssertUtil.assertNotBlank(resourceName, "resourceName cannot be blank");
+        AssertUtil.notNull(entryType, "entryType cannot be null");
+        AssertUtil.isTrue(acquireCount > 0, "acquireCount should be positive");
         this.resourceName = resourceName;
         this.entryType = entryType;
+        this.acquireCount = acquireCount;
+        this.args = args;
         // Constructed ContextConfig should be valid here. Null is allowed here.
         this.contextConfig = contextConfig;
     }
@@ -52,18 +65,16 @@ public class EntryConfig {
         return entryType;
     }
 
+    public int getAcquireCount() {
+        return acquireCount;
+    }
+
+    public Object[] getArgs() {
+        return args;
+    }
+
     public ContextConfig getContextConfig() {
         return contextConfig;
-    }
-
-    public static void assertValid(EntryConfig config) {
-        AssertUtil.notNull(config, "entry config cannot be null");
-        checkParams(config.resourceName, config.entryType);
-    }
-
-    private static void checkParams(String resourceName, EntryType entryType) {
-        AssertUtil.assertNotBlank(resourceName, "resourceName cannot be blank");
-        AssertUtil.notNull(entryType, "entryType cannot be null");
     }
 
     @Override
@@ -71,6 +82,8 @@ public class EntryConfig {
         return "EntryConfig{" +
             "resourceName='" + resourceName + '\'' +
             ", entryType=" + entryType +
+            ", acquireCount=" + acquireCount +
+            ", args=" + Arrays.toString(args) +
             ", contextConfig=" + contextConfig +
             '}';
     }

--- a/sentinel-adapter/sentinel-reactor-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/reactor/FluxSentinelOperator.java
+++ b/sentinel-adapter/sentinel-reactor-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/reactor/FluxSentinelOperator.java
@@ -15,6 +15,8 @@
  */
 package com.alibaba.csp.sentinel.adapter.reactor;
 
+import com.alibaba.csp.sentinel.util.AssertUtil;
+
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxOperator;
@@ -29,7 +31,7 @@ public class FluxSentinelOperator<T> extends FluxOperator<T, T> {
 
     public FluxSentinelOperator(Flux<? extends T> source, EntryConfig entryConfig) {
         super(source);
-        EntryConfig.assertValid(entryConfig);
+        AssertUtil.notNull(entryConfig, "entryConfig cannot be null");
         this.entryConfig = entryConfig;
     }
 

--- a/sentinel-adapter/sentinel-reactor-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/reactor/MonoSentinelOperator.java
+++ b/sentinel-adapter/sentinel-reactor-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/reactor/MonoSentinelOperator.java
@@ -15,6 +15,8 @@
  */
 package com.alibaba.csp.sentinel.adapter.reactor;
 
+import com.alibaba.csp.sentinel.util.AssertUtil;
+
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoOperator;
@@ -29,7 +31,7 @@ public class MonoSentinelOperator<T> extends MonoOperator<T, T> {
 
     public MonoSentinelOperator(Mono<? extends T> source, EntryConfig entryConfig) {
         super(source);
-        EntryConfig.assertValid(entryConfig);
+        AssertUtil.notNull(entryConfig, "entryConfig cannot be null");
         this.entryConfig = entryConfig;
     }
 

--- a/sentinel-adapter/sentinel-reactor-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/reactor/SentinelReactorSubscriber.java
+++ b/sentinel-adapter/sentinel-reactor-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/reactor/SentinelReactorSubscriber.java
@@ -88,7 +88,7 @@ public class SentinelReactorSubscriber<T> extends InheritableBaseSubscriber<T> {
             ContextUtil.enter(sentinelContextConfig.getContextName(), sentinelContextConfig.getOrigin());
         }
         try {
-            AsyncEntry entry = SphU.asyncEntry(entryConfig.getResourceName());
+            AsyncEntry entry = SphU.asyncEntry(entryConfig.getResourceName(), entryConfig.getEntryType());
             this.currentEntry = entry;
             actual.onSubscribe(this);
         } catch (BlockException ex) {

--- a/sentinel-adapter/sentinel-reactor-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/reactor/SentinelReactorSubscriber.java
+++ b/sentinel-adapter/sentinel-reactor-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/reactor/SentinelReactorSubscriber.java
@@ -23,6 +23,7 @@ import com.alibaba.csp.sentinel.SphU;
 import com.alibaba.csp.sentinel.Tracer;
 import com.alibaba.csp.sentinel.context.ContextUtil;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
+import com.alibaba.csp.sentinel.util.AssertUtil;
 import com.alibaba.csp.sentinel.util.function.Supplier;
 
 import org.reactivestreams.Subscription;
@@ -53,7 +54,7 @@ public class SentinelReactorSubscriber<T> extends InheritableBaseSubscriber<T> {
     }
 
     private void checkEntryConfig(EntryConfig config) {
-        EntryConfig.assertValid(config);
+        AssertUtil.notNull(config, "entryConfig cannot be null");
     }
 
     @Override
@@ -88,7 +89,8 @@ public class SentinelReactorSubscriber<T> extends InheritableBaseSubscriber<T> {
             ContextUtil.enter(sentinelContextConfig.getContextName(), sentinelContextConfig.getOrigin());
         }
         try {
-            AsyncEntry entry = SphU.asyncEntry(entryConfig.getResourceName(), entryConfig.getEntryType());
+            AsyncEntry entry = SphU.asyncEntry(entryConfig.getResourceName(), entryConfig.getEntryType(),
+                entryConfig.getAcquireCount(), entryConfig.getArgs());
             this.currentEntry = entry;
             actual.onSubscribe(this);
         } catch (BlockException ex) {

--- a/sentinel-adapter/sentinel-reactor-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/reactor/SentinelReactorTransformer.java
+++ b/sentinel-adapter/sentinel-reactor-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/reactor/SentinelReactorTransformer.java
@@ -17,6 +17,8 @@ package com.alibaba.csp.sentinel.adapter.reactor;
 
 import java.util.function.Function;
 
+import com.alibaba.csp.sentinel.util.AssertUtil;
+
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -36,7 +38,7 @@ public class SentinelReactorTransformer<T> implements Function<Publisher<T>, Pub
     }
 
     public SentinelReactorTransformer(EntryConfig entryConfig) {
-        EntryConfig.assertValid(entryConfig);
+        AssertUtil.notNull(entryConfig, "entryConfig cannot be null");
         this.entryConfig = entryConfig;
     }
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

Support passing acquireCount and parameters to entry via SentinelReactorSubscriber.

Also fixed the bug that entry type did not take effect in `SentinelReactorSubscriber`.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Fixes #629

### Describe how you did it

Modify `SentinelReactorSubscriber#entryWhenSubscribed` to carry the provided entry type, acquireCount and parameters.

### Describe how to verify it

Run the WebFlux demo. Virtual inbound traffic node should appear in the metrics log.

### Special notes for reviews

NONE
