### PR TITLE
fix the method of dashboard invoking cluster api 

### DIFF
--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/client/SentinelApiClient.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/client/SentinelApiClient.java
@@ -116,7 +116,7 @@ public class SentinelApiClient {
 
     private CloseableHttpAsyncClient httpClient;
 
-    private static final SentinelVersion version160 = new SentinelVersion(1, 6, 0);
+    private static final SentinelVersion version161 = new SentinelVersion(1, 6, 1);
     
     @Autowired
     private AppManagement appManagement;
@@ -248,7 +248,7 @@ public class SentinelApiClient {
         boolean supportPost = StringUtil.isNotEmpty(app) && Optional.ofNullable(appManagement.getDetailApp(app))
                 .flatMap(e -> e.getMachine(ip, port))
                 .flatMap(m -> VersionUtils.parseVersion(m.getVersion())
-                    .map(v -> v.greaterOrEqual(version160)))
+                    .map(v -> v.greaterThan(version161)))
                 .orElse(false);
         if (!useHttpPost || !supportPost) {
             // Using GET in older versions, append parameters after url
@@ -599,7 +599,7 @@ public class SentinelApiClient {
         try {
             Map<String, String> params = new HashMap<>(1);
             params.put("data", JSON.toJSONString(config));
-            return executeCommand(app, ip, port, MODIFY_CLUSTER_CLIENT_CONFIG_PATH, params, false)
+            return executeCommand(app, ip, port, MODIFY_CLUSTER_CLIENT_CONFIG_PATH, params, true)
                 .thenCompose(e -> {
                     if (CommandConstants.MSG_SUCCESS.equals(e)) {
                         return CompletableFuture.completedFuture(null);
@@ -621,7 +621,7 @@ public class SentinelApiClient {
         try {
             Map<String, String> params = new HashMap<>(1);
             params.put("data", JSON.toJSONString(config));
-            return executeCommand(app, ip, port, MODIFY_CLUSTER_SERVER_FLOW_CONFIG_PATH, params, false)
+            return executeCommand(app, ip, port, MODIFY_CLUSTER_SERVER_FLOW_CONFIG_PATH, params, true)
                 .thenCompose(e -> {
                     if (CommandConstants.MSG_SUCCESS.equals(e)) {
                         return CompletableFuture.completedFuture(null);

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/client/SentinelApiClient.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/client/SentinelApiClient.java
@@ -599,7 +599,7 @@ public class SentinelApiClient {
         try {
             Map<String, String> params = new HashMap<>(1);
             params.put("data", JSON.toJSONString(config));
-            return executeCommand(app, ip, port, MODIFY_CLUSTER_CLIENT_CONFIG_PATH, params, true)
+            return executeCommand(app, ip, port, MODIFY_CLUSTER_CLIENT_CONFIG_PATH, params, false)
                 .thenCompose(e -> {
                     if (CommandConstants.MSG_SUCCESS.equals(e)) {
                         return CompletableFuture.completedFuture(null);
@@ -621,7 +621,7 @@ public class SentinelApiClient {
         try {
             Map<String, String> params = new HashMap<>(1);
             params.put("data", JSON.toJSONString(config));
-            return executeCommand(app, ip, port, MODIFY_CLUSTER_SERVER_FLOW_CONFIG_PATH, params, true)
+            return executeCommand(app, ip, port, MODIFY_CLUSTER_SERVER_FLOW_CONFIG_PATH, params, false)
                 .thenCompose(e -> {
                     if (CommandConstants.MSG_SUCCESS.equals(e)) {
                         return CompletableFuture.completedFuture(null);


### PR DESCRIPTION
### Describe what this PR does / why we need it
被限流服务使用集群限流嵌入模式（Embedded）时，在dashborad的集群流控->新增Token Server页面，点击保存按钮后调用被限流节点以下两个api时，应该用get请求，否则会报empty data错误
http://ip:port/cluster/client/modifyConfig
http://ip:port/cluster/server/modifyFlowConfig

被限流服务为springboot应用,使用如下依赖：
org.springframework.cloud
spring-cloud-starter-alibaba-sentinel
0.9.0.RELEASE

com.alibaba.csp
sentinel-cluster-client-default
1.6.1

com.alibaba.csp
sentinel-cluster-server-default
1.6.1