### PR TITLE
Fix the numeric overflow bug of ping response data in the cluster module

### DIFF
--- a/sentinel-cluster/sentinel-cluster-client-default/pom.xml
+++ b/sentinel-cluster/sentinel-cluster-client-default/pom.xml
@@ -53,5 +53,10 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/sentinel-cluster/sentinel-cluster-client-default/src/test/java/com/alibaba/csp/sentinel/cluster/client/codec/data/PingResponseDataDecoderTest.java
+++ b/sentinel-cluster/sentinel-cluster-client-default/src/test/java/com/alibaba/csp/sentinel/cluster/client/codec/data/PingResponseDataDecoderTest.java
@@ -15,26 +15,30 @@
  */
 package com.alibaba.csp.sentinel.cluster.client.codec.data;
 
-import com.alibaba.csp.sentinel.cluster.codec.EntityDecoder;
-
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Eric Zhao
- * @since 1.4.0
  */
-public class PingResponseDataDecoder implements EntityDecoder<ByteBuf, Integer> {
+public class PingResponseDataDecoderTest {
 
-    @Override
-    public Integer decode(ByteBuf source) {
-        int size = source.readableBytes();
-        if (size == 1) {
-            // Compatible with old version (< 1.7.0).
-            return (int) source.readByte();
-        }
-        if (size >= 4) {
-            return source.readInt();
-        }
-        return -1;
+    @Test
+    public void testDecodePingResponseData() {
+        ByteBuf buf = Unpooled.buffer();
+        PingResponseDataDecoder decoder = new PingResponseDataDecoder();
+
+        int big = Integer.MAX_VALUE;
+        buf.writeInt(big);
+        assertThat(decoder.decode(buf)).isEqualTo(big);
+
+        byte small = 12;
+        buf.writeByte(small);
+        assertThat(decoder.decode(buf)).isEqualTo(small);
+
+        buf.release();
     }
 }

--- a/sentinel-cluster/sentinel-cluster-server-default/pom.xml
+++ b/sentinel-cluster/sentinel-cluster-server-default/pom.xml
@@ -52,5 +52,10 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/codec/data/PingResponseDataWriter.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/codec/data/PingResponseDataWriter.java
@@ -31,6 +31,6 @@ public class PingResponseDataWriter implements EntityWriter<Integer, ByteBuf> {
         if (entity == null || target == null) {
             return;
         }
-        target.writeByte(entity);
+        target.writeInt(entity);
     }
 }

--- a/sentinel-cluster/sentinel-cluster-server-default/src/test/java/com/alibaba/csp/sentinel/cluster/server/codec/data/PingResponseDataWriterTest.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/test/java/com/alibaba/csp/sentinel/cluster/server/codec/data/PingResponseDataWriterTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.cluster.server.codec.data;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test cases for {@link PingResponseDataWriter}.
+ *
+ * @author Eric Zhao
+ */
+public class PingResponseDataWriterTest {
+
+    @Test
+    public void testWritePingResponseAndParse() {
+        ByteBuf buf = Unpooled.buffer();
+        PingResponseDataWriter writer = new PingResponseDataWriter();
+
+        int small = 120;
+        writer.writeTo(small, buf);
+        assertThat(buf.readableBytes()).isGreaterThanOrEqualTo(4);
+        assertThat(buf.readInt()).isEqualTo(small);
+
+        int big = Integer.MAX_VALUE;
+        writer.writeTo(big, buf);
+        assertThat(buf.readableBytes()).isGreaterThanOrEqualTo(4);
+        assertThat(buf.readInt()).isEqualTo(big);
+
+        buf.release();
+    }
+}


### PR DESCRIPTION
Signed-off-by: Eric Zhao <sczyh16@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Fix the bug that the ping response data (of `byte` type) in the default cluster transport implementation might overflow.

### Does this pull request fix one issue?

Fixes #843

### Describe how you did it

Change type of cluster ping data response from `byte` to `int`. Both `PingResponseDataWriter` and `PingResponseDataDecoder` have been modified.

The `PingResponseDataDecoder` will be compatible with old versions:

- For old token servers and new clients, the client will parse the ping response as `byte`.
- Old clients will be compatible with token servers, but overflow will still happen.

### Describe how to verify it

Run the test cases.

### Special notes for reviews

NONE