### PR TITLE
fix Support circuit breaking according to statistics of other resources #605

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/RuleConstant.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/RuleConstant.java
@@ -50,6 +50,7 @@ public final class RuleConstant {
 
     public static final String LIMIT_APP_DEFAULT = "default";
     public static final String LIMIT_APP_OTHER = "other";
+    public static final String LIMIT_APP_ORIGIN = "origin";
 
     public static final int DEFAULT_SAMPLE_COUNT = 2;
     public static final int DEFAULT_WINDOW_INTERVAL_MS = 1000;

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeRule.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeRule.java
@@ -15,18 +15,20 @@
  */
 package com.alibaba.csp.sentinel.slots.block.degrade;
 
+
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.alibaba.csp.sentinel.concurrent.NamedThreadFactory;
 import com.alibaba.csp.sentinel.context.Context;
-import com.alibaba.csp.sentinel.node.ClusterNode;
 import com.alibaba.csp.sentinel.node.DefaultNode;
+import com.alibaba.csp.sentinel.node.Node;
 import com.alibaba.csp.sentinel.slots.block.AbstractRule;
 import com.alibaba.csp.sentinel.slots.block.RuleConstant;
-import com.alibaba.csp.sentinel.slots.clusterbuilder.ClusterBuilderSlot;
+
 
 /**
  * <p>
@@ -165,8 +167,8 @@ public class DegradeRule extends AbstractRule {
         if (cut) {
             return false;
         }
+        Node clusterNode = DegradeRuleChecker.selectNodeByLimitApp(this, context, node);
 
-        ClusterNode clusterNode = ClusterBuilderSlot.getClusterNode(this.getResource());
         if (clusterNode == null) {
             return true;
         }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeRuleChecker.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeRuleChecker.java
@@ -1,0 +1,28 @@
+package com.alibaba.csp.sentinel.slots.block.degrade;
+
+import com.alibaba.csp.sentinel.context.Context;
+import com.alibaba.csp.sentinel.node.DefaultNode;
+import com.alibaba.csp.sentinel.node.Node;
+import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+import com.alibaba.csp.sentinel.slots.clusterbuilder.ClusterBuilderSlot;
+import com.alibaba.csp.sentinel.util.StringUtil;
+
+public class DegradeRuleChecker {
+
+    /**
+     * @param rule         DegradeRule
+     * @param context      context
+     * @param entranceNode entranceNode
+     * @return select Node by limitApp. chain for entranceNode.other for clusterNode
+     */
+    public static Node selectNodeByLimitApp(/*@NonNull*/ DegradeRule rule, Context context, DefaultNode entranceNode) {
+        String limitApp = rule.getLimitApp();
+        if (StringUtil.isNotBlank(limitApp) && RuleConstant.LIMIT_APP_ORIGIN.equals(limitApp)) {
+            if (null != context.getOriginNode()) {
+                return context.getOriginNode();
+            }
+        }
+        return ClusterBuilderSlot.getClusterNode(rule.getResource());
+    }
+
+}

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeRuleTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeRuleTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.slots.block.degrade;
+
+import com.alibaba.csp.sentinel.context.Context;
+import com.alibaba.csp.sentinel.node.DefaultNode;
+import com.alibaba.csp.sentinel.node.Node;
+import com.alibaba.csp.sentinel.node.StatisticNode;
+import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author liufuguang.lao
+ */
+public class DegradeRuleTest {
+
+    @Test
+    public void testAverageRtDegradeByApp() throws InterruptedException {
+        String key = "test_degrade_average_rt";
+
+        Context context = mock(Context.class);
+        DefaultNode node = mock(DefaultNode.class);
+
+        StatisticNode originNode = new StatisticNode();
+        when(context.getOriginNode()).thenReturn(originNode);
+
+        DegradeRule rule = new DegradeRule();
+        rule.setCount(1);
+        rule.setResource(key);
+        rule.setTimeWindow(5);
+        rule.setLimitApp("origin");
+
+        for (int i = 0; i < 4; i++) {
+            originNode.addRtAndSuccess(2,1);
+            assertTrue(rule.passCheck(context, node, 1));
+        }
+
+        // The third time will fail.
+        originNode.addRtAndSuccess(2,1);
+        assertFalse(rule.passCheck(context, node, 1));
+        originNode.addRtAndSuccess(2,1);
+        assertFalse(rule.passCheck(context, node, 1));
+
+        // Restore.
+        TimeUnit.SECONDS.sleep(6);
+        assertTrue(rule.passCheck(context, node, 1));
+    }
+
+    @Test
+    public void testExceptionRatioModeDegradeByApp() throws Throwable {
+        String key = "test_degrade_exception_ratio";
+
+        Context context = mock(Context.class);
+        DefaultNode entranceNode = mock(DefaultNode.class);
+
+        StatisticNode originNode = new StatisticNode();
+        when(context.getOriginNode()).thenReturn(originNode);
+
+
+        // Indicates that there are QPS more than min threshold.
+        originNode.addRtAndSuccess(1,10);
+
+
+        DegradeRule rule = new DegradeRule();
+        rule.setCount(0.15);
+        rule.setResource(key);
+        rule.setTimeWindow(5);
+        rule.setGrade(RuleConstant.DEGRADE_GRADE_EXCEPTION_RATIO);
+        rule.setLimitApp("origin");
+
+        originNode.increaseExceptionQps(2);
+        originNode.addPassRequest(10);
+        // Will fail.
+        assertFalse(rule.passCheck(context, entranceNode, 1));
+
+        // Restore from the degrade timeout.
+        TimeUnit.SECONDS.sleep(6);
+
+        originNode.addRtAndSuccess(1,20);
+        // Will pass.
+        assertTrue(rule.passCheck(context, entranceNode, 1));
+    }
+
+    @Test
+    public void testExceptionCountModeDegradeByApp() throws Throwable {
+        String key = "test_degrade_exception_count";
+        Context context = mock(Context.class);
+        DefaultNode entranceNode = mock(DefaultNode.class);
+
+        StatisticNode originNode = new StatisticNode();
+        when(context.getOriginNode()).thenReturn(originNode);
+
+        DegradeRule rule = new DegradeRule();
+        rule.setCount(4);
+        rule.setResource(key);
+        rule.setTimeWindow(2);
+        rule.setGrade(RuleConstant.DEGRADE_GRADE_EXCEPTION_COUNT);
+        rule.setLimitApp("origin");
+
+        originNode.increaseExceptionQps(4);
+
+        // Will fail.
+        assertFalse(rule.passCheck(context, entranceNode, 1));
+
+        // Restore from the degrade timeout.
+        TimeUnit.SECONDS.sleep(3);
+
+        rule.setCount(5);
+        // Will pass.
+        assertTrue(rule.passCheck(context, entranceNode, 1));
+    }
+
+}

--- a/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/degrade/ExceptionRatioDegradeDemo.java
+++ b/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/degrade/ExceptionRatioDegradeDemo.java
@@ -15,11 +15,6 @@
  */
 package com.alibaba.csp.sentinel.demo.degrade;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import com.alibaba.csp.sentinel.Entry;
 import com.alibaba.csp.sentinel.SphU;
 import com.alibaba.csp.sentinel.Tracer;
@@ -28,6 +23,11 @@ import com.alibaba.csp.sentinel.slots.block.RuleConstant;
 import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRule;
 import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRuleManager;
 import com.alibaba.csp.sentinel.util.TimeUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * <p>
@@ -45,6 +45,9 @@ import com.alibaba.csp.sentinel.util.TimeUtil;
  * </li>
  * <li>
  * For average response time, see {@link RtDegradeDemo}.
+ * </li>
+ * <li>
+ * Degraded by app, see {@link RtDegradeByAppDemo}.
  * </li>
  * </ul>
  * </p>

--- a/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/degrade/RtDegradeByAppDemo.java
+++ b/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/degrade/RtDegradeByAppDemo.java
@@ -1,9 +1,23 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.csp.sentinel.demo.degrade;
 
 import com.alibaba.csp.sentinel.Entry;
 import com.alibaba.csp.sentinel.SphU;
-import com.alibaba.csp.sentinel.Tracer;
-import com.alibaba.csp.sentinel.slots.block.BlockException;
+import com.alibaba.csp.sentinel.context.ContextUtil;
 import com.alibaba.csp.sentinel.slots.block.RuleConstant;
 import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRule;
 import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRuleManager;
@@ -17,47 +31,65 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * <p>
  * Degrade is used when the resources are in an unstable state, these resources
- * will be degraded within the next defined time window. There are three ways to
+ * will be degraded within the next defined time window. There are two ways to
  * measure whether a resource is stable or not:
  * <ul>
  * <li>
- * Exception count: When the exception count in the last 60 seconds greats than
- * or equals to the threshold, access to the resource will be blocked in the
- * coming time window.
+ * Average Response Time ('DegradeRule.Grade=RuleContants.DEGRADE_GRADE_RT'): When the
+ * average RT greats than or equals to the threshold ('count' in 'DegradeRule', ms), the
+ * resource enters a quasi-degraded state. If the RT of next coming five requests still
+ * exceed this threshold, this resource will be downgraded, which means that in
+ * the next time window(Defined in 'timeWindow', s units) all the access to this
+ * resource will be blocked.
+ * </li>
+ * <li>
+ * Exception Count, see {@link RtDegradeDemo}.
  * </li>
  * <li>
  * Exception ratio, see {@link ExceptionRatioDegradeDemo}.
  * </li>
  * <li>
- * For average response time, see {@link RtDegradeDemo}.
- * </li>
- * <li>
- * Degraded by app, see {@link RtDegradeByAppDemo}.
+ * Exception Count, see {@link ExceptionCountDegradeDemo}.
  * </li>
  * </ul>
+ * <p>
  * </p>
  * <p>
- * Note: When degrading by {@link RuleConstant#DEGRADE_GRADE_EXCEPTION_COUNT}, time window
- * less than 60 seconds will not work as expected. Because the exception count is
- * summed by minute, when a short time window elapsed, the degradation condition
- * may still be satisfied.
- * </p>
+ * Run this demo, and the out put will be like,:
+ * <p>
+ * <pre>
+ * 1529399827825,total:0, pass:0, block:0
+ * 1529399828825,total:4263, pass:100, block:4164
+ * 1529399829825,total:19179, pass:4, block:19176
+ * 1529399830824,total:19806, pass:0, block:19806  //begin degrade
+ * 1529399831825,total:19198, pass:0, block:19198
+ * 1529399832824,total:19481, pass:0, block:19481
+ * 1529399833826,total:19241, pass:0, block:19241
+ * 1529399834826,total:17276, pass:0, block:17276
+ * 1529399835826,total:18722, pass:0, block:18722
+ * 1529399836826,total:19490, pass:0, block:19492
+ * 1529399837828,total:19355, pass:0, block:19355
+ * 1529399838827,total:11388, pass:0, block:11388
+ * 1529399839829,total:14494, pass:104, block:14390 //After 10 seconds, the system is restored, and degraded very
+ * quickly
+ * 1529399840854,total:18505, pass:0, block:18505
+ * 1529399841854,total:19673, pass:0, block:19676
+ * </pre>
  *
- * @author Carpenter Lee
+ * @author jialiang.linjl
  */
-public class ExceptionCountDegradeDemo {
-    private static final String KEY = "abc";
+public class RtDegradeByAppDemo {
 
-    private static AtomicInteger total = new AtomicInteger();
+    private static final String KEY = "abc";
+    private static final int threadCount = 100;
     private static AtomicInteger pass = new AtomicInteger();
     private static AtomicInteger block = new AtomicInteger();
-    private static AtomicInteger bizException = new AtomicInteger();
-
+    private static AtomicInteger total = new AtomicInteger();
     private static volatile boolean stop = false;
-    private static final int threadCount = 1;
     private static int seconds = 60 + 40;
 
     public static void main(String[] args) throws Exception {
+
         tick();
         initDegradeRule();
 
@@ -66,26 +98,20 @@ public class ExceptionCountDegradeDemo {
 
                 @Override
                 public void run() {
-                    int count = 0;
                     while (true) {
-                        count++;
                         Entry entry = null;
                         try {
-                            Thread.sleep(20);
+                            ContextUtil.enter(KEY);
+                            TimeUnit.MILLISECONDS.sleep(5);
                             entry = SphU.entry(KEY);
-                            // token acquired, means pass
-                            pass.addAndGet(1);
-                            if (count % 2 == 0) {
-                                // biz code raise an exception.
-                                throw new RuntimeException("throw runtime ");
-                            }
-                        } catch (BlockException e) {
-                            block.addAndGet(1);
-                        } catch (Throwable t) {
-                            bizException.incrementAndGet();
-                            Tracer.trace(t);
+                            // token acquired
+                            pass.incrementAndGet();
+                            // sleep 600 ms, as rt
+                            TimeUnit.MILLISECONDS.sleep(600);
+                        } catch (Exception e) {
+                            block.incrementAndGet();
                         } finally {
-                            total.addAndGet(1);
+                            total.incrementAndGet();
                             if (entry != null) {
                                 entry.exit();
                             }
@@ -97,23 +123,17 @@ public class ExceptionCountDegradeDemo {
             entryThread.setName("working-thread");
             entryThread.start();
         }
-
     }
 
     private static void initDegradeRule() {
         List<DegradeRule> rules = new ArrayList<DegradeRule>();
         DegradeRule rule = new DegradeRule();
         rule.setResource(KEY);
-        // set limit exception count to 4
-        rule.setCount(4);
-        rule.setGrade(RuleConstant.DEGRADE_GRADE_EXCEPTION_COUNT);
-        /**
-         * When degrading by {@link RuleConstant#DEGRADE_GRADE_EXCEPTION_COUNT}, time window
-         * less than 60 seconds will not work as expected. Because the exception count is
-         * summed by minute, when a short time window elapsed, the degradation condition
-         * may still be satisfied.
-         */
+        // set threshold rt, 10 ms
+        rule.setCount(10);
+        rule.setGrade(RuleConstant.DEGRADE_GRADE_RT);
         rule.setTimeWindow(10);
+        rule.setLimitApp("origin");
         rules.add(rule);
         DegradeRuleManager.loadRules(rules);
     }
@@ -125,6 +145,7 @@ public class ExceptionCountDegradeDemo {
     }
 
     static class TimerTask implements Runnable {
+
         @Override
         public void run() {
             long start = System.currentTimeMillis();
@@ -132,12 +153,13 @@ public class ExceptionCountDegradeDemo {
             long oldTotal = 0;
             long oldPass = 0;
             long oldBlock = 0;
-            long oldBizException = 0;
+
             while (!stop) {
                 try {
                     TimeUnit.SECONDS.sleep(1);
                 } catch (InterruptedException e) {
                 }
+
                 long globalTotal = total.get();
                 long oneSecondTotal = globalTotal - oldTotal;
                 oldTotal = globalTotal;
@@ -150,23 +172,20 @@ public class ExceptionCountDegradeDemo {
                 long oneSecondBlock = globalBlock - oldBlock;
                 oldBlock = globalBlock;
 
-                long globalBizException = bizException.get();
-                long oneSecondBizException = globalBizException - oldBizException;
-                oldBizException = globalBizException;
+                System.out.println(TimeUtil.currentTimeMillis() + ", total:" + oneSecondTotal
+                        + ", pass:" + oneSecondPass + ", block:" + oneSecondBlock);
 
-                System.out.println(TimeUtil.currentTimeMillis() + ", oneSecondTotal:" + oneSecondTotal
-                    + ", oneSecondPass:" + oneSecondPass
-                    + ", oneSecondBlock:" + oneSecondBlock
-                    + ", oneSecondBizException:" + oneSecondBizException);
                 if (seconds-- <= 0) {
                     stop = true;
                 }
             }
+
             long cost = System.currentTimeMillis() - start;
             System.out.println("time cost: " + cost + " ms");
             System.out.println("total:" + total.get() + ", pass:" + pass.get()
-                + ", block:" + block.get() + ", bizException:" + bizException.get());
+                    + ", block:" + block.get());
             System.exit(0);
         }
     }
+
 }

--- a/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/degrade/RtDegradeDemo.java
+++ b/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/degrade/RtDegradeDemo.java
@@ -15,17 +15,17 @@
  */
 package com.alibaba.csp.sentinel.demo.degrade;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import com.alibaba.csp.sentinel.util.TimeUtil;
 import com.alibaba.csp.sentinel.Entry;
 import com.alibaba.csp.sentinel.SphU;
 import com.alibaba.csp.sentinel.slots.block.RuleConstant;
 import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRule;
 import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRuleManager;
+import com.alibaba.csp.sentinel.util.TimeUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * <p>
@@ -46,6 +46,9 @@ import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRuleManager;
  * </li>
  * <li>
  * Exception Count, see {@link ExceptionCountDegradeDemo}.
+ * </li>
+ * <li>
+ * Degraded by app, see {@link RtDegradeByAppDemo}.
  * </li>
  * </ul>
  *


### PR DESCRIPTION
fix #605 Support circuit breaking according to statistics of other resources #605

降级熔断的规则增加统计策略，支持按照originNode统计

Does this pull request fix one issue?

Support circuit breaking according to statistics of other resources #605

Describe how you did it
1.增加常量"origin”
2.当rule的limitApp为"origin", 则按照`ContextUtil.entry(resourceName,origin)`的`originNode`统计值进行熔断检查

Describe how to verify it

1.增加测试用例
2.增加执行demo

Special notes for reviews
 
