### PR TITLE
Fix the NPE bug when passing null args and paramIdx is negative

### DIFF
--- a/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowSlotTest.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowSlotTest.java
@@ -50,6 +50,12 @@ public class ParamFlowSlotTest {
         paramFlowSlot.entry(null, resourceWrapper, null, 1, false, "abc", "def", "ghi");
         assertEquals(2, rule.getParamIdx().longValue());
 
+        rule.setParamIdx(-1);
+        ParamFlowRuleManager.loadRules(Collections.singletonList(rule));
+        paramFlowSlot.entry(null, resourceWrapper, null, 1, false, null);
+        // Null args will not trigger conversion.
+        assertEquals(-1, rule.getParamIdx().intValue());
+
         rule.setParamIdx(-100);
         ParamFlowRuleManager.loadRules(Collections.singletonList(rule));
         paramFlowSlot.entry(null, resourceWrapper, null, 1, false, "abc", "def", "ghi");


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Fix the NPE bug when passing null args to `SphU.entry(xxx, args)` and `paramIdx` of parameter flow rule is negative (< 0).

### Does this pull request fix one issue?

Fixes #643

### Describe how you did it

Check null args in `checkParams`. Also rearrange some code in `ParamFlowSlot`.

### Describe how to verify it

Run the test cases.

### Special notes for reviews

NONE