### PR TITLE
Add support for parsing cookie as request items in gateway flow control

### DIFF
--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/SentinelGatewayConstants.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/SentinelGatewayConstants.java
@@ -30,6 +30,7 @@ public final class SentinelGatewayConstants {
     public static final int PARAM_PARSE_STRATEGY_HOST = 1;
     public static final int PARAM_PARSE_STRATEGY_HEADER = 2;
     public static final int PARAM_PARSE_STRATEGY_URL_PARAM = 3;
+    public static final int PARAM_PARSE_STRATEGY_COOKIE = 4;
 
     public static final int PARAM_MATCH_STRATEGY_EXACT = 0;
     public static final int PARAM_MATCH_STRATEGY_PREFIX = 1;

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/GatewayParamParser.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/GatewayParamParser.java
@@ -42,8 +42,8 @@ public class GatewayParamParser<T> {
     /**
      * Parse parameters for given resource from the request entity on condition of the rule predicate.
      *
-     * @param resource valid resource name
-     * @param request valid request
+     * @param resource      valid resource name
+     * @param request       valid request
      * @param rulePredicate rule predicate indicating the rules to refer
      * @return the parameter array
      */
@@ -92,6 +92,8 @@ public class GatewayParamParser<T> {
                 return parseHeader(item, request);
             case SentinelGatewayConstants.PARAM_PARSE_STRATEGY_URL_PARAM:
                 return parseUrlParameter(item, request);
+            case SentinelGatewayConstants.PARAM_PARSE_STRATEGY_COOKIE:
+                return parseCookie(item, request);
             default:
                 return null;
         }
@@ -132,6 +134,17 @@ public class GatewayParamParser<T> {
         String paramName = item.getFieldName();
         String pattern = item.getPattern();
         String param = requestItemParser.getUrlParam(request, paramName);
+        if (pattern == null) {
+            return param;
+        }
+        // Match value according to regex pattern or exact mode.
+        return parseWithMatchStrategyInternal(item.getMatchStrategy(), param, pattern);
+    }
+
+    private String parseCookie(/*@Valid*/ GatewayParamFlowItem item, T request) {
+        String cookieName = item.getFieldName();
+        String pattern = item.getPattern();
+        String param = requestItemParser.getCookieValue(request, cookieName);
         if (pattern == null) {
             return param;
         }

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/RequestItemParser.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/RequestItemParser.java
@@ -41,7 +41,7 @@ public interface RequestItemParser<T> {
      * Get the header associated with the header key.
      *
      * @param request valid request
-     * @param key valid header key
+     * @param key     valid header key
      * @return the header
      */
     String getHeader(T request, String key);
@@ -49,9 +49,19 @@ public interface RequestItemParser<T> {
     /**
      * Get the parameter value associated with the parameter name.
      *
-     * @param request valid request
+     * @param request   valid request
      * @param paramName valid parameter name
      * @return the parameter value
      */
     String getUrlParam(T request, String paramName);
+
+    /**
+     * Get the cookie value associated with the cookie name.
+     *
+     * @param request    valid request
+     * @param cookieName valid cookie name
+     * @return the cookie value
+     * @since 1.7.0
+     */
+    String getCookieValue(T request, String cookieName);
 }

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/rule/GatewayRuleManager.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/rule/GatewayRuleManager.java
@@ -16,6 +16,7 @@
 package com.alibaba.csp.sentinel.adapter.gateway.common.rule;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -242,14 +243,18 @@ public final class GatewayRuleManager {
         if (item.getParseStrategy() < 0) {
             return false;
         }
-        if (item.getParseStrategy() == SentinelGatewayConstants.PARAM_PARSE_STRATEGY_URL_PARAM ||
-            item.getParseStrategy() == SentinelGatewayConstants.PARAM_PARSE_STRATEGY_HEADER) {
-            if (StringUtil.isBlank(item.getFieldName())) {
-                return false;
-            }
+        // Check required field name for item types.
+        if (FIELD_REQUIRED_SET.contains(item.getParseStrategy()) && StringUtil.isBlank(item.getFieldName())) {
+            return false;
         }
         return StringUtil.isEmpty(item.getPattern()) || item.getMatchStrategy() >= 0;
     }
+
+    private static final Set<Integer> FIELD_REQUIRED_SET = new HashSet<>(
+        Arrays.asList(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_URL_PARAM,
+            SentinelGatewayConstants.PARAM_PARSE_STRATEGY_HEADER,
+            SentinelGatewayConstants.PARAM_PARSE_STRATEGY_COOKIE)
+    );
 
     private GatewayRuleManager() {}
 }

--- a/sentinel-adapter/sentinel-spring-cloud-gateway-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/sc/ServerWebExchangeItemParser.java
+++ b/sentinel-adapter/sentinel-spring-cloud-gateway-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/sc/ServerWebExchangeItemParser.java
@@ -16,9 +16,11 @@
 package com.alibaba.csp.sentinel.adapter.gateway.sc;
 
 import java.net.InetSocketAddress;
+import java.util.Optional;
 
 import com.alibaba.csp.sentinel.adapter.gateway.common.param.RequestItemParser;
 
+import org.springframework.http.HttpCookie;
 import org.springframework.web.server.ServerWebExchange;
 
 /**
@@ -49,5 +51,12 @@ public class ServerWebExchangeItemParser implements RequestItemParser<ServerWebE
     @Override
     public String getUrlParam(ServerWebExchange exchange, String paramName) {
         return exchange.getRequest().getQueryParams().getFirst(paramName);
+    }
+
+    @Override
+    public String getCookieValue(ServerWebExchange exchange, String cookieName) {
+        return Optional.ofNullable(exchange.getResponse().getCookies().getFirst(cookieName))
+            .map(HttpCookie::getValue)
+            .orElse(null);
     }
 }

--- a/sentinel-adapter/sentinel-zuul-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/zuul/RequestContextItemParser.java
+++ b/sentinel-adapter/sentinel-zuul-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/zuul/RequestContextItemParser.java
@@ -15,6 +15,8 @@
  */
 package com.alibaba.csp.sentinel.adapter.gateway.zuul;
 
+import javax.servlet.http.Cookie;
+
 import com.alibaba.csp.sentinel.adapter.gateway.common.param.RequestItemParser;
 
 import com.netflix.zuul.context.RequestContext;
@@ -43,5 +45,19 @@ public class RequestContextItemParser implements RequestItemParser<RequestContex
     @Override
     public String getUrlParam(RequestContext requestContext, String paramName) {
         return requestContext.getRequest().getParameter(paramName);
+    }
+
+    @Override
+    public String getCookieValue(RequestContext requestContext, String cookieName) {
+        Cookie[] cookies = requestContext.getRequest().getCookies();
+        if (cookies == null || cookieName == null) {
+            return null;
+        }
+        for (Cookie cookie : cookies) {
+            if (cookie != null && cookieName.equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Signed-off-by: Eric Zhao <sczyh16@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Support parsing cookie as request items in gateway flow control.

### Does this pull request fix one issue?

Resolves #813

### Describe how you did it

- Add `getCookieValue` method in `RequestItemParser` interface and update `GatewayParamParser` with the logic
- Add cookie parsing logic for Spring Cloud Gateway and Zuul 1.x in respective adapters

### Describe how to verify it

Run the test cases.

### Special notes for reviews

NONE