### PR TITLE
Feature: Make transport-netty-http/transport-simple-http support posting

### DIFF
--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/node/ClusterNodeTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/node/ClusterNodeTest.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
@@ -81,8 +80,6 @@ public class ClusterNodeTest {
             // Here we need a thread-safe concurrent set (created from ConcurrentHashMap).
             final Set<Node> createdNodes = Collections.newSetFromMap(new ConcurrentHashMap<Node, Boolean>());
 
-            final Random random = new Random();
-
             // 10 threads, 3 origins, 20 tasks (calling 20 times of ClusterNode#getOrCreateOriginNode concurrently)
             final ExecutorService es = Executors.newFixedThreadPool(10);
             final List<String> origins = Arrays.asList("origin1", "origin2", "origin3");
@@ -91,11 +88,12 @@ public class ClusterNodeTest {
 
             List<Callable<Object>> tasks = new ArrayList<Callable<Object>>(taskCount);
             for (int i = 0; i < taskCount; i++) {
+                final int index = i % origins.size();
                 tasks.add(new Callable<Object>() {
                     @Override
                     public Object call() throws Exception {
                         // one task call one times of ClusterNode#getOrCreateOriginNode
-                        Node node = clusterNode.getOrCreateOriginNode(origins.get(random.nextInt(origins.size())));
+                        Node node = clusterNode.getOrCreateOriginNode(origins.get(index));
                         // add the result node to the createdNodes set
                         createdNodes.add(node);
                         latch.countDown();

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/controller/WarmUpRateLimiterControllerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/controller/WarmUpRateLimiterControllerTest.java
@@ -27,10 +27,14 @@ public class WarmUpRateLimiterControllerTest {
 
         assertTrue(controller.canPass(node, 1));
 
+        // Easily fail in single request testing, so we increase it to 10 requests and test the average time
         long start = System.currentTimeMillis();
-        assertTrue(controller.canPass(node, 1));
-        long cost = System.currentTimeMillis() - start;
-        assertTrue(cost >= 100 && cost <= 120);
+        int requests = 10;
+        for (int i = 0; i < requests; i++) {
+            assertTrue(controller.canPass(node, 1));
+        }
+        float cost = (System.currentTimeMillis() - start) / 1.0f / requests;
+        assertTrue(Math.abs(cost - 100) < 10);
     }
 
     @Test

--- a/sentinel-transport/sentinel-transport-netty-http/src/main/java/com/alibaba/csp/sentinel/transport/command/netty/HttpServerHandler.java
+++ b/sentinel-transport/sentinel-transport-netty-http/src/main/java/com/alibaba/csp/sentinel/transport/command/netty/HttpServerHandler.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.csp.sentinel.transport.command.netty;
 
+import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
@@ -39,10 +40,15 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.QueryStringDecoder;
+import io.netty.handler.codec.http.multipart.HttpData;
+import io.netty.handler.codec.http.multipart.HttpPostRequestDecoder;
+import io.netty.handler.codec.http.multipart.InterfaceHttpData;
+import io.netty.handler.codec.http.multipart.InterfaceHttpData.HttpDataType;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
@@ -168,6 +174,32 @@ public class HttpServerHandler extends SimpleChannelInboundHandler<Object> {
             for (Entry<String, List<String>> p : paramMap.entrySet()) {
                 if (!p.getValue().isEmpty()) {
                     serverRequest.addParam(p.getKey(), p.getValue().get(0));
+                }
+            }
+        }
+        // Deal with post method, parameter in post has more privilege compared to that in querystring
+        if (request.method().equals(HttpMethod.POST)) {
+            // support multi-part and form-urlencoded
+            HttpPostRequestDecoder postRequestDecoder = null;
+            try {
+                postRequestDecoder = new HttpPostRequestDecoder(request);
+                for (InterfaceHttpData data : postRequestDecoder.getBodyHttpDatas()) {
+                    data.retain(); // must retain each attr before destroy
+                    if (data.getHttpDataType() == HttpDataType.Attribute) {
+                        if (data instanceof HttpData) {
+                            HttpData httpData = (HttpData) data;
+                            try {
+                                String name = httpData.getName();
+                                String value = httpData.getString();
+                                serverRequest.addParam(name, value);
+                            } catch (IOException e) {
+                            }
+                        }
+                    }
+                }
+            } finally {
+                if (postRequestDecoder != null) {
+                    postRequestDecoder.destroy();
                 }
             }
         }


### PR DESCRIPTION
Make transport layer support parameters in post body

### Describe what this PR does / why we need it
include `netty-http` and `simple-http`

### Does this pull request fix one issue?
#618 
