### PR TITLE
Fix unknown command issue in sentinel-transport-netty-http module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,11 @@
             </dependency>
             <dependency>
                 <groupId>com.alibaba.csp</groupId>
+                <artifactId>sentinel-transport-netty-http</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.alibaba.csp</groupId>
                 <artifactId>sentinel-transport-common</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/sentinel-transport/sentinel-transport-netty-http/pom.xml
+++ b/sentinel-transport/sentinel-transport-netty-http/pom.xml
@@ -51,5 +51,11 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-cluster-server-default</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/sentinel-transport/sentinel-transport-netty-http/pom.xml
+++ b/sentinel-transport/sentinel-transport-netty-http/pom.xml
@@ -51,11 +51,5 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.alibaba.csp</groupId>
-            <artifactId>sentinel-cluster-server-default</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/sentinel-transport/sentinel-transport-netty-http/src/main/java/com/alibaba/csp/sentinel/transport/command/netty/HttpServerHandler.java
+++ b/sentinel-transport/sentinel-transport-netty-http/src/main/java/com/alibaba/csp/sentinel/transport/command/netty/HttpServerHandler.java
@@ -221,11 +221,15 @@ public class HttpServerHandler extends SimpleChannelInboundHandler<Object> {
         if (StringUtil.isEmpty(uri)) {
             return "";
         }
-        String[] arr = uri.split("/");
-        if (arr.length < 2) {
-            return "";
+
+        // Remove the / of the uri as the target(command name)
+        // Usually the uri is start with /
+        int start = uri.indexOf('/');
+        if (start != -1) {
+            return uri.substring(start + 1);
         }
-        return arr[1];
+
+        return uri;
     }
 
     private CommandHandler getHandler(String commandName) {

--- a/sentinel-transport/sentinel-transport-netty-http/src/test/java/com/alibaba/csp/sentinel/transport/command/handler/MultipleSlashNameCommandTestHandler.java
+++ b/sentinel-transport/sentinel-transport-netty-http/src/test/java/com/alibaba/csp/sentinel/transport/command/handler/MultipleSlashNameCommandTestHandler.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.transport.command.handler;
+
+import com.alibaba.csp.sentinel.command.CommandHandler;
+import com.alibaba.csp.sentinel.command.CommandRequest;
+import com.alibaba.csp.sentinel.command.CommandResponse;
+import com.alibaba.csp.sentinel.command.annotation.CommandMapping;
+
+/**
+ * @author cdfive
+ */
+@CommandMapping(name = "aa/bb/cc", desc = "a test handler with multiple / in its name")
+public class MultipleSlashNameCommandTestHandler implements CommandHandler<String> {
+    @Override
+    public CommandResponse<String> handle(CommandRequest request) {
+        return CommandResponse.ofSuccess("MultipleSlashNameCommandTestHandler result");
+    }
+}

--- a/sentinel-transport/sentinel-transport-netty-http/src/test/java/com/alibaba/csp/sentinel/transport/command/netty/HttpServerInitializerTest.java
+++ b/sentinel-transport/sentinel-transport-netty-http/src/test/java/com/alibaba/csp/sentinel/transport/command/netty/HttpServerInitializerTest.java
@@ -30,30 +30,29 @@ import static org.mockito.Mockito.*;
  * Test cases for {@link HttpServerInitializer}.
  *
  * @author cdfive
- * @date 2018-12-19
  */
 public class HttpServerInitializerTest {
 
     @Test
     public void testInitChannel() throws Exception {
-        // mock Objects
+        // Mock Objects
         HttpServerInitializer httpServerInitializer = mock(HttpServerInitializer.class);
         SocketChannel socketChannel = mock(SocketChannel.class);
         ChannelPipeline channelPipeline = mock(ChannelPipeline.class);
 
-        // mock SocketChannel#pipeline() method
+        // Mock SocketChannel#pipeline() method
         when(socketChannel.pipeline()).thenReturn(channelPipeline);
 
         // HttpServerInitializer#initChannel(SocketChannel) call real method
         doCallRealMethod().when(httpServerInitializer).initChannel(socketChannel);
 
-        // start test for HttpServerInitializer#initChannel(SocketChannel)
+        // Start test for HttpServerInitializer#initChannel(SocketChannel)
         httpServerInitializer.initChannel(socketChannel);
 
-        // verify 4 times calling ChannelPipeline#addLast() method
+        // Verify 4 times calling ChannelPipeline#addLast() method
         verify(channelPipeline, times(4)).addLast(any(ChannelHandler.class));
 
-        // verify the order of calling ChannelPipeline#addLast() method
+        // Verify the order of calling ChannelPipeline#addLast() method
         InOrder inOrder = inOrder(channelPipeline);
         inOrder.verify(channelPipeline).addLast(any(HttpRequestDecoder.class));
         inOrder.verify(channelPipeline).addLast(any(HttpObjectAggregator.class));

--- a/sentinel-transport/sentinel-transport-netty-http/src/test/java/com/alibaba/csp/sentinel/transport/command/netty/HttpServerTest.java
+++ b/sentinel-transport/sentinel-transport-netty-http/src/test/java/com/alibaba/csp/sentinel/transport/command/netty/HttpServerTest.java
@@ -31,7 +31,6 @@ import static org.junit.Assert.*;
  * Test cases for {@link HttpServer}.
  *
  * @author cdfive
- * @date 2018-12-19
  */
 public class HttpServerTest {
 
@@ -39,20 +38,20 @@ public class HttpServerTest {
 
     @BeforeClass
     public static void beforeClass() {
-        // note: clear handlerMap first, as other test case may init HttpServer.handlerMap
+        // Note: clear handlerMap first, as other test case may init HttpServer.handlerMap
         // if not, run mvn test, the next assertEquals(0, HttpServer.handlerMap.size()) may fail
         HttpServer.handlerMap.clear();
 
-        // create new HttpServer
+        // Create new HttpServer
         httpServer = new HttpServer();
 
-        // no handler in handlerMap at first
+        // No handler in handlerMap at first
         assertEquals(0, HttpServer.handlerMap.size());
     }
 
     @Before
     public void before() {
-        // clear handlerMap every method call
+        // Clear handlerMap every method call
         HttpServer.handlerMap.clear();
     }
 
@@ -61,37 +60,37 @@ public class HttpServerTest {
         String commandName;
         CommandHandler handler;
 
-        // if commandName is null, no handler added in handlerMap
+        // If commandName is null, no handler added in handlerMap
         commandName = null;
         handler = new VersionCommandHandler();
         httpServer.registerCommand(commandName, handler);
         assertEquals(0, HttpServer.handlerMap.size());
 
-        // if commandName is "", no handler added in handlerMap
+        // If commandName is "", no handler added in handlerMap
         commandName = "";
         handler = new VersionCommandHandler();
         httpServer.registerCommand(commandName, handler);
         assertEquals(0, HttpServer.handlerMap.size());
 
-        // if handler is null, no handler added in handlerMap
+        // If handler is null, no handler added in handlerMap
         commandName = "version";
         handler = null;
         httpServer.registerCommand(commandName, handler);
         assertEquals(0, HttpServer.handlerMap.size());
 
-        // add one handler, commandName:version, handler:VersionCommandHandler
+        // Add one handler, commandName:version, handler:VersionCommandHandler
         commandName = "version";
         handler = new VersionCommandHandler();
         httpServer.registerCommand(commandName, handler);
         assertEquals(1, HttpServer.handlerMap.size());
 
-        // add the same name Handler, no handler added in handlerMap
+        // Add the same name Handler, no handler added in handlerMap
         commandName = "version";
         handler = new VersionCommandHandler();
         httpServer.registerCommand(commandName, handler);
         assertEquals(1, HttpServer.handlerMap.size());
 
-        // add another handler, commandName:basicInfo, handler:BasicInfoCommandHandler
+        // Add another handler, commandName:basicInfo, handler:BasicInfoCommandHandler
         commandName = "basicInfo";
         handler = new BasicInfoCommandHandler();
         httpServer.registerCommand(commandName, handler);
@@ -102,16 +101,16 @@ public class HttpServerTest {
     public void testRegisterCommands() {
         Map<String, CommandHandler> handlerMap = null;
 
-        // if handlerMap is null, no handler added in handlerMap
+        // If handlerMap is null, no handler added in handlerMap
         httpServer.registerCommands(handlerMap);
         assertEquals(0, HttpServer.handlerMap.size());
 
-        // add handler from CommandHandlerProvider
+        // Add handler from CommandHandlerProvider
         handlerMap = CommandHandlerProvider.getInstance().namedHandlers();
         httpServer.registerCommands(handlerMap);
-        // check same size
+        // Check same size
         assertEquals(handlerMap.size(), HttpServer.handlerMap.size());
-        // check not same reference
+        // Check not same reference
         assertTrue(handlerMap != HttpServer.handlerMap);
     }
 }

--- a/sentinel-transport/sentinel-transport-netty-http/src/test/resources/META-INF/services/com.alibaba.csp.sentinel.command.CommandHandler
+++ b/sentinel-transport/sentinel-transport-netty-http/src/test/resources/META-INF/services/com.alibaba.csp.sentinel.command.CommandHandler
@@ -1,0 +1,1 @@
+com.alibaba.csp.sentinel.transport.command.handler.MultipleSlashNameCommandTestHandler

--- a/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/heartbeat/SimpleHttpHeartbeatSender.java
+++ b/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/heartbeat/SimpleHttpHeartbeatSender.java
@@ -100,7 +100,7 @@ public class SimpleHttpHeartbeatSender implements HeartbeatSender {
         try {
             String ipsStr = TransportConfig.getConsoleServer();
             if (StringUtil.isEmpty(ipsStr)) {
-                RecordLog.warn("[NettyHttpHeartbeatSender] Dashboard server address not configured");
+                RecordLog.warn("[SimpleHttpHeartbeatSender] Dashboard server address not configured");
                 return newAddrs;
             }
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

If a command whose mapping path and command name has more than one "/", 
the CommandHandler can't be found in `sentinel-transport-netty-http`,
such as:
`/cluster/server/flowRules`
`FetchClusterFlowRulesCommandHandler`
will case:
Unknown command "cluster"

### Does this pull request fix one issue?

Fixes #810

### Describe how you did it

Modify the `String parseTarget(String uri)` method in `HttpServerHandler` class.
Don't use `uri.split("/")` to parse, but use `indexOf("/")` instead, to remove the 
/ in uri, just like the `parseRequest` method of `HttpEventTask` class in `sentinel-transport-simple-http` module.

### Describe how to verify it

Add 2 test cases in `HttpServerHandlerTest` class: 
`testFetchClusterFlowRulesCommandEmptyRule`
`testFetchClusterFlowRulesCommandSomeFlowRules`
In order to test, `sentinel-cluster-server-default` dependency is added with `test` scope.

Run demo in `sentinel-demo-cluster-server-alone` module,
change the `sentinel-transport-simple-http` to `sentinel-transport-netty-http`,
start the `ClusterServerDemo` and visit http://localhost:8719/cluster/server/flowRules

### Special notes for reviews
The previous test case which marked FIXME in `HttpServerHandlerTest` class has been fixed, I found a way that we can call `embeddedChannel.readOutbound()` looply to get the whole result.

Some comments in test class have been improved, such as upper case the first letter.

In pom.xml of parent module, `sentinel-transport-netty-http` is added in `<dependencyManagement>` , so that we needn't add version number when use it.