### PR TITLE
Add log to console support for common logs

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/ConsoleHandler.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/ConsoleHandler.java
@@ -43,15 +43,9 @@ class ConsoleHandler extends Handler {
      */
     private StreamHandler stderrHandler;
 
-    /**
-     * Current Handler according to the current publish log level.
-     */
-    private StreamHandler currentHandler;
-
     public ConsoleHandler() {
         this.stdoutHandler = new StreamHandler(System.out, new CspFormatter());
         this.stderrHandler = new StreamHandler(System.err, new CspFormatter());
-        this.currentHandler = this.stdoutHandler;
     }
 
     @Override
@@ -69,34 +63,23 @@ class ConsoleHandler extends Handler {
     @Override
     public void publish(LogRecord record) {
         if (record.getLevel().intValue() >= Level.WARNING.intValue()) {
-            currentHandler = stderrHandler;
+            stderrHandler.publish(record);
+            stderrHandler.flush();
         } else {
-            currentHandler = stdoutHandler;
+            stdoutHandler.publish(record);
+            stdoutHandler.flush();
         }
-
-        currentHandler.publish(record);
-        currentHandler.flush();
     }
 
     @Override
     public void flush() {
-        currentHandler.flush();
+        stdoutHandler.flush();
+        stderrHandler.flush();
     }
 
     @Override
     public void close() throws SecurityException {
-        currentHandler.close();
-    }
-
-    public StreamHandler getStdoutHandler() {
-        return stdoutHandler;
-    }
-
-    public StreamHandler getStderrHandler() {
-        return stderrHandler;
-    }
-
-    public StreamHandler getCurrentHandler() {
-        return currentHandler;
+        stdoutHandler.close();
+        stderrHandler.close();
     }
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/ConsoleHandler.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/ConsoleHandler.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.log;
+
+/**
+ * This <tt>Handler</tt> publishes log records to <tt>System.out</tt>.
+ *
+ * Extends from {@link java.util.logging.ConsoleHandler}, and set the OutputStream to System.out.
+ *
+ * To use this handler, add the following VM argument:
+ * <pre>
+ * -Dcsp.sentinel.log.type=console
+ * </pre>
+ *
+ * @author cdfive
+ */
+class ConsoleHandler extends java.util.logging.ConsoleHandler {
+
+    public ConsoleHandler() {
+        super();
+        setOutputStream(System.out);
+    }
+}

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/ConsoleHandler.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/ConsoleHandler.java
@@ -15,6 +15,8 @@
  */
 package com.alibaba.csp.sentinel.log;
 
+import java.util.logging.*;
+
 /**
  * This <tt>Handler</tt> publishes log records to <tt>System.out</tt>.
  *
@@ -27,10 +29,35 @@ package com.alibaba.csp.sentinel.log;
  *
  * @author cdfive
  */
-class ConsoleHandler extends java.util.logging.ConsoleHandler {
+class ConsoleHandler extends StreamHandler {
 
     public ConsoleHandler() {
         super();
         setOutputStream(System.out);
+    }
+
+    /**
+     * Publish a <tt>LogRecord</tt>.
+     * <p>
+     * The logging request was made initially to a <tt>Logger</tt> object,
+     * which initialized the <tt>LogRecord</tt> and forwarded it here.
+     * <p>
+     * @param  record  description of the log event. A null record is
+     *                 silently ignored and is not published
+     */
+    @Override
+    public void publish(LogRecord record) {
+        super.publish(record);
+        flush();
+    }
+
+    /**
+     * Override <tt>StreamHandler.close</tt> to do a flush but not
+     * to close the output stream.  That is, we do <b>not</b>
+     * close <tt>System.err</tt>.
+     */
+    @Override
+    public void close() {
+        flush();
     }
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/ConsoleHandler.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/ConsoleHandler.java
@@ -26,7 +26,7 @@ import java.util.logging.*;
  *
  * To use this handler, add the following VM argument:
  * <pre>
- * -Dcsp.sentinel.log.type=console
+ * -Dcsp.sentinel.log.output.type=console
  * </pre>
  *
  * @author cdfive

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/CspFormatter.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/CspFormatter.java
@@ -28,7 +28,7 @@ class CspFormatter extends Formatter {
     private final ThreadLocal<SimpleDateFormat> dateFormatThreadLocal = new ThreadLocal<SimpleDateFormat>() {
         @Override
         public SimpleDateFormat initialValue() {
-            return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+            return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
         }
     };
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/CspFormatter.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/CspFormatter.java
@@ -37,6 +37,7 @@ class CspFormatter extends Formatter {
         final DateFormat df = dateFormatThreadLocal.get();
         StringBuilder builder = new StringBuilder(1000);
         builder.append(df.format(new Date(record.getMillis()))).append(" ");
+        builder.append(record.getLevel().getName()).append(" ");
         builder.append(formatMessage(record));
 
         String throwable = "";

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/LogBase.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/LogBase.java
@@ -69,29 +69,27 @@ public class LogBase {
             logType = LOG_TYPE_FILE;
         }
 
-        if (LOG_TYPE_FILE.equals(logType)) {
-            // first use -D, then use user home.
-            String logDir = System.getProperty(LOG_DIR);
+        // first use -D, then use user home.
+        String logDir = System.getProperty(LOG_DIR);
 
-            if (logDir == null || logDir.isEmpty()) {
-                logDir = System.getProperty(USER_HOME);
-                logDir = addSeparator(logDir) + DIR_NAME + File.separator;
-            }
-            logDir = addSeparator(logDir);
-            File dir = new File(logDir);
-            if (!dir.exists()) {
-                if (!dir.mkdirs()) {
-                    System.err.println("ERROR: create log base dir error: " + logDir);
-                }
-            }
-            // logBaseDir must end with File.separator
-            logBaseDir = logDir;
-            System.out.println("INFO: log base dir is: " + logBaseDir);
-
-            String usePid = System.getProperty(LOG_NAME_USE_PID, "");
-            logNameUsePid = "true".equalsIgnoreCase(usePid);
-            System.out.println("INFO: log name use pid is: " + logNameUsePid);
+        if (logDir == null || logDir.isEmpty()) {
+            logDir = System.getProperty(USER_HOME);
+            logDir = addSeparator(logDir) + DIR_NAME + File.separator;
         }
+        logDir = addSeparator(logDir);
+        File dir = new File(logDir);
+        if (!dir.exists()) {
+            if (!dir.mkdirs()) {
+                System.err.println("ERROR: create log base dir error: " + logDir);
+            }
+        }
+        // logBaseDir must end with File.separator
+        logBaseDir = logDir;
+        System.out.println("INFO: log base dir is: " + logBaseDir);
+
+        String usePid = System.getProperty(LOG_NAME_USE_PID, "");
+        logNameUsePid = "true".equalsIgnoreCase(usePid);
+        System.out.println("INFO: log name use pid is: " + logNameUsePid);
     }
 
     /**

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/LogBase.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/LogBase.java
@@ -65,7 +65,7 @@ public class LogBase {
         // By default, log to file
         if (StringUtil.isBlank(logType)) {
             logType = LOG_TYPE_FILE;
-        } else if (LOG_TYPE_FILE.equals(logType) && LOG_TYPE_CONSOLE.equals(logType)) {
+        } else if (!LOG_TYPE_FILE.equalsIgnoreCase(logType) && !LOG_TYPE_CONSOLE.equalsIgnoreCase(logType)) {
             logType = LOG_TYPE_FILE;
         }
 
@@ -101,10 +101,6 @@ public class LogBase {
      */
     public static boolean isLogNameUsePid() {
         return logNameUsePid;
-    }
-
-    public static boolean isLogToConsole() {
-        return LOG_TYPE_CONSOLE.endsWith(logType);
     }
 
     private static String addSeparator(String logDir) {

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/LogBase.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/LogBase.java
@@ -36,17 +36,20 @@ public class LogBase {
 
     public static final String LOG_CHARSET = "utf-8";
 
-    public static final String LOG_TYPE_FILE = "file";
-    public static final String LOG_TYPE_CONSOLE = "console";
+    // Output biz log(RecordLog,CommandCenterLog) to file
+    public static final String LOG_OUTPUT_TYPE_FILE = "file";
+    // Output biz log(RecordLog,CommandCenterLog) to console
+    public static final String LOG_OUTPUT_TYPE_CONSOLE = "console";
 
     private static final String DIR_NAME = "logs" + File.separator + "csp";
     private static final String USER_HOME = "user.home";
 
-    public static final String LOG_TYPE = "csp.sentinel.log.type";
+    // Output type of biz log(RecordLog,CommandCenterLog)
+    public static final String LOG_OUTPUT_TYPE = "csp.sentinel.log.output.type";
     public static final String LOG_DIR = "csp.sentinel.log.dir";
     public static final String LOG_NAME_USE_PID = "csp.sentinel.log.use.pid";
 
-    private static String logType;
+    private static String logOutputType;
     private static String logBaseDir;
     private static boolean logNameUsePid = false;
 
@@ -60,13 +63,13 @@ public class LogBase {
     }
 
     private static void init() {
-        logType = System.getProperty(LOG_TYPE);
+        logOutputType = System.getProperty(LOG_OUTPUT_TYPE);
 
-        // By default, log to file
-        if (StringUtil.isBlank(logType)) {
-            logType = LOG_TYPE_FILE;
-        } else if (!LOG_TYPE_FILE.equalsIgnoreCase(logType) && !LOG_TYPE_CONSOLE.equalsIgnoreCase(logType)) {
-            logType = LOG_TYPE_FILE;
+        // By default, output biz log(RecordLog,CommandCenterLog) to file
+        if (StringUtil.isBlank(logOutputType)) {
+            logOutputType = LOG_OUTPUT_TYPE_FILE;
+        } else if (!LOG_OUTPUT_TYPE_FILE.equalsIgnoreCase(logOutputType) && !LOG_OUTPUT_TYPE_CONSOLE.equalsIgnoreCase(logOutputType)) {
+            logOutputType = LOG_OUTPUT_TYPE_FILE;
         }
 
         // first use -D, then use user home.
@@ -142,9 +145,9 @@ public class LogBase {
 
         Handler handler = null;
 
-        // Create handler according to logType, set formatter to CspFormatter, set encoding to LOG_CHARSET
-        switch (logType) {
-            case LOG_TYPE_FILE:
+        // Create handler according to logOutputType, set formatter to CspFormatter, set encoding to LOG_CHARSET
+        switch (logOutputType) {
+            case LOG_OUTPUT_TYPE_FILE:
                 String fileName = LogBase.getLogBaseDir() + logName;
                 if (isLogNameUsePid()) {
                     fileName += ".pid" + PidUtil.getPid();
@@ -157,7 +160,7 @@ public class LogBase {
                     e.printStackTrace();
                 }
                 break;
-            case LOG_TYPE_CONSOLE:
+            case LOG_OUTPUT_TYPE_CONSOLE:
                 try {
                     handler = new ConsoleHandler();
                     handler.setFormatter(formatter);

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/log/ConsoleHandlerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/log/ConsoleHandlerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.log;
+
+import org.junit.Test;
+
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test cases for {@link ConsoleHandler}.
+ *
+ * @author cdfive
+ */
+public class ConsoleHandlerTest {
+
+    @Test
+    public void testPublish() {
+        ConsoleHandler consoleHandler = new ConsoleHandler();
+
+        LogRecord logRecord = mock(LogRecord.class);
+        when(logRecord.getMillis()).thenReturn(System.currentTimeMillis());
+
+        when(logRecord.getLevel()).thenReturn(Level.INFO);
+        when(logRecord.getMessage()).thenReturn("test info message");
+        consoleHandler.publish(logRecord);
+        assertEquals(consoleHandler.getStdoutHandler(), consoleHandler.getCurrentHandler());
+
+        when(logRecord.getLevel()).thenReturn(Level.WARNING);
+        when(logRecord.getMessage()).thenReturn("test warning message");
+        consoleHandler.publish(logRecord);
+        assertEquals(consoleHandler.getStderrHandler(), consoleHandler.getCurrentHandler());
+
+        // Default log level is INFO, to view FINE log message, add following config in $JAVA_HOME/jre/lib/logging.properties
+        // java.util.logging.StreamHandler.level=FINE
+        when(logRecord.getLevel()).thenReturn(Level.FINE);
+        when(logRecord.getMessage()).thenReturn("test fine message");
+        consoleHandler.publish(logRecord);
+        assertEquals(consoleHandler.getStdoutHandler(), consoleHandler.getCurrentHandler());
+
+        when(logRecord.getLevel()).thenReturn(Level.SEVERE);
+        when(logRecord.getMessage()).thenReturn("test severe message");
+        consoleHandler.publish(logRecord);
+        assertEquals(consoleHandler.getStderrHandler(), consoleHandler.getCurrentHandler());
+    }
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

In container environment, user may desire output log to stdout so that the log can be collected by ELK/EFK.

This PR simply add a option(`csp.sentinel.log.type`) to support log to console for common log(`RecordLog`,`CommandCenterLog`) which use log handler mechanism.

By default,  log to file as previous.

To make it log to console(stdout), add the VM argument:
`-Dcsp.sentinel.log.type=console`

For other two kinds of log:
`metrics log` and `sentinel-block.log`, and abstract **logging SPI** interface we may need more discussions.

### Does this pull request fix one issue?

Fixes #795 

### Describe how you did it

Add `ConsoleHandler` class which extends from `java.util.logging.ConsoleHandler`,
and set the OutputStream to System.out

Modify `LogBase` class, add `csp.sentinel.log.type` for choose log to **file** or **console**.

### Describe how to verify it

Add `-Dcsp.sentinel.log.type=console`, then start sentinel-dashboard and view the log in console.

### Special notes for reviews

The **level** of log message is added in `CspFormatter` class, since I think it maybe useful for user who view the log message.
