### PR TITLE
Add SPI precedence support and apply for transport SPI

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/spi/SpiOrder.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/spi/SpiOrder.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.spi;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Eric Zhao
+ * @since 1.6.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+@Documented
+public @interface SpiOrder {
+
+    /**
+     * Represents the lowest precedence.
+     */
+    int LOWEST_PRECEDENCE = Integer.MAX_VALUE;
+    /**
+     * Represents the highest precedence.
+     */
+    int HIGHEST_PRECEDENCE = Integer.MIN_VALUE;
+
+    /**
+     * The SPI precedence value. Lowest precedence by default.
+     *
+     * @return the precedence value
+     */
+    int value() default LOWEST_PRECEDENCE;
+}

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/SpiLoader.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/SpiLoader.java
@@ -15,10 +15,15 @@
  */
 package com.alibaba.csp.sentinel.util;
 
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
+
+import com.alibaba.csp.sentinel.log.RecordLog;
+import com.alibaba.csp.sentinel.spi.SpiOrder;
 
 /**
  * @author Eric Zhao
@@ -29,19 +34,137 @@ public final class SpiLoader {
     private static final Map<String, ServiceLoader> SERVICE_LOADER_MAP = new ConcurrentHashMap<String, ServiceLoader>();
 
     public static <T> T loadFirstInstance(Class<T> clazz) {
-        String key = clazz.getName();
-        // Not thread-safe, as it's expected to be resolved in a thread-safe context.
-        ServiceLoader<T> serviceLoader = SERVICE_LOADER_MAP.get(key);
-        if (serviceLoader == null) {
-            serviceLoader = ServiceLoader.load(clazz);
-            SERVICE_LOADER_MAP.put(key, serviceLoader);
+        try {
+            String key = clazz.getName();
+            // Not thread-safe, as it's expected to be resolved in a thread-safe context.
+            ServiceLoader<T> serviceLoader = SERVICE_LOADER_MAP.get(key);
+            if (serviceLoader == null) {
+                serviceLoader = ServiceLoader.load(clazz);
+                SERVICE_LOADER_MAP.put(key, serviceLoader);
+            }
+
+            Iterator<T> iterator = serviceLoader.iterator();
+            if (iterator.hasNext()) {
+                return iterator.next();
+            } else {
+                return null;
+            }
+        } catch (Throwable t) {
+            RecordLog.warn("[SpiLoader] ERROR: loadFirstInstance failed", t);
+            t.printStackTrace();
+            return null;
+        }
+    }
+
+    /**
+     * Load the SPI instance with highest priority.
+     *
+     * @param clazz class of the SPI
+     * @param <T>   SPI type
+     * @return the SPI instance with highest priority if exists, or else false
+     * @since 1.6.0
+     */
+    public static <T> T loadHighestPriorityInstance(Class<T> clazz) {
+        try {
+            String key = clazz.getName();
+            // Not thread-safe, as it's expected to be resolved in a thread-safe context.
+            ServiceLoader<T> serviceLoader = SERVICE_LOADER_MAP.get(key);
+            if (serviceLoader == null) {
+                serviceLoader = ServiceLoader.load(clazz);
+                SERVICE_LOADER_MAP.put(key, serviceLoader);
+            }
+
+            SpiOrderWrapper<T> w = null;
+            for (T spi : serviceLoader) {
+                int order = SpiOrderResolver.resolveOrder(spi);
+                RecordLog.info("[SpiLoader] Found {0} SPI: {1} with order " + order, clazz.getSimpleName(),
+                    spi.getClass().getCanonicalName());
+                if (w == null || order < w.order) {
+                    w = new SpiOrderWrapper<>(order, spi);
+                }
+            }
+            return w == null ? null : w.spi;
+        } catch (Throwable t) {
+            RecordLog.warn("[SpiLoader] ERROR: loadHighestPriorityInstance failed", t);
+            t.printStackTrace();
+            return null;
+        }
+    }
+
+    /**
+     * Load and sorted SPI instance list.
+     *
+     * @param clazz class of the SPI
+     * @param <T>   SPI type
+     * @return sorted SPI instance list
+     * @since 1.6.0
+     */
+    public static <T> List<T> loadInstanceListSorted(Class<T> clazz) {
+        try {
+            String key = clazz.getName();
+            // Not thread-safe, as it's expected to be resolved in a thread-safe context.
+            ServiceLoader<T> serviceLoader = SERVICE_LOADER_MAP.get(key);
+            if (serviceLoader == null) {
+                serviceLoader = ServiceLoader.load(clazz);
+                SERVICE_LOADER_MAP.put(key, serviceLoader);
+            }
+
+            List<SpiOrderWrapper<T>> orderWrappers = new ArrayList<>();
+            for (T spi : serviceLoader) {
+                int order = SpiOrderResolver.resolveOrder(spi);
+                // Since SPI is lazy initialized in ServiceLoader, we use online sort algorithm here.
+                SpiOrderResolver.insertSorted(orderWrappers, spi, order);
+                RecordLog.info("[SpiLoader] Found {0} SPI: {1} with order " + order, clazz.getSimpleName(),
+                    spi.getClass().getCanonicalName());
+            }
+            List<T> list = new ArrayList<>();
+            for (int i = 0; i < orderWrappers.size(); i++) {
+                list.add(i, orderWrappers.get(i).spi);
+            }
+            return list;
+        } catch (Throwable t) {
+            RecordLog.warn("[SpiLoader] ERROR: loadInstanceListSorted failed", t);
+            t.printStackTrace();
+            return new ArrayList<>();
+        }
+    }
+
+    private static class SpiOrderResolver {
+        private static <T> void insertSorted(List<SpiOrderWrapper<T>> list, T spi, int order) {
+            int idx = 0;
+            for (; idx < list.size(); idx++) {
+                if (list.get(idx).getOrder() > order) {
+                    break;
+                }
+            }
+            list.add(idx, new SpiOrderWrapper<>(order, spi));
         }
 
-        Iterator<T> iterator = serviceLoader.iterator();
-        if (iterator.hasNext()) {
-            return iterator.next();
-        } else {
-            return null;
+        private static <T> int resolveOrder(T spi) {
+            if (!spi.getClass().isAnnotationPresent(SpiOrder.class)) {
+                // Lowest precedence by default.
+                return SpiOrder.LOWEST_PRECEDENCE;
+            } else {
+                return spi.getClass().getAnnotation(SpiOrder.class).value();
+            }
+        }
+    }
+
+    private static class SpiOrderWrapper<T> {
+        private final int order;
+        private final T spi;
+
+        SpiOrderWrapper(int order, T spi) {
+            this.order = order;
+            this.spi = spi;
+        }
+
+        int getOrder() {
+            return order;
+        }
+
+        T getSpi() {
+            return spi;
         }
     }
 

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/command/CommandCenterProvider.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/command/CommandCenterProvider.java
@@ -25,7 +25,7 @@ import com.alibaba.csp.sentinel.util.SpiLoader;
  * @author cdfive
  * @since 1.5.0
  */
-public class CommandCenterProvider {
+public final class CommandCenterProvider {
 
     private static CommandCenter commandCenter = null;
 
@@ -34,10 +34,10 @@ public class CommandCenterProvider {
     }
 
     private static void resolveInstance() {
-        CommandCenter resolveCommandCenter = SpiLoader.loadFirstInstance(CommandCenter.class);
+        CommandCenter resolveCommandCenter = SpiLoader.loadHighestPriorityInstance(CommandCenter.class);
 
         if (resolveCommandCenter == null) {
-            RecordLog.warn("[CommandCenterProvider] No existing CommandCenter, resolve failed");
+            RecordLog.warn("[CommandCenterProvider] WARN: No existing CommandCenter found");
         } else {
             commandCenter = resolveCommandCenter;
             RecordLog.info("[CommandCenterProvider] CommandCenter resolved: " + resolveCommandCenter.getClass()

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/heartbeat/HeartbeatSenderProvider.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/heartbeat/HeartbeatSenderProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.heartbeat;
+
+import com.alibaba.csp.sentinel.log.RecordLog;
+import com.alibaba.csp.sentinel.transport.HeartbeatSender;
+import com.alibaba.csp.sentinel.util.SpiLoader;
+
+/**
+ * @author Eric Zhao
+ * @since 1.6.0
+ */
+public final class HeartbeatSenderProvider {
+
+    private static HeartbeatSender heartbeatSender = null;
+
+    static {
+        resolveInstance();
+    }
+
+    private static void resolveInstance() {
+        HeartbeatSender resolved = SpiLoader.loadHighestPriorityInstance(HeartbeatSender.class);
+        if (resolved == null) {
+            RecordLog.warn("[HeartbeatSenderProvider] WARN: No existing HeartbeatSender found");
+        } else {
+            heartbeatSender = resolved;
+            RecordLog.info("[HeartbeatSenderProvider] HeartbeatSender activated: " + resolved.getClass()
+                .getCanonicalName());
+        }
+    }
+
+    /**
+     * Get resolved {@link HeartbeatSender} instance.
+     *
+     * @return resolved {@code HeartbeatSender} instance
+     */
+    public static HeartbeatSender getHeartbeatSender() {
+        return heartbeatSender;
+    }
+
+    private HeartbeatSenderProvider() {}
+}

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/init/HeartbeatSenderInitFunc.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/init/HeartbeatSenderInitFunc.java
@@ -15,15 +15,16 @@
  */
 package com.alibaba.csp.sentinel.transport.init;
 
-import java.util.Iterator;
-import java.util.ServiceLoader;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadPoolExecutor.DiscardOldestPolicy;
 import java.util.concurrent.TimeUnit;
 
 import com.alibaba.csp.sentinel.concurrent.NamedThreadFactory;
 import com.alibaba.csp.sentinel.config.SentinelConfig;
+import com.alibaba.csp.sentinel.heartbeat.HeartbeatSenderProvider;
 import com.alibaba.csp.sentinel.init.InitFunc;
+import com.alibaba.csp.sentinel.init.InitOrder;
 import com.alibaba.csp.sentinel.log.RecordLog;
 import com.alibaba.csp.sentinel.transport.HeartbeatSender;
 import com.alibaba.csp.sentinel.transport.config.TransportConfig;
@@ -33,30 +34,35 @@ import com.alibaba.csp.sentinel.transport.config.TransportConfig;
  *
  * @author Eric Zhao
  */
+@InitOrder(-1)
 public class HeartbeatSenderInitFunc implements InitFunc {
 
-    @SuppressWarnings("PMD.ThreadPoolCreationRule")
-    private static ScheduledExecutorService pool = Executors.newScheduledThreadPool(2,
-        new NamedThreadFactory("sentinel-heartbeat-send-task", true));
+    private ScheduledExecutorService pool = null;
 
-    private boolean validHeartbeatInterval(Long interval) {
-        return interval != null && interval > 0;
+    private void initSchedulerIfNeeded() {
+        if (pool == null) {
+            pool = new ScheduledThreadPoolExecutor(2,
+                new NamedThreadFactory("sentinel-heartbeat-send-task", true),
+                new DiscardOldestPolicy());
+        }
     }
 
     @Override
     public void init() {
-        ServiceLoader<HeartbeatSender> loader = ServiceLoader.load(HeartbeatSender.class);
-        Iterator<HeartbeatSender> iterator = loader.iterator();
-        if (iterator.hasNext()) {
-            final HeartbeatSender sender = iterator.next();
-            if (iterator.hasNext()) {
-                throw new IllegalStateException("Only single heartbeat sender can be scheduled");
-            } else {
-                long interval = retrieveInterval(sender);
-                setIntervalIfNotExists(interval);
-                scheduleHeartbeatTask(sender, interval);
-            }
+        HeartbeatSender sender = HeartbeatSenderProvider.getHeartbeatSender();
+        if (sender == null) {
+            RecordLog.warn("[HeartbeatSenderInitFunc] WARN: No HeartbeatSender loaded");
+            return;
         }
+
+        initSchedulerIfNeeded();
+        long interval = retrieveInterval(sender);
+        setIntervalIfNotExists(interval);
+        scheduleHeartbeatTask(sender, interval);
+    }
+
+    private boolean isValidHeartbeatInterval(Long interval) {
+        return interval != null && interval > 0;
     }
 
     private void setIntervalIfNotExists(long interval) {
@@ -65,13 +71,14 @@ public class HeartbeatSenderInitFunc implements InitFunc {
 
     long retrieveInterval(/*@NonNull*/ HeartbeatSender sender) {
         Long intervalInConfig = TransportConfig.getHeartbeatIntervalMs();
-        if (validHeartbeatInterval(intervalInConfig)) {
-            RecordLog.info("[HeartbeatSenderInit] Using heartbeat interval in Sentinel config property: " + intervalInConfig);
+        if (isValidHeartbeatInterval(intervalInConfig)) {
+            RecordLog.info("[HeartbeatSenderInitFunc] Using heartbeat interval "
+                + "in Sentinel config property: " + intervalInConfig);
             return intervalInConfig;
         } else {
             long senderInterval = sender.intervalMs();
-            RecordLog.info("[HeartbeatSenderInit] Heartbeat interval not configured in config property or invalid, "
-                + "using sender default: " + senderInterval);
+            RecordLog.info("[HeartbeatSenderInit] Heartbeat interval not configured in "
+                + "config property or invalid, using sender default: " + senderInterval);
             return senderInterval;
         }
     }

--- a/sentinel-transport/sentinel-transport-netty-http/src/main/java/com/alibaba/csp/sentinel/transport/command/NettyHttpCommandCenter.java
+++ b/sentinel-transport/sentinel-transport-netty-http/src/main/java/com/alibaba/csp/sentinel/transport/command/NettyHttpCommandCenter.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Executors;
 import com.alibaba.csp.sentinel.command.CommandHandler;
 import com.alibaba.csp.sentinel.command.CommandHandlerProvider;
 import com.alibaba.csp.sentinel.concurrent.NamedThreadFactory;
+import com.alibaba.csp.sentinel.spi.SpiOrder;
 import com.alibaba.csp.sentinel.transport.command.netty.HttpServer;
 import com.alibaba.csp.sentinel.log.RecordLog;
 import com.alibaba.csp.sentinel.transport.CommandCenter;
@@ -31,6 +32,7 @@ import com.alibaba.csp.sentinel.transport.CommandCenter;
  *
  * @author Eric Zhao
  */
+@SpiOrder(SpiOrder.LOWEST_PRECEDENCE - 100)
 public class NettyHttpCommandCenter implements CommandCenter {
 
     private final HttpServer server = new HttpServer();

--- a/sentinel-transport/sentinel-transport-netty-http/src/main/java/com/alibaba/csp/sentinel/transport/heartbeat/HttpHeartbeatSender.java
+++ b/sentinel-transport/sentinel-transport-netty-http/src/main/java/com/alibaba/csp/sentinel/transport/heartbeat/HttpHeartbeatSender.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.alibaba.csp.sentinel.Constants;
+import com.alibaba.csp.sentinel.spi.SpiOrder;
 import com.alibaba.csp.sentinel.transport.config.TransportConfig;
 import com.alibaba.csp.sentinel.log.RecordLog;
 import com.alibaba.csp.sentinel.util.AppNameUtil;
@@ -39,6 +40,7 @@ import org.apache.http.impl.client.HttpClients;
  * @author Eric Zhao
  * @author leyou
  */
+@SpiOrder(SpiOrder.LOWEST_PRECEDENCE - 100)
 public class HttpHeartbeatSender implements HeartbeatSender {
 
     private final CloseableHttpClient client;


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Add `@SpiOrder` support and apply precedence support for transport SPI (`CommandCenter`, `HeartbeatSender`).

### Does this pull request fix one issue?

NONE

### Describe how you did it

- Add a `@SpiOrder` annotation to indicate precedence. Also update `SpiLoader` to support get the SPI with the highest precedence.
- Add precedence support for transport SPI (`CommandCenter`, `HeartbeatSender`). Two providers now will choose the instance with the highest precedence.

### Describe how to verify it

Run a demo, put with two different transport modules, then see whether the SPI of higher order is activated.

### Special notes for reviews

NONE
