### PR TITLE
Add Exceptions to trace or ignore in Tracer

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Tracer.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Tracer.java
@@ -29,7 +29,12 @@ import com.alibaba.csp.sentinel.metric.extension.MetricExtension;
  * @author jialiang.linjl
  * @author Eric Zhao
  */
-public final class Tracer {
+public class Tracer {
+
+    protected static Class<? extends Throwable>[] traceClasses;
+    protected static Class<? extends Throwable>[] ignoreClasses;
+
+    protected Tracer() {}
 
     /**
      * Trace provided {@link Throwable} and increment exception count to entry in current context.
@@ -47,7 +52,7 @@ public final class Tracer {
      * @param count exception count to add
      */
     public static void trace(Throwable e, int count) {
-        if (e == null || e instanceof BlockException) {
+        if (!shouldTrace(e)) {
             return;
         }
 
@@ -68,7 +73,7 @@ public final class Tracer {
      * @since 1.4.2
      */
     public static void traceContext(Throwable e, int count, Context context) {
-        if (e == null || e instanceof BlockException) {
+        if (!shouldTrace(e)) {
             return;
         }
         if (context == null) {
@@ -97,7 +102,7 @@ public final class Tracer {
      * @since 1.4.2
      */
     public static void traceEntry(Throwable e, int count, Entry entry) {
-        if (e == null || e instanceof BlockException) {
+        if (!shouldTrace(e)) {
             return;
         }
         if (entry == null || entry.getCurNode() == null) {
@@ -124,5 +129,81 @@ public final class Tracer {
         clusterNode.trace(t, count);
     }
 
-    private Tracer() {}
+    /**
+     * Set exception to trace. If not set, all Exception except for {@link BlockException} will be traced.
+     * <p>
+     * Note that if both {@link #setExceptionsToIgnore(Class[])} and this method is set,
+     * the ExceptionsToIgnore will be of higher precedence.
+     * </p>
+     *
+     * @param traceClasses the list of exception classes to trace.
+     * @since 1.6.1
+     */
+    @SafeVarargs
+    public static void setExceptionsToTrace(Class<? extends Throwable>... traceClasses) {
+        Tracer.traceClasses = traceClasses;
+    }
+
+    /**
+     * Get exception classes to trace.
+     *
+     * @return an array of exception classes to trace.
+     * @since 1.6.1
+     */
+    public static Class<? extends Throwable>[] getExceptionsToTrace() {
+        return traceClasses;
+    }
+
+    /**
+     * Set exceptions to ignore. if not set, all Exception except for {@link BlockException} will be traced.
+     * <p>
+     * Note that if both {@link #setExceptionsToTrace(Class[])} and this method is set,
+     * the ExceptionsToIgnore will be of higher precedence.
+     * </p>
+     *
+     * @param ignoreClasses the list of exception classes to ignore.
+     * @since 1.6.1
+     */
+    @SafeVarargs
+    public static void setExceptionsToIgnore(Class<? extends Throwable>... ignoreClasses) {
+        Tracer.ignoreClasses = ignoreClasses;
+    }
+
+    /**
+     * Get exception classes to ignore.
+     *
+     * @return an array of exception classes to ignore.
+     * @since 1.6.1
+     */
+    public static Class<? extends Throwable>[] getExceptionsToIgnore() {
+        return ignoreClasses;
+    }
+
+    /**
+     * Check whether the throwable should be traced.
+     *
+     * @param t the throwable to check.
+     * @return true if the throwable should be traced, else return false.
+     */
+    protected static boolean shouldTrace(Throwable t) {
+        if (t == null || t instanceof BlockException) {
+            return false;
+        }
+        if (ignoreClasses != null) {
+            for (Class<? extends Throwable> clazz : ignoreClasses) {
+                if (clazz.isAssignableFrom(t.getClass())) {
+                    return false;
+                }
+            }
+        }
+        if (traceClasses != null) {
+            for (Class<? extends Throwable> clazz : traceClasses) {
+                if (clazz.isAssignableFrom(t.getClass())) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        return true;
+    }
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Tracer.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Tracer.java
@@ -22,6 +22,7 @@ import com.alibaba.csp.sentinel.node.ClusterNode;
 import com.alibaba.csp.sentinel.node.DefaultNode;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
 import com.alibaba.csp.sentinel.metric.extension.MetricExtension;
+import com.alibaba.csp.sentinel.util.AssertUtil;
 
 /**
  * This class is used to record other exceptions except block exception.
@@ -141,6 +142,7 @@ public class Tracer {
      */
     @SafeVarargs
     public static void setExceptionsToTrace(Class<? extends Throwable>... traceClasses) {
+        checkNotNull(traceClasses);
         Tracer.traceClasses = traceClasses;
     }
 
@@ -166,6 +168,7 @@ public class Tracer {
      */
     @SafeVarargs
     public static void setExceptionsToIgnore(Class<? extends Throwable>... ignoreClasses) {
+        checkNotNull(ignoreClasses);
         Tracer.ignoreClasses = ignoreClasses;
     }
 
@@ -177,6 +180,13 @@ public class Tracer {
      */
     public static Class<? extends Throwable>[] getExceptionsToIgnore() {
         return ignoreClasses;
+    }
+
+    private static void checkNotNull(Class<? extends Throwable>[] classes) {
+        AssertUtil.notNull(classes, "trace or ignore classes must not be null");
+        for (Class<? extends Throwable> clazz : classes) {
+            AssertUtil.notNull(clazz, "trace or ignore classes must not be null");
+        }
     }
 
     /**
@@ -191,14 +201,14 @@ public class Tracer {
         }
         if (ignoreClasses != null) {
             for (Class<? extends Throwable> clazz : ignoreClasses) {
-                if (clazz.isAssignableFrom(t.getClass())) {
+                if (clazz != null && clazz.isAssignableFrom(t.getClass())) {
                     return false;
                 }
             }
         }
         if (traceClasses != null) {
             for (Class<? extends Throwable> clazz : traceClasses) {
-                if (clazz.isAssignableFrom(t.getClass())) {
+                if (clazz != null && clazz.isAssignableFrom(t.getClass())) {
                     return true;
                 }
             }

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/TracerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/TracerTest.java
@@ -39,6 +39,21 @@ public class TracerTest extends Tracer {
         Assert.assertTrue(Tracer.shouldTrace(new TraceException()));
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testNull() {
+        Tracer.setExceptionsToTrace(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNull1() {
+        Tracer.setExceptionsToTrace(TraceException.class, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNull2() {
+        Tracer.setExceptionsToIgnore(IgnoreException.class, null);
+    }
+
     private class TraceException extends Exception {}
 
     private class TraceException2 extends Exception {}

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/TracerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/TracerTest.java
@@ -1,0 +1,55 @@
+package com.alibaba.csp.sentinel;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Carpenter Lee
+ */
+public class TracerTest extends Tracer {
+
+    @Test
+    public void setExceptionsToTrace() {
+        Tracer.ignoreClasses = null;
+        Tracer.traceClasses = null;
+        Tracer.setExceptionsToTrace(TraceException.class, TraceException2.class);
+        Assert.assertTrue(Tracer.shouldTrace(new TraceException2()));
+        Assert.assertTrue(Tracer.shouldTrace(new TraceExceptionSub()));
+        Assert.assertFalse(Tracer.shouldTrace(new Exception()));
+    }
+
+    @Test
+    public void setExceptionsToIgnore() {
+        Tracer.ignoreClasses = null;
+        Tracer.traceClasses = null;
+        Tracer.setExceptionsToIgnore(IgnoreException.class, IgnoreException2.class);
+        Assert.assertFalse(Tracer.shouldTrace(new IgnoreException()));
+        Assert.assertFalse(Tracer.shouldTrace(new IgnoreExceptionSub()));
+        Assert.assertTrue(Tracer.shouldTrace(new Exception()));
+    }
+
+    @Test
+    public void testBoth() {
+        Tracer.ignoreClasses = null;
+        Tracer.traceClasses = null;
+        Tracer.setExceptionsToTrace(TraceException.class, TraceException2.class, BothException.class);
+        Tracer.setExceptionsToIgnore(IgnoreException.class, IgnoreException2.class, BothException.class);
+        Assert.assertFalse(Tracer.shouldTrace(new IgnoreException()));
+        Assert.assertFalse(Tracer.shouldTrace(new BothException()));
+        Assert.assertTrue(Tracer.shouldTrace(new TraceException()));
+    }
+
+    private class TraceException extends Exception {}
+
+    private class TraceException2 extends Exception {}
+
+    private class TraceExceptionSub extends TraceException {}
+
+    private class IgnoreException extends Exception {}
+
+    private class IgnoreException2 extends Exception {}
+
+    private class IgnoreExceptionSub extends IgnoreException {}
+
+    private class BothException extends Exception {}
+}


### PR DESCRIPTION
Signed-off-by: Carpenter Lee <hooleeucas@163.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Exception statistics are the basis for degradation or circuit breaker, and `Tracer.trace()` will trace any exception besides `BlockException`, this means any kinds of exception except for BlockException will have an effect on degradation. 

Sometimes we may want to ignore some kind of exceptions in the statistics.

This PR Supports inclusive or exclusive Exception types in exception tracing.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #761

### Describe how you did it

Add `Tracer.setExceptionsToTrace()` and `Tracer.setExceptionsToIgnore()` in `Tracer`, to supports inclusive or exclusive Exception types in exception tracing.

### Describe how to verify it
Run test cases.