### PR TITLE
Add support for request item pattern matching in API gateway flow control

### DIFF
--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/SentinelGatewayConstants.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/SentinelGatewayConstants.java
@@ -32,15 +32,20 @@ public final class SentinelGatewayConstants {
     public static final int PARAM_PARSE_STRATEGY_URL_PARAM = 3;
     public static final int PARAM_PARSE_STRATEGY_COOKIE = 4;
 
+    public static final int URL_MATCH_STRATEGY_EXACT = 0;
+    public static final int URL_MATCH_STRATEGY_PREFIX = 1;
+    public static final int URL_MATCH_STRATEGY_REGEX = 2;
+
     public static final int PARAM_MATCH_STRATEGY_EXACT = 0;
     public static final int PARAM_MATCH_STRATEGY_PREFIX = 1;
     public static final int PARAM_MATCH_STRATEGY_REGEX = 2;
+    public static final int PARAM_MATCH_STRATEGY_CONTAINS = 3;
 
     public static final String GATEWAY_CONTEXT_DEFAULT = "sentinel_gateway_context_default";
     public static final String GATEWAY_CONTEXT_PREFIX = "sentinel_gateway_context$$";
     public static final String GATEWAY_CONTEXT_ROUTE_PREFIX = "sentinel_gateway_context$$route$$";
 
-    public static final String GATEWAY_NOT_MATCH_PARAM = "$$not_match";
+    public static final String GATEWAY_NOT_MATCH_PARAM = "$NM";
     public static final String GATEWAY_DEFAULT_PARAM = "$D";
 
     private SentinelGatewayConstants() {}

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/api/ApiPathPredicateItem.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/api/ApiPathPredicateItem.java
@@ -17,6 +17,8 @@ package com.alibaba.csp.sentinel.adapter.gateway.common.api;
 
 import java.util.Objects;
 
+import com.alibaba.csp.sentinel.adapter.gateway.common.SentinelGatewayConstants;
+
 /**
  * @author Eric Zhao
  * @since 1.6.0
@@ -24,7 +26,7 @@ import java.util.Objects;
 public class ApiPathPredicateItem implements ApiPredicateItem {
 
     private String pattern;
-    private int matchStrategy;
+    private int matchStrategy = SentinelGatewayConstants.URL_MATCH_STRATEGY_EXACT;
 
     public ApiPathPredicateItem setPattern(String pattern) {
         this.pattern = pattern;

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/GatewayParamParser.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/GatewayParamParser.java
@@ -17,6 +17,7 @@ package com.alibaba.csp.sentinel.adapter.gateway.common.param;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import com.alibaba.csp.sentinel.adapter.gateway.common.SentinelGatewayConstants;
 import com.alibaba.csp.sentinel.adapter.gateway.common.rule.GatewayFlowRule;
@@ -153,13 +154,22 @@ public class GatewayParamParser<T> {
     }
 
     private String parseWithMatchStrategyInternal(int matchStrategy, String value, String pattern) {
-        // TODO: implement here.
         if (value == null) {
             return null;
         }
-        if (matchStrategy == SentinelGatewayConstants.PARAM_MATCH_STRATEGY_REGEX) {
-            return value;
+        switch (matchStrategy) {
+            case SentinelGatewayConstants.PARAM_MATCH_STRATEGY_EXACT:
+                return value.equals(pattern) ? value : SentinelGatewayConstants.GATEWAY_NOT_MATCH_PARAM;
+            case SentinelGatewayConstants.PARAM_MATCH_STRATEGY_CONTAINS:
+                return value.contains(pattern) ? value : SentinelGatewayConstants.GATEWAY_NOT_MATCH_PARAM;
+            case SentinelGatewayConstants.PARAM_MATCH_STRATEGY_REGEX:
+                Pattern regex = GatewayRegexCache.getRegexPattern(pattern);
+                if (regex == null) {
+                    return value;
+                }
+                return regex.matcher(value).matches() ? value : SentinelGatewayConstants.GATEWAY_NOT_MATCH_PARAM;
+            default:
+                return value;
         }
-        return value;
     }
 }

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/GatewayRegexCache.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/GatewayRegexCache.java
@@ -23,7 +23,7 @@ import com.alibaba.csp.sentinel.log.RecordLog;
 
 /**
  * @author Eric Zhao
- * @since 1.7.0
+ * @since 1.6.2
  */
 public final class GatewayRegexCache {
 

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/GatewayRegexCache.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/GatewayRegexCache.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.gateway.common.param;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+
+import com.alibaba.csp.sentinel.log.RecordLog;
+
+/**
+ * @author Eric Zhao
+ * @since 1.7.0
+ */
+public final class GatewayRegexCache {
+
+    private static final Map<String, Pattern> REGEX_CACHE = new ConcurrentHashMap<>();
+
+    public static Pattern getRegexPattern(String pattern) {
+        if (pattern == null) {
+            return null;
+        }
+        return REGEX_CACHE.get(pattern);
+    }
+
+    public static boolean addRegexPattern(String pattern) {
+        if (pattern == null) {
+            return false;
+        }
+        try {
+            Pattern regex = Pattern.compile(pattern);
+            REGEX_CACHE.put(pattern, regex);
+            return true;
+        } catch (Exception ex) {
+            RecordLog.warn("[GatewayRegexCache] Failed to compile the regex: " + pattern, ex);
+            return false;
+        }
+    }
+
+    public static void clear() {
+        REGEX_CACHE.clear();
+    }
+
+    private GatewayRegexCache() {}
+}

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/rule/GatewayRuleConverter.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/rule/GatewayRuleConverter.java
@@ -15,7 +15,9 @@
  */
 package com.alibaba.csp.sentinel.adapter.gateway.common.rule;
 
+import com.alibaba.csp.sentinel.adapter.gateway.common.SentinelGatewayConstants;
 import com.alibaba.csp.sentinel.slots.block.flow.FlowRule;
+import com.alibaba.csp.sentinel.slots.block.flow.param.ParamFlowItem;
 import com.alibaba.csp.sentinel.slots.block.flow.param.ParamFlowRule;
 
 /**
@@ -30,6 +32,18 @@ final class GatewayRuleConverter {
             .setCount(rule.getCount())
             .setGrade(rule.getGrade())
             .setMaxQueueingTimeMs(rule.getMaxQueueingTimeoutMs());
+    }
+
+    static ParamFlowItem generateNonMatchPassParamItem() {
+        return new ParamFlowItem().setClassType(String.class.getName())
+            .setCount(1000_0000)
+            .setObject(SentinelGatewayConstants.GATEWAY_NOT_MATCH_PARAM);
+    }
+
+    static ParamFlowItem generateNonMatchBlockParamItem() {
+        return new ParamFlowItem().setClassType(String.class.getName())
+            .setCount(0)
+            .setObject(SentinelGatewayConstants.GATEWAY_NOT_MATCH_PARAM);
     }
 
     static ParamFlowRule applyNonParamToParamRule(/*@Valid*/ GatewayFlowRule gatewayRule, int idx) {
@@ -63,7 +77,11 @@ final class GatewayRuleConverter {
         GatewayParamFlowItem gatewayItem = gatewayRule.getParamItem();
         // Apply the current idx to gateway rule item.
         gatewayItem.setIndex(idx);
-        // TODO: implement for pattern-based parameters.
+        // Apply for pattern-based parameters.
+        String valuePattern = gatewayItem.getPattern();
+        if (valuePattern != null) {
+            paramRule.getParamFlowItemList().add(generateNonMatchPassParamItem());
+        }
         return paramRule;
     }
 

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/GatewayRegexCacheTest.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/GatewayRegexCacheTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.gateway.common.param;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Eric Zhao
+ */
+public class GatewayRegexCacheTest {
+
+    @Before
+    public void setUp() {
+        GatewayRegexCache.clear();
+    }
+
+    @After
+    public void tearDown() {
+        GatewayRegexCache.clear();
+    }
+
+    @Test
+    public void testAddAndGetRegexPattern() {
+        // Test for invalid pattern.
+        assertThat(GatewayRegexCache.addRegexPattern("\\")).isFalse();
+        assertThat(GatewayRegexCache.addRegexPattern(null)).isFalse();
+        // Test for good pattern.
+        String goodPattern = "\\d+";
+        assertThat(GatewayRegexCache.addRegexPattern(goodPattern)).isTrue();
+        assertThat(GatewayRegexCache.getRegexPattern(goodPattern)).isNotNull();
+    }
+}

--- a/sentinel-adapter/sentinel-spring-cloud-gateway-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/sc/api/matcher/WebExchangeApiMatcher.java
+++ b/sentinel-adapter/sentinel-spring-cloud-gateway-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/sc/api/matcher/WebExchangeApiMatcher.java
@@ -59,9 +59,9 @@ public class WebExchangeApiMatcher extends AbstractApiMatcher<ServerWebExchange>
             return Optional.empty();
         }
         switch (item.getMatchStrategy()) {
-            case SentinelGatewayConstants.PARAM_MATCH_STRATEGY_REGEX:
+            case SentinelGatewayConstants.URL_MATCH_STRATEGY_REGEX:
                 return Optional.of(RouteMatchers.regexPath(pattern));
-            case SentinelGatewayConstants.PARAM_MATCH_STRATEGY_PREFIX:
+            case SentinelGatewayConstants.URL_MATCH_STRATEGY_PREFIX:
                 return Optional.of(RouteMatchers.antPath(pattern));
             default:
                 return Optional.of(RouteMatchers.exactPath(pattern));

--- a/sentinel-adapter/sentinel-spring-cloud-gateway-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/sc/SentinelGatewayFilterTest.java
+++ b/sentinel-adapter/sentinel-spring-cloud-gateway-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/sc/SentinelGatewayFilterTest.java
@@ -44,14 +44,14 @@ public class SentinelGatewayFilterTest {
         ApiDefinition api1 = new ApiDefinition(apiName1)
             .setPredicateItems(Collections.singleton(
                 new ApiPathPredicateItem().setPattern("/product/**")
-                    .setMatchStrategy(SentinelGatewayConstants.PARAM_MATCH_STRATEGY_PREFIX)
+                    .setMatchStrategy(SentinelGatewayConstants.URL_MATCH_STRATEGY_PREFIX)
             ));
         String apiName2 = "another_customized_api";
         ApiDefinition api2 = new ApiDefinition(apiName2)
             .setPredicateItems(new HashSet<ApiPredicateItem>() {{
                 add(new ApiPathPredicateItem().setPattern("/something"));
                 add(new ApiPathPredicateItem().setPattern("/other/**")
-                    .setMatchStrategy(SentinelGatewayConstants.PARAM_MATCH_STRATEGY_PREFIX));
+                    .setMatchStrategy(SentinelGatewayConstants.URL_MATCH_STRATEGY_PREFIX));
             }});
         apiDefinitions.add(api1);
         apiDefinitions.add(api2);

--- a/sentinel-adapter/sentinel-zuul-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/zuul/api/matcher/RequestContextApiMatcher.java
+++ b/sentinel-adapter/sentinel-zuul-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/zuul/api/matcher/RequestContextApiMatcher.java
@@ -61,9 +61,9 @@ public class RequestContextApiMatcher extends AbstractApiMatcher<RequestContext>
             return null;
         }
         switch (item.getMatchStrategy()) {
-            case SentinelGatewayConstants.PARAM_MATCH_STRATEGY_REGEX:
+            case SentinelGatewayConstants.URL_MATCH_STRATEGY_REGEX:
                 return ZuulRouteMatchers.regexPath(pattern);
-            case SentinelGatewayConstants.PARAM_MATCH_STRATEGY_PREFIX:
+            case SentinelGatewayConstants.URL_MATCH_STRATEGY_PREFIX:
                 return ZuulRouteMatchers.antPath(pattern);
             default:
                 return ZuulRouteMatchers.exactPath(pattern);

--- a/sentinel-demo/sentinel-demo-spring-cloud-gateway/src/main/java/com/alibaba/csp/sentinel/demo/spring/sc/gateway/GatewayConfiguration.java
+++ b/sentinel-demo/sentinel-demo-spring-cloud-gateway/src/main/java/com/alibaba/csp/sentinel/demo/spring/sc/gateway/GatewayConfiguration.java
@@ -83,12 +83,12 @@ public class GatewayConfiguration {
             .setPredicateItems(new HashSet<ApiPredicateItem>() {{
                 add(new ApiPathPredicateItem().setPattern("/ahas"));
                 add(new ApiPathPredicateItem().setPattern("/product/**")
-                    .setMatchStrategy(SentinelGatewayConstants.PARAM_MATCH_STRATEGY_PREFIX));
+                    .setMatchStrategy(SentinelGatewayConstants.URL_MATCH_STRATEGY_PREFIX));
             }});
         ApiDefinition api2 = new ApiDefinition("another_customized_api")
             .setPredicateItems(new HashSet<ApiPredicateItem>() {{
                 add(new ApiPathPredicateItem().setPattern("/**")
-                    .setMatchStrategy(SentinelGatewayConstants.PARAM_MATCH_STRATEGY_PREFIX));
+                    .setMatchStrategy(SentinelGatewayConstants.URL_MATCH_STRATEGY_PREFIX));
             }});
         definitions.add(api1);
         definitions.add(api2);
@@ -125,6 +125,16 @@ public class GatewayConfiguration {
             .setParamItem(new GatewayParamFlowItem()
                 .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_URL_PARAM)
                 .setFieldName("pa")
+            )
+        );
+        rules.add(new GatewayFlowRule("httpbin_route")
+            .setCount(2)
+            .setIntervalSec(30)
+            .setParamItem(new GatewayParamFlowItem()
+                .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_URL_PARAM)
+                .setFieldName("type")
+                .setPattern("warn")
+                .setMatchStrategy(SentinelGatewayConstants.PARAM_MATCH_STRATEGY_CONTAINS)
             )
         );
 

--- a/sentinel-demo/sentinel-demo-zuul-gateway/src/main/java/com/alibaba/csp/sentinel/demo/zuul/gateway/GatewayRuleConfig.java
+++ b/sentinel-demo/sentinel-demo-zuul-gateway/src/main/java/com/alibaba/csp/sentinel/demo/zuul/gateway/GatewayRuleConfig.java
@@ -52,12 +52,12 @@ public class GatewayRuleConfig {
             .setPredicateItems(new HashSet<ApiPredicateItem>() {{
                 add(new ApiPathPredicateItem().setPattern("/ahas"));
                 add(new ApiPathPredicateItem().setPattern("/aliyun_product/**")
-                    .setMatchStrategy(SentinelGatewayConstants.PARAM_MATCH_STRATEGY_PREFIX));
+                    .setMatchStrategy(SentinelGatewayConstants.URL_MATCH_STRATEGY_PREFIX));
             }});
         ApiDefinition api2 = new ApiDefinition("another_customized_api")
             .setPredicateItems(new HashSet<ApiPredicateItem>() {{
                 add(new ApiPathPredicateItem().setPattern("/**")
-                    .setMatchStrategy(SentinelGatewayConstants.PARAM_MATCH_STRATEGY_PREFIX));
+                    .setMatchStrategy(SentinelGatewayConstants.URL_MATCH_STRATEGY_PREFIX));
             }});
         definitions.add(api1);
         definitions.add(api2);


### PR DESCRIPTION
Signed-off-by: Eric Zhao <sczyh16@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Support pattern matching for request items in API gateway flow control.

### Does this pull request fix one issue?

Resolves #839

### Describe how you did it

- Update the `GatewayParamParser` to support matching the request item.
  - Till now three matching strategies has been supported: *exact*, *contains* and *regex*.
  - The items that are not matched will be unified as a constant parameter (`SentinelGatewayConstants.GATEWAY_NOT_MATCH_PARAM`)
- Update the internal logic of converting gateway rules to parameter flow rules. The unified mismatched parameters (`SentinelGatewayConstants.GATEWAY_NOT_MATCH_PARAM`) will be configured as an exception item with a large threshold (indicating always pass).
- Add a `GatewayRegexCache` to cache the compiled regex for performance.
- Constant rename: separate URL matching strategy from parameter matching strategy

### Describe how to verify it

Run the test cases and demo.

### Special notes for reviews

NONE