### PR TITLE
fix sentinel-dashboard中test模块错误FlowRuleZookeeperProvider component name

### DIFF
--- a/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/rule/zookeeper/FlowRuleZookeeperProvider.java
+++ b/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/rule/zookeeper/FlowRuleZookeeperProvider.java
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Component;
 import java.util.ArrayList;
 import java.util.List;
 
-@Component("flowRuleZookeeperPublisher")
+@Component("flowRuleZookeeperProvider")
 public class FlowRuleZookeeperProvider implements DynamicRuleProvider<List<FlowRuleEntity>> {
 
     @Autowired


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
sentinel-dashboard module的test模块中存在两个同名冲突的Component，包路径：com.alibaba.csp.sentinel.dashboard.rule.zookeeper

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
修改com.alibaba.csp.sentinel.dashboard.rule.zookeeper.FlowRuleZookeeperProvider的Component name为flowRuleZookeeperProvider

### Describe how to verify it
diff com.alibaba.csp.sentinel.dashboard.rule.zookeeper.FlowRuleZookeeperProvider和com.alibaba.csp.sentinel.dashboard.rule.zookeeper.FlowRuleZookeeperPublisher的Component注解name是否一致

### Special notes for reviews
