### PR TITLE
Make SentinelConfig.loadProps thread safe

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/config/SentinelConfig.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/config/SentinelConfig.java
@@ -20,6 +20,7 @@ import java.io.FileInputStream;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 import com.alibaba.csp.sentinel.log.LogBase;
 import com.alibaba.csp.sentinel.log.RecordLog;
@@ -123,7 +124,7 @@ public class SentinelConfig {
         }
 
         // JVM parameter override file config.
-        for (Map.Entry<Object, Object> entry : System.getProperties().entrySet()) {
+        for (Map.Entry<Object, Object> entry : new CopyOnWriteArraySet<>(System.getProperties().entrySet())) {
             String configKey = entry.getKey().toString();
             String configValue = entry.getValue().toString();
             String configValueOld = getConfig(configKey);


### PR DESCRIPTION
### Describe what this PR does / why we need it
Make SentinelConfig.loadProps thread safe

### Does this pull request fix one issue?
Related to #705 

### Describe how you did it
Make snapshot of System.properties

### Describe how to verify it
```java
public class DashboardApplication {

    public static void main(String[] args) {
        new Thread() {
            public void run() {
                for (int i = 0; i < 10000; i ++) {
                    System.setProperty("prefix-" + i, "test");
                    try {
                        sleep(1);
                    } catch (InterruptedException e) {
                    }
                }
            }
        }.start();
        triggerSentinelInit();
        SpringApplication.run(DashboardApplication.class, args);
    }

    private static void triggerSentinelInit() {
        new Thread(() -> InitExecutor.doInit()).start();
    }
}
```
