### PR TITLE
Improve the parameter flow module and refactor API gateway adapter common module

### DIFF
--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/pom.xml
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/pom.xml
@@ -37,5 +37,15 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/SentinelGatewayConstants.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/SentinelGatewayConstants.java
@@ -40,6 +40,7 @@ public final class SentinelGatewayConstants {
     public static final String GATEWAY_CONTEXT_ROUTE_PREFIX = "sentinel_gateway_context$$route$$";
 
     public static final String GATEWAY_NOT_MATCH_PARAM = "$$not_match";
+    public static final String GATEWAY_DEFAULT_PARAM = "$D";
 
     private SentinelGatewayConstants() {}
 }

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/GatewayParamParser.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/GatewayParamParser.java
@@ -62,10 +62,10 @@ public class GatewayParamParser<T> {
                 hasNonParamRule = true;
             }
         }
-        if (gatewayRules.isEmpty()) {
+        if (!hasNonParamRule && gatewayRules.isEmpty()) {
             return new Object[0];
         }
-        if (predSet.size() != 1 || predSet.contains(false)) {
+        if (predSet.size() > 1 || predSet.contains(false)) {
             return new Object[0];
         }
         int size = hasNonParamRule ? gatewayRules.size() + 1 : gatewayRules.size();

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/GatewayParamParser.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/GatewayParamParser.java
@@ -53,10 +53,13 @@ public class GatewayParamParser<T> {
         }
         Set<GatewayFlowRule> gatewayRules = new HashSet<>();
         Set<Boolean> predSet = new HashSet<>();
+        boolean hasNonParamRule = false;
         for (GatewayFlowRule rule : GatewayRuleManager.getRulesForResource(resource)) {
             if (rule.getParamItem() != null) {
                 gatewayRules.add(rule);
                 predSet.add(rulePredicate.test(rule));
+            } else {
+                hasNonParamRule = true;
             }
         }
         if (gatewayRules.isEmpty()) {
@@ -65,12 +68,16 @@ public class GatewayParamParser<T> {
         if (predSet.size() != 1 || predSet.contains(false)) {
             return new Object[0];
         }
-        Object[] arr = new Object[gatewayRules.size()];
+        int size = hasNonParamRule ? gatewayRules.size() + 1 : gatewayRules.size();
+        Object[] arr = new Object[size];
         for (GatewayFlowRule rule : gatewayRules) {
             GatewayParamFlowItem paramItem = rule.getParamItem();
             int idx = paramItem.getIndex();
             String param = parseInternal(paramItem, request);
             arr[idx] = param;
+        }
+        if (hasNonParamRule) {
+            arr[size - 1] = SentinelGatewayConstants.GATEWAY_DEFAULT_PARAM;
         }
         return arr;
     }

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/rule/GatewayRuleConverter.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/rule/GatewayRuleConverter.java
@@ -32,6 +32,17 @@ final class GatewayRuleConverter {
             .setMaxQueueingTimeMs(rule.getMaxQueueingTimeoutMs());
     }
 
+    static ParamFlowRule applyNonParamToParamRule(/*@Valid*/ GatewayFlowRule gatewayRule, int idx) {
+        return new ParamFlowRule(gatewayRule.getResource())
+            .setCount(gatewayRule.getCount())
+            .setGrade(gatewayRule.getGrade())
+            .setDurationInSec(gatewayRule.getIntervalSec())
+            .setBurstCount(gatewayRule.getBurst())
+            .setControlBehavior(gatewayRule.getControlBehavior())
+            .setMaxQueueingTimeMs(gatewayRule.getMaxQueueingTimeoutMs())
+            .setParamIdx(idx);
+    }
+
     /**
      * Convert a gateway rule to parameter flow rule, then apply the generated
      * parameter index to {@link GatewayParamFlowItem} of the rule.

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/slot/GatewayFlowSlot.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/slot/GatewayFlowSlot.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.gateway.common.slot;
+
+import java.util.List;
+
+import com.alibaba.csp.sentinel.adapter.gateway.common.rule.GatewayRuleManager;
+import com.alibaba.csp.sentinel.context.Context;
+import com.alibaba.csp.sentinel.node.DefaultNode;
+import com.alibaba.csp.sentinel.slotchain.AbstractLinkedProcessorSlot;
+import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
+import com.alibaba.csp.sentinel.slots.block.BlockException;
+import com.alibaba.csp.sentinel.slots.block.flow.param.ParamFlowChecker;
+import com.alibaba.csp.sentinel.slots.block.flow.param.ParamFlowException;
+import com.alibaba.csp.sentinel.slots.block.flow.param.ParamFlowRule;
+import com.alibaba.csp.sentinel.slots.block.flow.param.ParameterMetricStorage;
+
+/**
+ * @author Eric Zhao
+ * @since 1.6.1
+ */
+public class GatewayFlowSlot extends AbstractLinkedProcessorSlot<DefaultNode> {
+
+    @Override
+    public void entry(Context context, ResourceWrapper resource, DefaultNode node, int count,
+                      boolean prioritized, Object... args) throws Throwable {
+        checkGatewayParamFlow(resource, count, args);
+
+        fireEntry(context, resource, node, count, prioritized, args);
+    }
+
+    private void checkGatewayParamFlow(ResourceWrapper resourceWrapper, int count, Object... args)
+        throws BlockException {
+        if (args == null) {
+            return;
+        }
+
+        List<ParamFlowRule> rules = GatewayRuleManager.getConvertedParamRules(resourceWrapper.getName());
+        if (rules == null || rules.isEmpty()) {
+            return;
+        }
+
+        for (ParamFlowRule rule : rules) {
+            // Initialize the parameter metrics.
+            ParameterMetricStorage.initParamMetricsFor(resourceWrapper, rule);
+
+            if (!ParamFlowChecker.passCheck(resourceWrapper, rule, count, args)) {
+                String triggeredParam = "";
+                if (args.length > rule.getParamIdx()) {
+                    Object value = args[rule.getParamIdx()];
+                    triggeredParam = String.valueOf(value);
+                }
+                throw new ParamFlowException(resourceWrapper.getName(), triggeredParam, rule);
+            }
+        }
+    }
+
+    @Override
+    public void exit(Context context, ResourceWrapper resourceWrapper, int count, Object... args) {
+        fireExit(context, resourceWrapper, count, args);
+    }
+}

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/slot/GatewaySlotChainBuilder.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/slot/GatewaySlotChainBuilder.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.gateway.common.slot;
+
+import com.alibaba.csp.sentinel.slotchain.DefaultProcessorSlotChain;
+import com.alibaba.csp.sentinel.slotchain.ProcessorSlotChain;
+import com.alibaba.csp.sentinel.slotchain.SlotChainBuilder;
+import com.alibaba.csp.sentinel.slots.block.authority.AuthoritySlot;
+import com.alibaba.csp.sentinel.slots.block.degrade.DegradeSlot;
+import com.alibaba.csp.sentinel.slots.block.flow.FlowSlot;
+import com.alibaba.csp.sentinel.slots.block.flow.param.ParamFlowSlot;
+import com.alibaba.csp.sentinel.slots.clusterbuilder.ClusterBuilderSlot;
+import com.alibaba.csp.sentinel.slots.logger.LogSlot;
+import com.alibaba.csp.sentinel.slots.nodeselector.NodeSelectorSlot;
+import com.alibaba.csp.sentinel.slots.statistic.StatisticSlot;
+import com.alibaba.csp.sentinel.slots.system.SystemSlot;
+
+/**
+ * @author Eric Zhao
+ * @since 1.6.1
+ */
+public class GatewaySlotChainBuilder implements SlotChainBuilder {
+
+    @Override
+    public ProcessorSlotChain build() {
+        ProcessorSlotChain chain = new DefaultProcessorSlotChain();
+        // Prepare slot
+        chain.addLast(new NodeSelectorSlot());
+        chain.addLast(new ClusterBuilderSlot());
+        // Stat slot
+        chain.addLast(new LogSlot());
+        chain.addLast(new StatisticSlot());
+        // Rule checking slot
+        chain.addLast(new AuthoritySlot());
+        chain.addLast(new SystemSlot());
+        chain.addLast(new GatewayFlowSlot());
+
+        chain.addLast(new ParamFlowSlot());
+        chain.addLast(new FlowSlot());
+        chain.addLast(new DegradeSlot());
+
+        return chain;
+    }
+}

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/resources/META-INF/services/com.alibaba.csp.sentinel.slotchain.SlotChainBuilder
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/resources/META-INF/services/com.alibaba.csp.sentinel.slotchain.SlotChainBuilder
@@ -1,0 +1,1 @@
+com.alibaba.csp.sentinel.adapter.gateway.common.slot.GatewaySlotChainBuilder

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/GatewayParamParserTest.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/GatewayParamParserTest.java
@@ -70,10 +70,15 @@ public class GatewayParamParserTest {
             .setCount(5)
             .setIntervalSec(1)
         );
+        rules.add(new GatewayFlowRule(routeId1)
+            .setCount(10)
+            .setControlBehavior(2)
+            .setMaxQueueingTimeoutMs(1000)
+        );
         GatewayRuleManager.loadRules(rules);
 
         Object[] params = parser.parseParameterFor(routeId1, request, routeIdPredicate);
-        assertThat(params.length).isZero();
+        assertThat(params.length).isEqualTo(1);
     }
 
     @Test

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/GatewayParamParserTest.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/GatewayParamParserTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.gateway.common.param;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.alibaba.csp.sentinel.adapter.gateway.common.SentinelGatewayConstants;
+import com.alibaba.csp.sentinel.adapter.gateway.common.api.ApiDefinition;
+import com.alibaba.csp.sentinel.adapter.gateway.common.api.GatewayApiDefinitionManager;
+import com.alibaba.csp.sentinel.adapter.gateway.common.rule.GatewayFlowRule;
+import com.alibaba.csp.sentinel.adapter.gateway.common.rule.GatewayParamFlowItem;
+import com.alibaba.csp.sentinel.adapter.gateway.common.rule.GatewayRuleManager;
+import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+import com.alibaba.csp.sentinel.util.function.Predicate;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Eric Zhao
+ */
+@SuppressWarnings("unchecked")
+public class GatewayParamParserTest {
+
+    private final Predicate<GatewayFlowRule> routeIdPredicate = new Predicate<GatewayFlowRule>() {
+        @Override
+        public boolean test(GatewayFlowRule e) {
+            return e.getResourceMode() == SentinelGatewayConstants.RESOURCE_MODE_ROUTE_ID;
+        }
+    };
+    private final Predicate<GatewayFlowRule> apiNamePredicate = new Predicate<GatewayFlowRule>() {
+        @Override
+        public boolean test(GatewayFlowRule e) {
+            return e.getResourceMode() == SentinelGatewayConstants.RESOURCE_MODE_CUSTOM_API_NAME;
+        }
+    };
+
+    @Test
+    public void testParseParametersNoParamItem() {
+        RequestItemParser<Object> itemParser = mock(RequestItemParser.class);
+        GatewayParamParser<Object> parser = new GatewayParamParser<>(itemParser);
+        // Create a fake request.
+        Object request = new Object();
+        // Prepare gateway rules.
+        Set<GatewayFlowRule> rules = new HashSet<>();
+        String routeId1 = "my_test_route_A";
+        rules.add(new GatewayFlowRule(routeId1)
+            .setCount(5)
+            .setIntervalSec(1)
+        );
+        GatewayRuleManager.loadRules(rules);
+
+        Object[] params = parser.parseParameterFor(routeId1, request, routeIdPredicate);
+        assertThat(params.length).isZero();
+    }
+
+    @Test
+    public void testParseParametersWithItems() {
+        RequestItemParser<Object> itemParser = mock(RequestItemParser.class);
+        GatewayParamParser<Object> paramParser = new GatewayParamParser<>(itemParser);
+        // Create a fake request.
+        Object request = new Object();
+
+        // Prepare gateway rules.
+        Set<GatewayFlowRule> rules = new HashSet<>();
+        final String routeId1 = "my_test_route_A";
+        final String api1 = "my_test_route_B";
+        final String headerName = "X-Sentinel-Flag";
+        final String paramName = "p";
+        GatewayFlowRule routeRuleNoParam = new GatewayFlowRule(routeId1)
+            .setCount(10)
+            .setIntervalSec(10);
+        GatewayFlowRule routeRule1 = new GatewayFlowRule(routeId1)
+            .setCount(2)
+            .setIntervalSec(2)
+            .setBurst(2)
+            .setParamItem(new GatewayParamFlowItem()
+                .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_CLIENT_IP)
+            );
+        GatewayFlowRule routeRule2 = new GatewayFlowRule(routeId1)
+            .setCount(10)
+            .setIntervalSec(1)
+            .setControlBehavior(RuleConstant.CONTROL_BEHAVIOR_RATE_LIMITER)
+            .setMaxQueueingTimeoutMs(600)
+            .setParamItem(new GatewayParamFlowItem()
+                .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_HEADER)
+                .setFieldName(headerName)
+            );
+        GatewayFlowRule routeRule3 = new GatewayFlowRule(routeId1)
+            .setCount(20)
+            .setIntervalSec(1)
+            .setBurst(5)
+            .setParamItem(new GatewayParamFlowItem()
+                .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_URL_PARAM)
+                .setFieldName(paramName)
+            );
+        GatewayFlowRule routeRule4 = new GatewayFlowRule(routeId1)
+            .setCount(120)
+            .setIntervalSec(10)
+            .setBurst(30)
+            .setParamItem(new GatewayParamFlowItem()
+                .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_HOST)
+            );
+        GatewayFlowRule apiRule1 = new GatewayFlowRule(api1)
+            .setResourceMode(SentinelGatewayConstants.RESOURCE_MODE_CUSTOM_API_NAME)
+            .setCount(5)
+            .setIntervalSec(1)
+            .setParamItem(new GatewayParamFlowItem()
+                .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_URL_PARAM)
+                .setFieldName(paramName)
+            );
+        rules.add(routeRule1);
+        rules.add(routeRule2);
+        rules.add(routeRule3);
+        rules.add(routeRule4);
+        rules.add(routeRuleNoParam);
+        rules.add(apiRule1);
+        GatewayRuleManager.loadRules(rules);
+
+        final String expectedHost = "hello.test.sentinel";
+        final String expectedAddress = "66.77.88.99";
+        final String expectedHeaderValue1 = "Sentinel";
+        final String expectedUrlParamValue1 = "17";
+        mockClientHostAddress(itemParser, expectedAddress);
+        Map<String, String> expectedHeaders = new HashMap<String, String>() {{
+            put(headerName, expectedHeaderValue1); put("Host", expectedHost);
+        }};
+        mockHeaders(itemParser, expectedHeaders);
+        mockSingleUrlParam(itemParser, paramName, expectedUrlParamValue1);
+        Object[] params = paramParser.parseParameterFor(routeId1, request, routeIdPredicate);
+        // Param length should be 5 (4 with parameters, 1 normal flow with generated constant)
+        assertThat(params.length).isEqualTo(5);
+        assertThat(params[routeRule1.getParamItem().getIndex()]).isEqualTo(expectedAddress);
+        assertThat(params[routeRule2.getParamItem().getIndex()]).isEqualTo(expectedHeaderValue1);
+        assertThat(params[routeRule3.getParamItem().getIndex()]).isEqualTo(expectedUrlParamValue1);
+        assertThat(params[routeRule4.getParamItem().getIndex()]).isEqualTo(expectedHost);
+        assertThat(params[params.length - 1]).isEqualTo(SentinelGatewayConstants.GATEWAY_DEFAULT_PARAM);
+
+        assertThat(paramParser.parseParameterFor(api1, request, routeIdPredicate).length).isZero();
+
+        String expectedUrlParamValue2 = "fs";
+        mockSingleUrlParam(itemParser, paramName, expectedUrlParamValue2);
+        params = paramParser.parseParameterFor(api1, request, apiNamePredicate);
+        assertThat(params.length).isEqualTo(1);
+        assertThat(params[apiRule1.getParamItem().getIndex()]).isEqualTo(expectedUrlParamValue2);
+    }
+
+    private void mockClientHostAddress(/*@Mock*/ RequestItemParser parser, String address) {
+        when(parser.getRemoteAddress(any())).thenReturn(address);
+    }
+
+    private void mockHeaders(/*@Mock*/ RequestItemParser parser, Map<String, String> headerMap) {
+        for (Map.Entry<String, String> e : headerMap.entrySet()) {
+            when(parser.getHeader(any(), eq(e.getKey()))).thenReturn(e.getValue());
+        }
+    }
+
+    private void mockUrlParams(/*@Mock*/ RequestItemParser parser, Map<String, String> paramMap) {
+        for (Map.Entry<String, String> e : paramMap.entrySet()) {
+            when(parser.getUrlParam(any(), eq(e.getKey()))).thenReturn(e.getValue());
+        }
+    }
+
+    private void mockSingleUrlParam(/*@Mock*/ RequestItemParser parser, String key, String value) {
+        when(parser.getUrlParam(any(), eq(key))).thenReturn(value);
+    }
+
+    private void mockSingleHeader(/*@Mock*/ RequestItemParser parser, String key, String value) {
+        when(parser.getHeader(any(), eq(key))).thenReturn(value);
+    }
+
+    @Before
+    public void setUp() {
+        GatewayApiDefinitionManager.loadApiDefinitions(new HashSet<ApiDefinition>());
+        GatewayRuleManager.loadRules(new HashSet<GatewayFlowRule>());
+    }
+
+    @After
+    public void tearDown() {
+        GatewayApiDefinitionManager.loadApiDefinitions(new HashSet<ApiDefinition>());
+        GatewayRuleManager.loadRules(new HashSet<GatewayFlowRule>());
+    }
+}

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/common/rule/GatewayRuleManagerTest.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/common/rule/GatewayRuleManagerTest.java
@@ -16,12 +16,12 @@
 package com.alibaba.csp.sentinel.adapter.gateway.common.rule;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import com.alibaba.csp.sentinel.adapter.gateway.common.SentinelGatewayConstants;
 import com.alibaba.csp.sentinel.slots.block.RuleConstant;
-import com.alibaba.csp.sentinel.slots.block.flow.FlowRuleManager;
-import com.alibaba.csp.sentinel.slots.block.flow.param.ParamFlowRuleManager;
+import com.alibaba.csp.sentinel.slots.block.flow.param.ParamFlowRule;
 
 import org.junit.After;
 import org.junit.Before;
@@ -62,8 +62,8 @@ public class GatewayRuleManagerTest {
         rules.add(rule3);
         GatewayRuleManager.loadRules(rules);
 
-        assertTrue(FlowRuleManager.hasConfig(ahasRoute));
-        assertTrue(ParamFlowRuleManager.hasRules(ahasRoute));
+        List<ParamFlowRule> convertedRules = GatewayRuleManager.getConvertedParamRules(ahasRoute);
+        assertNotNull(convertedRules);
         assertEquals(0, (int)rule2.getParamItem().getIndex());
         assertEquals(0, (int)rule3.getParamItem().getIndex());
         assertTrue(GatewayRuleManager.getRulesForResource(ahasRoute).contains(rule1));

--- a/sentinel-adapter/sentinel-spring-cloud-gateway-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/sc/SpringCloudGatewayParamParserTest.java
+++ b/sentinel-adapter/sentinel-spring-cloud-gateway-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/sc/SpringCloudGatewayParamParserTest.java
@@ -67,7 +67,7 @@ public class SpringCloudGatewayParamParserTest {
 
         Object[] params = paramParser.parseParameterFor(routeId1, exchange,
             e -> e.getResourceMode() == 0);
-        assertThat(params.length).isZero();
+        assertThat(params.length).isEqualTo(1);
     }
 
     @Test

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowSlot.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowSlot.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.csp.sentinel.slots.block.flow;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -23,6 +24,8 @@ import com.alibaba.csp.sentinel.node.DefaultNode;
 import com.alibaba.csp.sentinel.slotchain.AbstractLinkedProcessorSlot;
 import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
+import com.alibaba.csp.sentinel.util.AssertUtil;
+import com.alibaba.csp.sentinel.util.function.Function;
 
 /**
  * <p>
@@ -135,6 +138,23 @@ import com.alibaba.csp.sentinel.slots.block.BlockException;
  */
 public class FlowSlot extends AbstractLinkedProcessorSlot<DefaultNode> {
 
+    private final FlowRuleChecker checker;
+
+    public FlowSlot() {
+        this(new FlowRuleChecker());
+    }
+
+    /**
+     * Package-private for test.
+     *
+     * @param checker flow rule checker
+     * @since 1.6.1
+     */
+    FlowSlot(FlowRuleChecker checker) {
+        AssertUtil.notNull(checker, "flow checker should not be null");
+        this.checker = checker;
+    }
+
     @Override
     public void entry(Context context, ResourceWrapper resourceWrapper, DefaultNode node, int count,
                       boolean prioritized, Object... args) throws Throwable {
@@ -143,26 +163,22 @@ public class FlowSlot extends AbstractLinkedProcessorSlot<DefaultNode> {
         fireEntry(context, resourceWrapper, node, count, prioritized, args);
     }
 
-    void checkFlow(ResourceWrapper resource, Context context, DefaultNode node, int count, boolean prioritized) throws BlockException {
-        // Flow rule map cannot be null.
-        Map<String, List<FlowRule>> flowRules = FlowRuleManager.getFlowRuleMap();
-
-        List<FlowRule> rules = flowRules.get(resource.getName());
-        if (rules != null) {
-            for (FlowRule rule : rules) {
-                if (!canPassCheck(rule, context, node, count, prioritized)) {
-                    throw new FlowException(rule.getLimitApp(), rule);
-                }
-            }
-        }
-    }
-
-    boolean canPassCheck(FlowRule rule, Context context, DefaultNode node, int count, boolean prioritized) {
-        return FlowRuleChecker.passCheck(rule, context, node, count, prioritized);
+    void checkFlow(ResourceWrapper resource, Context context, DefaultNode node, int count, boolean prioritized)
+        throws BlockException {
+        checker.checkFlow(ruleProvider, resource, context, node, count, prioritized);
     }
 
     @Override
     public void exit(Context context, ResourceWrapper resourceWrapper, int count, Object... args) {
         fireExit(context, resourceWrapper, count, args);
     }
+
+    private final Function<String, Collection<FlowRule>> ruleProvider = new Function<String, Collection<FlowRule>>() {
+        @Override
+        public Collection<FlowRule> apply(String resource) {
+            // Flow rule map should not be null.
+            Map<String, List<FlowRule>> flowRules = FlowRuleManager.getFlowRuleMap();
+            return flowRules.get(resource);
+        }
+    };
 }

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleCheckerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleCheckerTest.java
@@ -149,7 +149,8 @@ public class FlowRuleCheckerTest {
     public void testPassCheckNullLimitApp() {
         FlowRule rule = new FlowRule("abc").setCount(1);
         rule.setLimitApp(null);
-        assertTrue(FlowRuleChecker.passCheck(rule, null, null, 1));
+        FlowRuleChecker checker = new FlowRuleChecker();
+        assertTrue(checker.canPassCheck(rule, null, null, 1));
     }
 
     @Test
@@ -161,7 +162,8 @@ public class FlowRuleCheckerTest {
         Context context = mock(Context.class);
         when(context.getOrigin()).thenReturn("def");
 
-        assertTrue(FlowRuleChecker.passCheck(rule, context, node, 1));
+        FlowRuleChecker checker = new FlowRuleChecker();
+        assertTrue(checker.canPassCheck(rule, context, node, 1));
     }
 
     @Before

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/FlowSlotTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/FlowSlotTest.java
@@ -23,6 +23,7 @@ import com.alibaba.csp.sentinel.context.ContextTestUtil;
 import com.alibaba.csp.sentinel.node.DefaultNode;
 import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
 import com.alibaba.csp.sentinel.slotchain.StringResourceWrapper;
+import com.alibaba.csp.sentinel.util.function.Function;
 
 import org.junit.After;
 import org.junit.Before;
@@ -49,11 +50,13 @@ public class FlowSlotTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testCheckFlowPass() throws Exception {
-        FlowSlot flowSlot = mock(FlowSlot.class);
+        FlowRuleChecker checker = mock(FlowRuleChecker.class);
+        FlowSlot flowSlot = new FlowSlot(checker);
         Context context = mock(Context.class);
         DefaultNode node = mock(DefaultNode.class);
-        doCallRealMethod().when(flowSlot).checkFlow(any(ResourceWrapper.class), any(Context.class),
+        doCallRealMethod().when(checker).checkFlow(any(Function.class), any(ResourceWrapper.class), any(Context.class),
             any(DefaultNode.class), anyInt(), anyBoolean());
 
         String resA = "resAK";
@@ -63,9 +66,9 @@ public class FlowSlotTest {
         // Here we only load rules for resA.
         FlowRuleManager.loadRules(Collections.singletonList(rule1));
 
-        when(flowSlot.canPassCheck(eq(rule1), any(Context.class), any(DefaultNode.class), anyInt(), anyBoolean()))
+        when(checker.canPassCheck(eq(rule1), any(Context.class), any(DefaultNode.class), anyInt(), anyBoolean()))
             .thenReturn(true);
-        when(flowSlot.canPassCheck(eq(rule2), any(Context.class), any(DefaultNode.class), anyInt(), anyBoolean()))
+        when(checker.canPassCheck(eq(rule2), any(Context.class), any(DefaultNode.class), anyInt(), anyBoolean()))
             .thenReturn(false);
 
         flowSlot.checkFlow(new StringResourceWrapper(resA, EntryType.IN), context, node, 1, false);
@@ -73,18 +76,20 @@ public class FlowSlotTest {
     }
 
     @Test(expected = FlowException.class)
+    @SuppressWarnings("unchecked")
     public void testCheckFlowBlock() throws Exception {
-        FlowSlot flowSlot = mock(FlowSlot.class);
+        FlowRuleChecker checker = mock(FlowRuleChecker.class);
+        FlowSlot flowSlot = new FlowSlot(checker);
         Context context = mock(Context.class);
         DefaultNode node = mock(DefaultNode.class);
-        doCallRealMethod().when(flowSlot).checkFlow(any(ResourceWrapper.class), any(Context.class),
+        doCallRealMethod().when(checker).checkFlow(any(Function.class), any(ResourceWrapper.class), any(Context.class),
             any(DefaultNode.class), anyInt(), anyBoolean());
 
         String resA = "resAK";
         FlowRule rule = new FlowRule(resA).setCount(10);
         FlowRuleManager.loadRules(Collections.singletonList(rule));
 
-        when(flowSlot.canPassCheck(any(FlowRule.class), any(Context.class), any(DefaultNode.class), anyInt(), anyBoolean()))
+        when(checker.canPassCheck(any(FlowRule.class), any(Context.class), any(DefaultNode.class), anyInt(), anyBoolean()))
             .thenReturn(false);
 
         flowSlot.checkFlow(new StringResourceWrapper(resA, EntryType.IN), context, node, 1, false);

--- a/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowChecker.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowChecker.java
@@ -43,9 +43,9 @@ import com.alibaba.csp.sentinel.util.TimeUtil;
  * @author Eric Zhao
  * @since 0.2.0
  */
-final class ParamFlowChecker {
+public final class ParamFlowChecker {
 
-    static boolean passCheck(ResourceWrapper resourceWrapper, /*@Valid*/ ParamFlowRule rule, /*@Valid*/ int count,
+    public static boolean passCheck(ResourceWrapper resourceWrapper, /*@Valid*/ ParamFlowRule rule, /*@Valid*/ int count,
                              Object... args) {
         if (args == null) {
             return true;
@@ -249,7 +249,7 @@ final class ParamFlowChecker {
 
     private static ParameterMetric getParameterMetric(ResourceWrapper resourceWrapper) {
         // Should not be null.
-        return ParamFlowSlot.getParamMetric(resourceWrapper);
+        return ParameterMetricStorage.getParamMetric(resourceWrapper);
     }
 
     @SuppressWarnings("unchecked")

--- a/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowRuleManager.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowRuleManager.java
@@ -16,7 +16,6 @@
 package com.alibaba.csp.sentinel.slots.block.flow.param;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -26,9 +25,7 @@ import com.alibaba.csp.sentinel.log.RecordLog;
 import com.alibaba.csp.sentinel.property.DynamicSentinelProperty;
 import com.alibaba.csp.sentinel.property.PropertyListener;
 import com.alibaba.csp.sentinel.property.SentinelProperty;
-import com.alibaba.csp.sentinel.slots.block.RuleConstant;
 import com.alibaba.csp.sentinel.util.AssertUtil;
-import com.alibaba.csp.sentinel.util.StringUtil;
 
 /**
  * Manager for frequent ("hot-spot") parameter flow rules.
@@ -39,7 +36,7 @@ import com.alibaba.csp.sentinel.util.StringUtil;
  */
 public final class ParamFlowRuleManager {
 
-    private static final Map<String, Set<ParamFlowRule>> paramFlowRules = new ConcurrentHashMap<>();
+    private static final Map<String, List<ParamFlowRule>> paramFlowRules = new ConcurrentHashMap<>();
 
     private final static RulePropertyListener PROPERTY_LISTENER = new RulePropertyListener();
     private static SentinelProperty<List<ParamFlowRule>> currentProperty = new DynamicSentinelProperty<>();
@@ -83,7 +80,7 @@ public final class ParamFlowRuleManager {
     }
 
     public static boolean hasRules(String resourceName) {
-        Set<ParamFlowRule> rules = paramFlowRules.get(resourceName);
+        List<ParamFlowRule> rules = paramFlowRules.get(resourceName);
         return rules != null && !rules.isEmpty();
     }
 
@@ -94,7 +91,7 @@ public final class ParamFlowRuleManager {
      */
     public static List<ParamFlowRule> getRules() {
         List<ParamFlowRule> rules = new ArrayList<>();
-        for (Map.Entry<String, Set<ParamFlowRule>> entry : paramFlowRules.entrySet()) {
+        for (Map.Entry<String, List<ParamFlowRule>> entry : paramFlowRules.entrySet()) {
             rules.addAll(entry.getValue());
         }
         return rules;
@@ -104,61 +101,38 @@ public final class ParamFlowRuleManager {
 
         @Override
         public void configUpdate(List<ParamFlowRule> list) {
-            Map<String, Set<ParamFlowRule>> rules = aggregateHotParamRules(list);
+            Map<String, List<ParamFlowRule>> rules = aggregateAndPrepareParamRules(list);
             if (rules != null) {
                 paramFlowRules.clear();
                 paramFlowRules.putAll(rules);
             }
-            RecordLog.info("[ParamFlowRuleManager] Hot spot parameter flow rules received: " + paramFlowRules);
+            RecordLog.info("[ParamFlowRuleManager] Parameter flow rules received: " + paramFlowRules);
         }
 
         @Override
         public void configLoad(List<ParamFlowRule> list) {
-            Map<String, Set<ParamFlowRule>> rules = aggregateHotParamRules(list);
+            Map<String, List<ParamFlowRule>> rules = aggregateAndPrepareParamRules(list);
             if (rules != null) {
                 paramFlowRules.clear();
                 paramFlowRules.putAll(rules);
             }
-            RecordLog.info("[ParamFlowRuleManager] Hot spot parameter flow rules received: " + paramFlowRules);
+            RecordLog.info("[ParamFlowRuleManager] Parameter flow rules received: " + paramFlowRules);
         }
 
-        private Map<String, Set<ParamFlowRule>> aggregateHotParamRules(List<ParamFlowRule> list) {
-            Map<String, Set<ParamFlowRule>> newRuleMap = new ConcurrentHashMap<>();
-
-            if (list == null || list.isEmpty()) {
+        private Map<String, List<ParamFlowRule>> aggregateAndPrepareParamRules(List<ParamFlowRule> list) {
+            Map<String, List<ParamFlowRule>> newRuleMap = ParamFlowRuleUtil.buildParamRuleMap(list);
+            if (newRuleMap == null || newRuleMap.isEmpty()) {
                 // No parameter flow rules, so clear all the metrics.
-                ParamFlowSlot.getMetricsMap().clear();
+                ParameterMetricStorage.getMetricsMap().clear();
                 RecordLog.info("[ParamFlowRuleManager] No parameter flow rules, clearing all parameter metrics");
                 return newRuleMap;
             }
 
-            for (ParamFlowRule rule : list) {
-                if (!ParamFlowRuleUtil.isValidRule(rule)) {
-                    RecordLog.warn("[ParamFlowRuleManager] Ignoring invalid rule when loading new rules: " + rule);
-                    continue;
-                }
-
-                if (StringUtil.isBlank(rule.getLimitApp())) {
-                    rule.setLimitApp(RuleConstant.LIMIT_APP_DEFAULT);
-                }
-
-                ParamFlowRuleUtil.fillExceptionFlowItems(rule);
-
-                String resourceName = rule.getResource();
-                Set<ParamFlowRule> ruleSet = newRuleMap.get(resourceName);
-                if (ruleSet == null) {
-                    ruleSet = new HashSet<>();
-                    newRuleMap.put(resourceName, ruleSet);
-                }
-
-                ruleSet.add(rule);
-            }
-
-            // Clear unused hot param metrics.
+            // Clear unused parameter metrics.
             Set<String> previousResources = paramFlowRules.keySet();
             for (String resource : previousResources) {
                 if (!newRuleMap.containsKey(resource)) {
-                    ParamFlowSlot.clearHotParamMetricForName(resource);
+                    ParameterMetricStorage.clearParamMetricForResource(resource);
                 }
             }
 
@@ -166,6 +140,5 @@ public final class ParamFlowRuleManager {
         }
     }
 
-    private ParamFlowRuleManager() {
-    }
+    private ParamFlowRuleManager() {}
 }

--- a/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowRuleUtil.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowRuleUtil.java
@@ -17,18 +17,32 @@ package com.alibaba.csp.sentinel.slots.block.flow.param;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.alibaba.csp.sentinel.log.RecordLog;
+import com.alibaba.csp.sentinel.slots.block.RuleConstant;
 import com.alibaba.csp.sentinel.slots.block.flow.FlowRuleUtil;
+import com.alibaba.csp.sentinel.util.AssertUtil;
 import com.alibaba.csp.sentinel.util.StringUtil;
+import com.alibaba.csp.sentinel.util.function.Function;
+import com.alibaba.csp.sentinel.util.function.Predicate;
 
 /**
  * @author Eric Zhao
  */
 public final class ParamFlowRuleUtil {
 
+    /**
+     * Check whether the provided rule is valid.
+     *
+     * @param rule any parameter rule
+     * @return true if valid, otherwise false
+     */
     public static boolean isValidRule(ParamFlowRule rule) {
         return rule != null && !StringUtil.isBlank(rule.getResource()) && rule.getCount() >= 0
             && rule.getGrade() >= 0 && rule.getParamIdx() != null
@@ -55,6 +69,11 @@ public final class ParamFlowRuleUtil {
         return id != null && id > 0;
     }
 
+    /**
+     * Fill the parameter rule with parsed items.
+     *
+     * @param rule valid parameter rule
+     */
     public static void fillExceptionFlowItems(ParamFlowRule rule) {
         if (rule != null) {
             if (rule.getParamFlowItemList() == null) {
@@ -66,11 +85,111 @@ public final class ParamFlowRuleUtil {
         }
     }
 
-    static Map<Object, Integer> parseHotItems(List<ParamFlowItem> items) {
-        Map<Object, Integer> itemMap = new HashMap<Object, Integer>();
-        if (items == null || items.isEmpty()) {
-            return itemMap;
+    /**
+     * Build the flow rule map from raw list of flow rules, grouping by resource name.
+     *
+     * @param list raw list of flow rules
+     * @return constructed new flow rule map; empty map if list is null or empty, or no valid rules
+     * @since 1.6.1
+     */
+    public static Map<String, List<ParamFlowRule>> buildParamRuleMap(List<ParamFlowRule> list) {
+        return buildParamRuleMap(list, null);
+    }
+
+    /**
+     * Build the parameter flow rule map from raw list of rules, grouping by resource name.
+     *
+     * @param list          raw list of parameter flow rules
+     * @param filter        rule filter
+     * @return constructed new parameter flow rule map; empty map if list is null or empty, or no wanted rules
+     * @since 1.6.1
+     */
+    public static Map<String, List<ParamFlowRule>> buildParamRuleMap(List<ParamFlowRule> list,
+                                                                     Predicate<ParamFlowRule> filter) {
+        return buildParamRuleMap(list, filter, true);
+    }
+
+    /**
+     * Build the parameter flow rule map from raw list of rules, grouping by resource name.
+     *
+     * @param list          raw list of parameter flow rules
+     * @param filter        rule filter
+     * @param shouldSort    whether the rules should be sorted
+     * @return constructed new parameter flow rule map; empty map if list is null or empty, or no wanted rules
+     * @since 1.6.1
+     */
+    public static Map<String, List<ParamFlowRule>> buildParamRuleMap(List<ParamFlowRule> list,
+                                                                     Predicate<ParamFlowRule> filter,
+                                                                     boolean shouldSort) {
+        return buildParamRuleMap(list, EXTRACT_RESOURCE, filter, shouldSort);
+    }
+
+    /**
+     * Build the rule map from raw list of parameter flow rules, grouping by provided group function.
+     *
+     * @param list          raw list of parameter flow rules
+     * @param groupFunction grouping function of the map (by key)
+     * @param filter        rule filter
+     * @param shouldSort    whether the rules should be sorted
+     * @param <K>           type of key
+     * @return constructed new rule map; empty map if list is null or empty, or no wanted rules
+     * @since 1.6.1
+     */
+    public static <K> Map<K, List<ParamFlowRule>> buildParamRuleMap(List<ParamFlowRule> list,
+                                                                    Function<ParamFlowRule, K> groupFunction,
+                                                                    Predicate<ParamFlowRule> filter,
+                                                                    boolean shouldSort) {
+        AssertUtil.notNull(groupFunction, "groupFunction should not be null");
+        Map<K, List<ParamFlowRule>> newRuleMap = new ConcurrentHashMap<>();
+        if (list == null || list.isEmpty()) {
+            return newRuleMap;
         }
+        Map<K, Set<ParamFlowRule>> tmpMap = new ConcurrentHashMap<>();
+
+        for (ParamFlowRule rule : list) {
+            if (!ParamFlowRuleUtil.isValidRule(rule)) {
+                RecordLog.warn("[ParamFlowRuleManager] Ignoring invalid rule when loading new rules: " + rule);
+                continue;
+            }
+            if (filter != null && !filter.test(rule)) {
+                continue;
+            }
+            if (StringUtil.isBlank(rule.getLimitApp())) {
+                rule.setLimitApp(RuleConstant.LIMIT_APP_DEFAULT);
+            }
+
+            ParamFlowRuleUtil.fillExceptionFlowItems(rule);
+
+            K key = groupFunction.apply(rule);
+            if (key == null) {
+                continue;
+            }
+            Set<ParamFlowRule> flowRules = tmpMap.get(key);
+
+            if (flowRules == null) {
+                // Use hash set here to remove duplicate rules.
+                flowRules = new HashSet<>();
+                tmpMap.put(key, flowRules);
+            }
+
+            flowRules.add(rule);
+        }
+        for (Entry<K, Set<ParamFlowRule>> entries : tmpMap.entrySet()) {
+            List<ParamFlowRule> rules = new ArrayList<>(entries.getValue());
+            if (shouldSort) {
+                // TODO: Sort the rules.
+            }
+            newRuleMap.put(entries.getKey(), rules);
+        }
+
+        return newRuleMap;
+    }
+
+    static Map<Object, Integer> parseHotItems(List<ParamFlowItem> items) {
+        if (items == null || items.isEmpty()) {
+            return new HashMap<>();
+        }
+        Map<Object, Integer> itemMap = new HashMap<>(items.size());
         for (ParamFlowItem item : items) {
             // Value should not be null.
             Object value;
@@ -119,6 +238,13 @@ public final class ParamFlowRuleUtil {
 
         return value;
     }
+
+    private static final Function<ParamFlowRule, String> EXTRACT_RESOURCE = new Function<ParamFlowRule, String>() {
+        @Override
+        public String apply(ParamFlowRule rule) {
+            return rule.getResource();
+        }
+    };
 
     private ParamFlowRuleUtil() {}
 }

--- a/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowSlot.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowSlot.java
@@ -16,18 +16,12 @@
 package com.alibaba.csp.sentinel.slots.block.flow.param;
 
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
-import com.alibaba.csp.sentinel.EntryType;
 import com.alibaba.csp.sentinel.context.Context;
-import com.alibaba.csp.sentinel.log.RecordLog;
 import com.alibaba.csp.sentinel.node.DefaultNode;
 import com.alibaba.csp.sentinel.slotchain.AbstractLinkedProcessorSlot;
 import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
-import com.alibaba.csp.sentinel.slotchain.StringResourceWrapper;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
-import com.alibaba.csp.sentinel.util.StringUtil;
 
 /**
  * A processor slot that is responsible for flow control by frequent ("hot spot") parameters.
@@ -37,13 +31,6 @@ import com.alibaba.csp.sentinel.util.StringUtil;
  * @since 0.2.0
  */
 public class ParamFlowSlot extends AbstractLinkedProcessorSlot<DefaultNode> {
-
-    private static final Map<ResourceWrapper, ParameterMetric> metricsMap = new ConcurrentHashMap<>();
-
-    /**
-     * Lock for a specific resource.
-     */
-    private final Object LOCK = new Object();
 
     @Override
     public void entry(Context context, ResourceWrapper resourceWrapper, DefaultNode node, int count,
@@ -68,7 +55,7 @@ public class ParamFlowSlot extends AbstractLinkedProcessorSlot<DefaultNode> {
             if (-paramIdx <= length) {
                 rule.setParamIdx(length + paramIdx);
             } else {
-                // illegal index, give it a illegal positive value, latter rule check will pass
+                // Illegal index, give it a illegal positive value, latter rule checking will pass.
                 rule.setParamIdx(-paramIdx);
             }
         }
@@ -87,7 +74,7 @@ public class ParamFlowSlot extends AbstractLinkedProcessorSlot<DefaultNode> {
             applyRealParamIdx(rule, args.length);
 
             // Initialize the parameter metrics.
-            initHotParamMetricsFor(resourceWrapper, rule);
+            ParameterMetricStorage.initParamMetricsFor(resourceWrapper, rule);
 
             if (!ParamFlowChecker.passCheck(resourceWrapper, rule, count, args)) {
                 String triggeredParam = "";
@@ -98,61 +85,5 @@ public class ParamFlowSlot extends AbstractLinkedProcessorSlot<DefaultNode> {
                 throw new ParamFlowException(resourceWrapper.getName(), triggeredParam, rule);
             }
         }
-    }
-
-    /**
-     * Init the parameter metric and index map for given resource.
-     * Package-private for test.
-     *
-     * @param resourceWrapper resource to init
-     * @param rule            relevant rule
-     */
-    void initHotParamMetricsFor(ResourceWrapper resourceWrapper, /*@Valid*/ ParamFlowRule rule) {
-        ParameterMetric metric;
-        // Assume that the resource is valid.
-        if ((metric = metricsMap.get(resourceWrapper)) == null) {
-            synchronized (LOCK) {
-                if ((metric = metricsMap.get(resourceWrapper)) == null) {
-                    metric = new ParameterMetric();
-                    metricsMap.put(resourceWrapper, metric);
-                    RecordLog.info("[ParamFlowSlot] Creating parameter metric for: " + resourceWrapper.getName());
-                }
-            }
-        }
-        metric.initialize(rule);
-    }
-
-    public static ParameterMetric getParamMetric(ResourceWrapper resourceWrapper) {
-        if (resourceWrapper == null || resourceWrapper.getName() == null) {
-            return null;
-        }
-        return metricsMap.get(resourceWrapper);
-    }
-
-    public static ParameterMetric getHotParamMetricForName(String resourceName) {
-        if (StringUtil.isBlank(resourceName)) {
-            return null;
-        }
-        for (EntryType nodeType : EntryType.values()) {
-            ParameterMetric metric = metricsMap.get(new StringResourceWrapper(resourceName, nodeType));
-            if (metric != null) {
-                return metric;
-            }
-        }
-        return null;
-    }
-
-    static void clearHotParamMetricForName(String resourceName) {
-        if (StringUtil.isBlank(resourceName)) {
-            return;
-        }
-        for (EntryType nodeType : EntryType.values()) {
-            metricsMap.remove(new StringResourceWrapper(resourceName, nodeType));
-        }
-        RecordLog.info("[ParamFlowSlot] Clearing parameter metric for: " + resourceName);
-    }
-
-    static Map<ResourceWrapper, ParameterMetric> getMetricsMap() {
-        return metricsMap;
     }
 }

--- a/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParameterMetricStorage.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParameterMetricStorage.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.slots.block.flow.param;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.alibaba.csp.sentinel.log.RecordLog;
+import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
+import com.alibaba.csp.sentinel.util.StringUtil;
+
+/**
+ * @author Eric Zhao
+ * @since 1.6.1
+ */
+public final class ParameterMetricStorage {
+
+    private static final Map<String, ParameterMetric> metricsMap = new ConcurrentHashMap<>();
+
+    /**
+     * Lock for a specific resource.
+     */
+    private static final Object LOCK = new Object();
+
+    /**
+     * Init the parameter metric and index map for given resource.
+     * Package-private for test.
+     *
+     * @param resourceWrapper resource to init
+     * @param rule            relevant rule
+     */
+    public static void initParamMetricsFor(ResourceWrapper resourceWrapper, /*@Valid*/ ParamFlowRule rule) {
+        if (resourceWrapper == null || resourceWrapper.getName() == null) {
+            return;
+        }
+        String resourceName = resourceWrapper.getName();
+        ParameterMetric metric;
+        // Assume that the resource is valid.
+        if ((metric = metricsMap.get(resourceName)) == null) {
+            synchronized (LOCK) {
+                if ((metric = metricsMap.get(resourceName)) == null) {
+                    metric = new ParameterMetric();
+                    metricsMap.put(resourceWrapper.getName(), metric);
+                    RecordLog.info("[ParameterMetricStorage] Creating parameter metric for: " + resourceWrapper.getName());
+                }
+            }
+        }
+        metric.initialize(rule);
+    }
+
+    public static ParameterMetric getParamMetric(ResourceWrapper resourceWrapper) {
+        if (resourceWrapper == null || resourceWrapper.getName() == null) {
+            return null;
+        }
+        return metricsMap.get(resourceWrapper.getName());
+    }
+
+    public static ParameterMetric getParamMetricForResource(String resourceName) {
+        if (resourceName == null) {
+            return null;
+        }
+        return metricsMap.get(resourceName);
+    }
+
+    public static void clearParamMetricForResource(String resourceName) {
+        if (StringUtil.isBlank(resourceName)) {
+            return;
+        }
+        metricsMap.remove(resourceName);
+        RecordLog.info("[ParameterMetricStorage] Clearing parameter metric for: " + resourceName);
+    }
+
+    static Map<String, ParameterMetric> getMetricsMap() {
+        return metricsMap;
+    }
+
+    private ParameterMetricStorage() {}
+}

--- a/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/statistic/ParamFlowStatisticEntryCallback.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/statistic/ParamFlowStatisticEntryCallback.java
@@ -20,8 +20,8 @@ import com.alibaba.csp.sentinel.node.DefaultNode;
 import com.alibaba.csp.sentinel.slotchain.ProcessorSlotEntryCallback;
 import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
-import com.alibaba.csp.sentinel.slots.block.flow.param.ParamFlowSlot;
 import com.alibaba.csp.sentinel.slots.block.flow.param.ParameterMetric;
+import com.alibaba.csp.sentinel.slots.block.flow.param.ParameterMetricStorage;
 
 /**
  * @author Eric Zhao
@@ -32,7 +32,7 @@ public class ParamFlowStatisticEntryCallback implements ProcessorSlotEntryCallba
     @Override
     public void onPass(Context context, ResourceWrapper resourceWrapper, DefaultNode node, int count, Object... args) {
         // The "hot spot" parameter metric is present only if parameter flow rules for the resource exist.
-        ParameterMetric parameterMetric = ParamFlowSlot.getParamMetric(resourceWrapper);
+        ParameterMetric parameterMetric = ParameterMetricStorage.getParamMetric(resourceWrapper);
 
         if (parameterMetric != null) {
             parameterMetric.addThreadCount(args);

--- a/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/statistic/ParamFlowStatisticExitCallback.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/statistic/ParamFlowStatisticExitCallback.java
@@ -18,8 +18,8 @@ package com.alibaba.csp.sentinel.slots.statistic;
 import com.alibaba.csp.sentinel.context.Context;
 import com.alibaba.csp.sentinel.slotchain.ProcessorSlotExitCallback;
 import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
-import com.alibaba.csp.sentinel.slots.block.flow.param.ParamFlowSlot;
 import com.alibaba.csp.sentinel.slots.block.flow.param.ParameterMetric;
+import com.alibaba.csp.sentinel.slots.block.flow.param.ParameterMetricStorage;
 
 /**
  * @author Eric Zhao
@@ -30,7 +30,7 @@ public class ParamFlowStatisticExitCallback implements ProcessorSlotExitCallback
     @Override
     public void onExit(Context context, ResourceWrapper resourceWrapper, int count, Object... args) {
         if (context.getCurEntry().getError() == null) {
-            ParameterMetric parameterMetric = ParamFlowSlot.getParamMetric(resourceWrapper);
+            ParameterMetric parameterMetric = ParameterMetricStorage.getParamMetric(resourceWrapper);
 
             if (parameterMetric != null) {
                 parameterMetric.decreaseThreadCount(args);

--- a/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowCheckerTest.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowCheckerTest.java
@@ -90,7 +90,7 @@ public class ParamFlowCheckerTest {
         rule.setParsedHotItems(map);
 
         ParameterMetric metric = new ParameterMetric();
-        ParamFlowSlot.getMetricsMap().put(resourceWrapper, metric);
+        ParameterMetricStorage.getMetricsMap().put(resourceWrapper.getName(), metric);
         metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
 
         assertTrue(ParamFlowChecker.passSingleValueCheck(resourceWrapper, rule, 1, valueA));
@@ -127,7 +127,7 @@ public class ParamFlowCheckerTest {
         when(metric.getThreadCount(paramIdx, valueB)).thenReturn(globalThreshold - 1);
         when(metric.getThreadCount(paramIdx, valueC)).thenReturn(globalThreshold - 1);
         when(metric.getThreadCount(paramIdx, valueD)).thenReturn(globalThreshold + 1);
-        ParamFlowSlot.getMetricsMap().put(resourceWrapper, metric);
+        ParameterMetricStorage.getMetricsMap().put(resourceWrapper.getName(), metric);
 
         assertTrue(ParamFlowChecker.passSingleValueCheck(resourceWrapper, rule, 1, valueA));
         assertFalse(ParamFlowChecker.passSingleValueCheck(resourceWrapper, rule, 1, valueB));
@@ -158,7 +158,7 @@ public class ParamFlowCheckerTest {
         String v1 = "a", v2 = "B", v3 = "Cc";
         List<String> list = Arrays.asList(v1, v2, v3);
         ParameterMetric metric = new ParameterMetric();
-        ParamFlowSlot.getMetricsMap().put(resourceWrapper, metric);
+        ParameterMetricStorage.getMetricsMap().put(resourceWrapper.getName(), metric);
         metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
         metric.getRuleTokenCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicInteger>(4000));
 
@@ -181,7 +181,7 @@ public class ParamFlowCheckerTest {
         String v1 = "a", v2 = "B", v3 = "Cc";
         Object arr = new String[] {v1, v2, v3};
         ParameterMetric metric = new ParameterMetric();
-        ParamFlowSlot.getMetricsMap().put(resourceWrapper, metric);
+        ParameterMetricStorage.getMetricsMap().put(resourceWrapper.getName(), metric);
         metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
 
         assertTrue(ParamFlowChecker.passCheck(resourceWrapper, rule, 1, arr));
@@ -190,11 +190,11 @@ public class ParamFlowCheckerTest {
 
     @Before
     public void setUp() throws Exception {
-        ParamFlowSlot.getMetricsMap().clear();
+        ParameterMetricStorage.getMetricsMap().clear();
     }
 
     @After
     public void tearDown() throws Exception {
-        ParamFlowSlot.getMetricsMap().clear();
+        ParameterMetricStorage.getMetricsMap().clear();
     }
 }

--- a/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowDefaultCheckerTest.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowDefaultCheckerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.csp.sentinel.slots.block.flow.param;
 
 import static org.junit.Assert.assertEquals;
@@ -41,7 +56,7 @@ public class ParamFlowDefaultCheckerTest extends AbstractTimeBasedTest {
 
         String valueA = "valueA";
         ParameterMetric metric = new ParameterMetric();
-        ParamFlowSlot.getMetricsMap().put(resourceWrapper, metric);
+        ParameterMetricStorage.getMetricsMap().put(resourceWrapper.getName(), metric);
         metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
         metric.getRuleTokenCounterMap().put(rule,
             new ConcurrentLinkedHashMapWrapper<Object, AtomicInteger>(4000));
@@ -81,7 +96,7 @@ public class ParamFlowDefaultCheckerTest extends AbstractTimeBasedTest {
 
         String valueA = "valueA";
         ParameterMetric metric = new ParameterMetric();
-        ParamFlowSlot.getMetricsMap().put(resourceWrapper, metric);
+        ParameterMetricStorage.getMetricsMap().put(resourceWrapper.getName(), metric);
         metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
         metric.getRuleTokenCounterMap().put(rule,
             new ConcurrentLinkedHashMapWrapper<Object, AtomicInteger>(4000));
@@ -151,7 +166,7 @@ public class ParamFlowDefaultCheckerTest extends AbstractTimeBasedTest {
 
         String valueA = "helloWorld";
         ParameterMetric metric = new ParameterMetric();
-        ParamFlowSlot.getMetricsMap().put(resourceWrapper, metric);
+        ParameterMetricStorage.getMetricsMap().put(resourceWrapper.getName(), metric);
         metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
         metric.getRuleTokenCounterMap().put(rule,
             new ConcurrentLinkedHashMapWrapper<Object, AtomicInteger>(4000));
@@ -204,7 +219,7 @@ public class ParamFlowDefaultCheckerTest extends AbstractTimeBasedTest {
 
         final String valueA = "valueA";
         ParameterMetric metric = new ParameterMetric();
-        ParamFlowSlot.getMetricsMap().put(resourceWrapper, metric);
+        ParameterMetricStorage.getMetricsMap().put(resourceWrapper.getName(), metric);
         metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
         metric.getRuleTokenCounterMap().put(rule,
             new ConcurrentLinkedHashMapWrapper<Object, AtomicInteger>(4000));
@@ -270,11 +285,11 @@ public class ParamFlowDefaultCheckerTest extends AbstractTimeBasedTest {
 
     @Before
     public void setUp() throws Exception {
-        ParamFlowSlot.getMetricsMap().clear();
+        ParameterMetricStorage.getMetricsMap().clear();
     }
 
     @After
     public void tearDown() throws Exception {
-        ParamFlowSlot.getMetricsMap().clear();
+        ParameterMetricStorage.getMetricsMap().clear();
     }
 }

--- a/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowRuleManagerTest.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowRuleManagerTest.java
@@ -19,8 +19,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import com.alibaba.csp.sentinel.EntryType;
-import com.alibaba.csp.sentinel.slotchain.StringResourceWrapper;
 import com.alibaba.csp.sentinel.slots.block.RuleConstant;
 
 import org.junit.After;
@@ -40,33 +38,36 @@ public class ParamFlowRuleManagerTest {
     @Before
     public void setUp() {
         ParamFlowRuleManager.loadRules(null);
+        ParameterMetricStorage.getMetricsMap().clear();
     }
 
     @After
     public void tearDown() {
         ParamFlowRuleManager.loadRules(null);
+        ParameterMetricStorage.getMetricsMap().clear();
     }
 
     @Test
-    public void testLoadHotParamRulesClearingUnusedMetrics() {
+    public void testLoadParamRulesClearingUnusedMetrics() {
         final String resA = "resA";
         ParamFlowRule ruleA = new ParamFlowRule(resA)
             .setCount(1)
             .setParamIdx(0);
         ParamFlowRuleManager.loadRules(Collections.singletonList(ruleA));
-        ParamFlowSlot.getMetricsMap().put(new StringResourceWrapper(resA, EntryType.IN), new ParameterMetric());
-        assertNotNull(ParamFlowSlot.getHotParamMetricForName(resA));
+        ParameterMetricStorage.getMetricsMap().put(resA, new ParameterMetric());
+        assertNotNull(ParameterMetricStorage.getParamMetricForResource(resA));
 
         final String resB = "resB";
         ParamFlowRule ruleB = new ParamFlowRule(resB)
             .setCount(2)
             .setParamIdx(1);
         ParamFlowRuleManager.loadRules(Collections.singletonList(ruleB));
-        assertNull("The unused hot param metric should be cleared", ParamFlowSlot.getHotParamMetricForName(resA));
+        assertNull("The unused hot param metric should be cleared",
+            ParameterMetricStorage.getParamMetricForResource(resA));
     }
 
     @Test
-    public void testLoadHotParamRulesAndGet() {
+    public void testLoadParamRulesAndGet() {
         final String resA = "abc";
         final String resB = "foo";
         final String resC = "baz";

--- a/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowSlotTest.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowSlotTest.java
@@ -82,7 +82,7 @@ public class ParamFlowSlotTest {
         ResourceWrapper resourceWrapper = new StringResourceWrapper(resourceName, EntryType.IN);
         paramFlowSlot.entry(null, resourceWrapper, null, 1, false, "abc");
         // The parameter metric instance will not be created.
-        assertNull(ParamFlowSlot.getParamMetric(resourceWrapper));
+        assertNull(ParameterMetricStorage.getParamMetric(resourceWrapper));
     }
 
     @Test
@@ -106,7 +106,7 @@ public class ParamFlowSlotTest {
         map.put(argToGo, new AtomicLong(TimeUtil.currentTimeMillis()));
 
         // Insert the mock metric to control pass or block.
-        ParamFlowSlot.getMetricsMap().put(resourceWrapper, metric);
+        ParameterMetricStorage.getMetricsMap().put(resourceWrapper.getName(), metric);
 
         // The first entry will pass.
         paramFlowSlot.entry(null, resourceWrapper, null, 1, false, argToGo);
@@ -121,48 +121,16 @@ public class ParamFlowSlotTest {
         fail("The second entry should be blocked");
     }
 
-    @Test
-    public void testGetNullParamMetric() {
-        assertNull(ParamFlowSlot.getParamMetric(null));
-    }
-
-    @Test
-    public void testInitParamMetrics() {
-
-        ParamFlowRule rule = new ParamFlowRule();
-        rule.setParamIdx(1);
-        int index = 1;
-        String resourceName = "res-" + System.currentTimeMillis();
-        ResourceWrapper resourceWrapper = new StringResourceWrapper(resourceName, EntryType.IN);
-
-        assertNull(ParamFlowSlot.getParamMetric(resourceWrapper));
-
-        paramFlowSlot.initHotParamMetricsFor(resourceWrapper, rule);
-        ParameterMetric metric = ParamFlowSlot.getParamMetric(resourceWrapper);
-        assertNotNull(metric);
-        assertNotNull(metric.getRuleTimeCounterMap().get(rule));
-        assertNotNull(metric.getThreadCountMap().get(index));
-
-        // Duplicate init.
-        paramFlowSlot.initHotParamMetricsFor(resourceWrapper, rule);
-        assertSame(metric, ParamFlowSlot.getParamMetric(resourceWrapper));
-
-        ParamFlowRule rule2 = new ParamFlowRule();
-        rule2.setParamIdx(1);
-        assertSame(metric, ParamFlowSlot.getParamMetric(resourceWrapper));
-
-    }
-
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         ParamFlowRuleManager.loadRules(null);
-        ParamFlowSlot.getMetricsMap().clear();
+        ParameterMetricStorage.getMetricsMap().clear();
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         // Clean the metrics map.
-        ParamFlowSlot.getMetricsMap().clear();
         ParamFlowRuleManager.loadRules(null);
+        ParameterMetricStorage.getMetricsMap().clear();
     }
 }

--- a/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowThrottleRateLimitingCheckerTest.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowThrottleRateLimitingCheckerTest.java
@@ -1,6 +1,19 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.csp.sentinel.slots.block.flow.param;
-
-import static org.junit.Assert.assertEquals;
 
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
@@ -18,6 +31,8 @@ import com.alibaba.csp.sentinel.slotchain.StringResourceWrapper;
 import com.alibaba.csp.sentinel.slots.block.RuleConstant;
 import com.alibaba.csp.sentinel.slots.statistic.cache.ConcurrentLinkedHashMapWrapper;
 import com.alibaba.csp.sentinel.util.TimeUtil;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author jialiang.linjl
@@ -41,7 +56,7 @@ public class ParamFlowThrottleRateLimitingCheckerTest {
 
         String valueA = "valueA";
         ParameterMetric metric = new ParameterMetric();
-        ParamFlowSlot.getMetricsMap().put(resourceWrapper, metric);
+        ParameterMetricStorage.getMetricsMap().put(resourceWrapper.getName(), metric);
         metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
 
         long currentTime = TimeUtil.currentTimeMillis();
@@ -85,7 +100,7 @@ public class ParamFlowThrottleRateLimitingCheckerTest {
 
         final String valueA = "valueA";
         ParameterMetric metric = new ParameterMetric();
-        ParamFlowSlot.getMetricsMap().put(resourceWrapper, metric);
+        ParameterMetricStorage.getMetricsMap().put(resourceWrapper.getName(), metric);
         metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
 
         int threadCount = 40;
@@ -154,11 +169,11 @@ public class ParamFlowThrottleRateLimitingCheckerTest {
 
     @Before
     public void setUp() throws Exception {
-        ParamFlowSlot.getMetricsMap().clear();
+        ParameterMetricStorage.getMetricsMap().clear();
     }
 
     @After
     public void tearDown() throws Exception {
-        ParamFlowSlot.getMetricsMap().clear();
+        ParameterMetricStorage.getMetricsMap().clear();
     }
 }

--- a/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParameterMetricStorageTest.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParameterMetricStorageTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.slots.block.flow.param;
+
+import com.alibaba.csp.sentinel.EntryType;
+import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
+import com.alibaba.csp.sentinel.slotchain.StringResourceWrapper;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Eric Zhao
+ */
+public class ParameterMetricStorageTest {
+
+    @Test
+    public void testGetNullParamMetric() {
+        assertNull(ParameterMetricStorage.getParamMetric(null));
+    }
+
+    @Test
+    public void testInitParamMetrics() {
+        ParamFlowRule rule = new ParamFlowRule();
+        rule.setParamIdx(1);
+        int index = 1;
+        String resourceName = "res-" + System.currentTimeMillis();
+        ResourceWrapper resourceWrapper = new StringResourceWrapper(resourceName, EntryType.IN);
+
+        assertNull(ParameterMetricStorage.getParamMetric(resourceWrapper));
+
+        ParameterMetricStorage.initParamMetricsFor(resourceWrapper, rule);
+        ParameterMetric metric = ParameterMetricStorage.getParamMetric(resourceWrapper);
+        assertNotNull(metric);
+        assertNotNull(metric.getRuleTimeCounterMap().get(rule));
+        assertNotNull(metric.getThreadCountMap().get(index));
+
+        // Duplicate init.
+        ParameterMetricStorage.initParamMetricsFor(resourceWrapper, rule);
+        assertSame(metric, ParameterMetricStorage.getParamMetric(resourceWrapper));
+
+        ParamFlowRule rule2 = new ParamFlowRule();
+        rule2.setParamIdx(1);
+        assertSame(metric, ParameterMetricStorage.getParamMetric(resourceWrapper));
+    }
+
+    @Before
+    public void setUp() {
+        ParameterMetricStorage.getMetricsMap().clear();
+    }
+
+    @After
+    public void tearDown() {
+        ParameterMetricStorage.getMetricsMap().clear();
+    }
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Improve the parameter flow module and refactor the API gateway adapter common module. See #756 for details.

### Does this pull request fix one issue?

Resolves #756 

### Describe how you did it

- Refactor `FlowRuleChecker` to improve code reuse. Add `checkFlow` method to support applying rule retrieving function and then check.
-  Separate parameter metric storage from `ParamFlowSlot` and improve `ParamFlowRuleUtil`
  -  Add a `ParameterMetricStorage` specific for caching ParameterMetric (moved from ParamSlot)
  -  Add rule map building helper method in `ParamFlowRuleUtil` so that we can reuse it in other rule managers
- Refactor API gateway common module to separate converted rules from other rule managers
  - Separate converted parameter rules from ParamFlowManager. Now the converted rules will be kept in `GatewayRuleManager` directly.
  - Add a `GatewayFlowSlot` to do separate flow checking for generated rules.
  - Refactor rule converting mechanism: now non-param gateway rules (normal mode) will also be converted to parameter flow rules. The index will be the las position. In `GatewayParamParser` we put **a constant value** to the last position to achieve the effect of non-param flow control.

### Describe how to verify it

Run the test cases and demo.

### Special notes for reviews

Please take care of the *internal breaking changes*.