### PR TITLE
增加基于注解的流控和降级配置

### DIFF
--- a/sentinel-extension/sentinel-annotation-aspectj/pom.xml
+++ b/sentinel-extension/sentinel-annotation-aspectj/pom.xml
@@ -52,15 +52,21 @@
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>${spring.test.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
             <version>${spring.test.version}</version>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-aop</artifactId>
             <version>${spring.test.version}</version>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/SentinelAnnotationBeanProcessor.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/SentinelAnnotationBeanProcessor.java
@@ -1,0 +1,121 @@
+package com.alibaba.csp.sentinel.annotation.aspectj;
+
+import com.alibaba.csp.sentinel.annotation.SentinelResource;
+import com.alibaba.csp.sentinel.annotation.aspectj.annotation.DegradeRuleDefine;
+import com.alibaba.csp.sentinel.annotation.aspectj.annotation.FlowRuleDefine;
+import com.alibaba.csp.sentinel.log.RecordLog;
+import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRule;
+import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRuleManager;
+import com.alibaba.csp.sentinel.slots.block.flow.FlowRule;
+import com.alibaba.csp.sentinel.slots.block.flow.FlowRuleManager;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SentinelAnnotationBeanProcessor implements BeanPostProcessor, ApplicationListener<ContextRefreshedEvent> {
+
+    List<FlowRule> flowRules = new ArrayList<FlowRule>();
+    List<DegradeRule> degradeRules = new ArrayList<DegradeRule>();
+
+    private String flowGradeString(int grade) {
+        switch (grade) {
+            case 0: return "FLOW_GRADE_THREAD";
+            case 1: return "FLOW_GRADE_QPS";
+            default: return "unknown flow grade";
+        }
+    }
+
+    private String degradeGradeString(int grade) {
+        switch (grade) {
+            case 0: return "DEGRADE_GRADE_RT";
+            case 1: return "DEGRADE_GRADE_EXCEPTION_RATIO";
+            case 2: return "DEGRADE_GRADE_EXCEPTION_COUNT";
+            default: return "unknown degrade grade";
+        }
+    }
+
+    private String behaviorGradeString(int behavior) {
+        switch (behavior) {
+            case 0: return "CONTROL_BEHAVIOR_DEFAULT";
+            case 1: return "CONTROL_BEHAVIOR_WARM_UP";
+            case 2: return "CONTROL_BEHAVIOR_RATE_LIMITER";
+            case 3: return "CONTROL_BEHAVIOR_WARM_UP_RATE_LIMITER";
+            default: return "unknown behavior grade";
+        }
+    }
+
+    @Override
+    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+        return bean;
+    }
+
+    private boolean isHandlerDefined(String handler) {
+        return handler != null && !handler.isEmpty();
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        //logger.info("{} => {}", bean.getClass().getSimpleName(), AopUtils.getTargetClass(bean).getSimpleName());
+
+        String className = AopUtils.getTargetClass(bean).getCanonicalName();
+
+        for (Method method : AopUtils.getTargetClass(bean).getDeclaredMethods()) {
+            if (method.isAnnotationPresent(SentinelResource.class)) {
+
+                SentinelResource annotationSentinel = method.getAnnotation(SentinelResource.class);
+
+                if (isHandlerDefined(annotationSentinel.blockHandler())) {
+                    FlowRuleDefine flowDef = method.getAnnotation(FlowRuleDefine.class);
+                    if (flowDef != null) {
+                        FlowRule rule = new FlowRule();
+                        rule.setResource(annotationSentinel.value());
+                        rule.setCount(flowDef.count());
+                        rule.setGrade(flowDef.grade());
+                        rule.setControlBehavior(flowDef.behavior());
+                        flowRules.add(rule);
+                        RecordLog.info("SENTINEL   FLOW  ==> {0}.{1}() withResourceName {2} = (grade:{3}, count:{4}, behavior:{5})",
+                                className, method.getName(), annotationSentinel.value(),
+                                flowGradeString(flowDef.grade()), flowDef.count(), behaviorGradeString(flowDef.behavior()));
+                    } else {
+                        //RecordLog.warn("SENTINEL   FLOW  ==> not found @FlowRuleDefine at [{0}.{1}], remove `blockHandler` or add @FlowRuleDefine",
+                        //        className, method.getName());
+                    }
+                }
+
+                if (isHandlerDefined(annotationSentinel.fallback()) ||
+                        isHandlerDefined(annotationSentinel.defaultFallback())) {
+                    DegradeRuleDefine degradeDef = method.getAnnotation(DegradeRuleDefine.class);
+                    if (degradeDef != null) {
+                        DegradeRule rule = new DegradeRule();
+                        rule.setResource(annotationSentinel.value());
+                        rule.setCount(degradeDef.count());
+                        rule.setGrade(degradeDef.grade());
+                        rule.setTimeWindow(degradeDef.timeWindow());
+                        degradeRules.add(rule);
+                        RecordLog.info("SENTINEL DEGRADE ==> {0}.{1}() withResourceName {2} = (grade:{3}, count:{4}, timeWindow:{5}(s))",
+                                className, method.getName(), annotationSentinel.value(),
+                                degradeGradeString(degradeDef.grade()), degradeDef.count(), degradeDef.timeWindow());
+                    } else {
+                        //RecordLog.warn("SENTINEL DEGRADE ==> not found @DegradeRuleDefine at [{0}.{1}], remove `fallback` or add @DegradeRuleDefine",
+                        //        className, method.getName());
+                    }
+                }
+            }
+        }
+        return bean;
+    }
+
+    @Override
+    public void onApplicationEvent(ContextRefreshedEvent contextRefreshedEvent) {
+        RecordLog.info("SENTINEL         ==> load {0} flow rules", flowRules.size());
+        FlowRuleManager.loadRules(flowRules);
+        RecordLog.info("SENTINEL         ==> load {0} degrade rules", degradeRules.size());
+        DegradeRuleManager.loadRules(degradeRules);
+    }
+}

--- a/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/annotation/DegradeRuleDefine.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/annotation/DegradeRuleDefine.java
@@ -1,0 +1,15 @@
+package com.alibaba.csp.sentinel.annotation.aspectj.annotation;
+
+import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+@Inherited
+@Documented
+public @interface DegradeRuleDefine {
+    int timeWindow() default 10; // seconds
+    int count() default 20;
+    int grade() default RuleConstant.DEGRADE_GRADE_RT;
+}

--- a/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/annotation/EnableSentinel.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/annotation/EnableSentinel.java
@@ -1,0 +1,14 @@
+package com.alibaba.csp.sentinel.annotation.aspectj.annotation;
+
+import com.alibaba.csp.sentinel.annotation.aspectj.configuration.SentinelConfiguration;
+import org.springframework.context.annotation.Import;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+@Inherited
+@Documented
+@Import({SentinelConfiguration.class})
+public @interface EnableSentinel {
+}

--- a/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/annotation/FlowRuleDefine.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/annotation/FlowRuleDefine.java
@@ -1,0 +1,15 @@
+package com.alibaba.csp.sentinel.annotation.aspectj.annotation;
+
+import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+@Inherited
+@Documented
+public @interface FlowRuleDefine {
+    int count() default 20;
+    int grade() default RuleConstant.FLOW_GRADE_QPS;
+    int behavior() default RuleConstant.CONTROL_BEHAVIOR_DEFAULT;
+}

--- a/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/configuration/SentinelConfiguration.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/configuration/SentinelConfiguration.java
@@ -1,0 +1,18 @@
+package com.alibaba.csp.sentinel.annotation.aspectj.configuration;
+
+import com.alibaba.csp.sentinel.annotation.aspectj.SentinelAnnotationBeanProcessor;
+import com.alibaba.csp.sentinel.annotation.aspectj.SentinelResourceAspect;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SentinelConfiguration {
+
+    @Bean
+    public SentinelResourceAspect sentinelResourceAspect() {
+        return new SentinelResourceAspect();
+    }
+
+    @Bean
+    public SentinelAnnotationBeanProcessor processor() { return new SentinelAnnotationBeanProcessor(); }
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
简化FlowRule和DegradeRule的配置,目前的配置方式是在需要降级的地方写上SentinelResource注解,
然后专门找个文件写FlowRule和DegradeRule,配置内容分散,resource名需要在多处拷贝,需要多加小心保持各处resource名的一致性,给代码维护增加负担.
使用注解定义FlowRule和DegradeRule后,资源名只需要出现一次, 限流和降级规则在定义SentinelResource处直接可见,降低配置分散度,维护起来比较轻松.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
1.增加一个BeanPostProcess类SentinelAnnotationBeanProcessor在每个bean生成时扫描SentinelResource注解,在有注解的方法上找FlowRuleDefine和DegradeRuleDefine注解,如果找到就记录下来.
2.所有bean加载完后,调用FlowRuleManager和DegradeRuleManager的loadRules方法加载第一步找到的所有rule.

### Describe how to verify it
1.如果是Spring Boot项目, 在Starter类上加上EnableSentinel注解启用Sentinel.同时不再需要手工配置SentinelResourceAspect这个bean. Starter类看起来如下:
![image](https://user-images.githubusercontent.com/15826438/58538491-d6c3c380-8227-11e9-9b53-ea3665c9856a.png)
  在定义SentinelResource资源的地方加上FlowRuleDefine和DegradeRuleDefine注解
![image](https://user-images.githubusercontent.com/15826438/58538704-43d75900-8228-11e9-8418-38531904b7e5.png)

2.如果是基于xml的Spring配置,需要在xml中额外配置上 SentinelAnnotationBeanProcessor 这个bean,之后FlowRuleDefine和DegradeRuleDefine的注解方法和上面一样

### Special notes for reviews
