### PR TITLE
Add appType property field in SentinelConfig

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Constants.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Constants.java
@@ -64,4 +64,6 @@ public final class Constants {
      * The global switch for Sentinel.
      */
     public static volatile boolean ON = true;
+
+    private Constants() {}
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/config/SentinelConfig.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/config/SentinelConfig.java
@@ -27,15 +27,25 @@ import com.alibaba.csp.sentinel.util.AppNameUtil;
 import com.alibaba.csp.sentinel.util.AssertUtil;
 
 /**
- * The universal config of Courier. The config is retrieved from
- * {@code ${user.home}/logs/csp/${appName}.properties} by default.
+ * The universal local config center of Sentinel. The config is retrieved from command line arguments
+ * and {@code ${user.home}/logs/csp/${appName}.properties} file by default.
  *
  * @author leyou
+ * @author Eric Zhao
  */
 public class SentinelConfig {
 
-    private static final Map<String, String> props = new ConcurrentHashMap<String, String>();
+    /**
+     * The default application type.
+     *
+     * @since 1.6.0
+     */
+    public static final int APP_TYPE_COMMON = 0;
 
+    private static final Map<String, String> props = new ConcurrentHashMap<>();
+    private static int appType = APP_TYPE_COMMON;
+
+    public static final String APP_TYPE = "csp.sentinel.app.type";
     public static final String CHARSET = "csp.sentinel.charset";
     public static final String SINGLE_METRIC_FILE_SIZE = "csp.sentinel.metric.file.single.size";
     public static final String TOTAL_METRIC_FILE_COUNT = "csp.sentinel.metric.file.total.count";
@@ -49,8 +59,32 @@ public class SentinelConfig {
     static final int DEFAULT_STATISTIC_MAX_RT = 4900;
 
     static {
-        initialize();
-        loadProps();
+        try {
+            initialize();
+            loadProps();
+
+            resolveAppType();
+            RecordLog.info("[SentinelConfig] Application type resolved: " + appType);
+        } catch (Throwable ex) {
+            RecordLog.warn("[SentinelConfig] Failed to initialize", ex);
+            ex.printStackTrace();
+        }
+    }
+
+    private static void resolveAppType() {
+        try {
+            String type = getConfig(APP_TYPE);
+            if (type == null) {
+                appType = APP_TYPE_COMMON;
+                return;
+            }
+            appType = Integer.parseInt(type);
+            if (appType < 0) {
+                appType = APP_TYPE_COMMON;
+            }
+        } catch (Exception ex) {
+            appType = APP_TYPE_COMMON;
+        }
     }
 
     private static void initialize() {
@@ -135,6 +169,16 @@ public class SentinelConfig {
         return AppNameUtil.getAppName();
     }
 
+    /**
+     * Get application type.
+     *
+     * @return application type, common (0) by default
+     * @since 1.6.0
+     */
+    public static int getAppType() {
+        return appType;
+    }
+
     public static String charset() {
         return props.get(CHARSET);
     }
@@ -162,7 +206,8 @@ public class SentinelConfig {
     public static int coldFactor() {
         try {
             int coldFactor = Integer.parseInt(props.get(COLD_FACTOR));
-            if (coldFactor <= 1) {// check the cold factor larger than 1
+            // check the cold factor larger than 1
+            if (coldFactor <= 1) {
                 coldFactor = DEFAULT_COLD_FACTOR;
                 RecordLog.warn("cold factor=" + coldFactor + ", should be larger than 1, use default value: "
                         + DEFAULT_COLD_FACTOR);

--- a/sentinel-transport/sentinel-transport-netty-http/src/main/java/com/alibaba/csp/sentinel/transport/heartbeat/HttpHeartbeatSender.java
+++ b/sentinel-transport/sentinel-transport-netty-http/src/main/java/com/alibaba/csp/sentinel/transport/heartbeat/HttpHeartbeatSender.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.alibaba.csp.sentinel.Constants;
+import com.alibaba.csp.sentinel.config.SentinelConfig;
 import com.alibaba.csp.sentinel.spi.SpiOrder;
 import com.alibaba.csp.sentinel.transport.config.TransportConfig;
 import com.alibaba.csp.sentinel.log.RecordLog;
@@ -110,6 +111,7 @@ public class HttpHeartbeatSender implements HeartbeatSender {
         uriBuilder.setScheme("http").setHost(consoleHost).setPort(consolePort)
             .setPath("/registry/machine")
             .setParameter("app", AppNameUtil.getAppName())
+            .setParameter("app_type", String.valueOf(SentinelConfig.getAppType()))
             .setParameter("v", Constants.SENTINEL_VERSION)
             .setParameter("version", String.valueOf(System.currentTimeMillis()))
             .setParameter("hostname", HostNameUtil.getHostName())

--- a/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/heartbeat/HeartbeatMessage.java
+++ b/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/heartbeat/HeartbeatMessage.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.alibaba.csp.sentinel.Constants;
+import com.alibaba.csp.sentinel.config.SentinelConfig;
 import com.alibaba.csp.sentinel.transport.config.TransportConfig;
 import com.alibaba.csp.sentinel.util.AppNameUtil;
 import com.alibaba.csp.sentinel.util.HostNameUtil;
@@ -38,6 +39,8 @@ public class HeartbeatMessage {
         message.put("hostname", HostNameUtil.getHostName());
         message.put("ip", TransportConfig.getHeartbeatClientIp());
         message.put("app", AppNameUtil.getAppName());
+        // Put application type (since 1.6.0).
+        message.put("app_type", String.valueOf(SentinelConfig.getAppType()));
         message.put("port", String.valueOf(TransportConfig.getPort()));
     }
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

Add an `appType` property field in `SentinelConfig` which can be retrieved from `csp.sentinel.app.type` argument. It's useful to identify the service type (e.g. API gateway).

### Does this pull request fix one issue?

NONE

### Describe how you did it

Add an `appType` property field in `SentinelConfig`. It will be parsed during initialization of `SentinelConfig`. If the provided value is invalid or empty, it will be set to 0 (common) by default.

### Describe how to verify it

Run the test cases.

### Special notes for reviews

None.