### PR TITLE
Add batch request support for transport of cluster flow control

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,23 @@
             </dependency>
             <dependency>
                 <groupId>com.alibaba.csp</groupId>
+                <artifactId>sentinel-cluster-client-default</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.alibaba.csp</groupId>
+                <artifactId>sentinel-cluster-server-default</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.alibaba.csp</groupId>
                 <artifactId>sentinel-adapter</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.alibaba.csp</groupId>
+                <artifactId>sentinel-api-gateway-adapter-common</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/ClientConstants.java
+++ b/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/ClientConstants.java
@@ -21,10 +21,6 @@ package com.alibaba.csp.sentinel.cluster.client;
  */
 public final class ClientConstants {
 
-    public static final int TYPE_PING = 0;
-    public static final int TYPE_FLOW = 1;
-    public static final int TYPE_PARAM_FLOW = 2;
-
     public static final int CLIENT_STATUS_OFF = 0;
     public static final int CLIENT_STATUS_PENDING = 1;
     public static final int CLIENT_STATUS_STARTED = 2;

--- a/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/codec/data/BatchFlowRequestDataWriter.java
+++ b/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/codec/data/BatchFlowRequestDataWriter.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.cluster.client.codec.data;
+
+import com.alibaba.csp.sentinel.cluster.codec.EntityWriter;
+import com.alibaba.csp.sentinel.cluster.request.data.BatchFlowRequestData;
+import com.alibaba.csp.sentinel.log.RecordLog;
+
+import io.netty.buffer.ByteBuf;
+
+/**
+ * <p>The encoding format of the batch request:</p>
+ * <pre>
+ * +----------------+---------------+------------------+
+ * |  Flow ID Set   | Count(4 byte) | PriorityFlag (1) |
+ * +----------------+---------------+------------------+
+ * </pre>
+ * <p>The encoding format of flow ID set:</p>
+ * <pre>
+ * +----------------+-----------------------------+
+ * | Amount(4 byte) | repeated: FlowId(8 byte)... |
+ * +----------------+-----------------------------+
+ * </pre>
+ *
+ * @author Eric Zhao
+ * @since 1.7.0
+ */
+public class BatchFlowRequestDataWriter implements EntityWriter<BatchFlowRequestData, ByteBuf> {
+
+    @Override
+    public void writeTo(BatchFlowRequestData entity, ByteBuf target) {
+        if (entity.getFlowIds() == null || entity.getFlowIds().isEmpty()) {
+            RecordLog.warn("[BatchFlowRequestDataWriter] Flow ID set is empty, ignoring the request");
+            return;
+        }
+        int ruleAmount = entity.getFlowIds().size();
+        // Write the amount.
+        target.writeInt(ruleAmount);
+        for (Long id : entity.getFlowIds()) {
+            target.writeLong(id);
+        }
+
+        target.writeInt(entity.getCount());
+        target.writeBoolean(entity.isPriority());
+    }
+}

--- a/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/codec/data/BatchFlowResponseDataDecoder.java
+++ b/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/codec/data/BatchFlowResponseDataDecoder.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.cluster.client.codec.data;
+
+import com.alibaba.csp.sentinel.cluster.codec.EntityDecoder;
+import com.alibaba.csp.sentinel.cluster.response.data.BatchFlowTokenResponseData;
+
+import io.netty.buffer.ByteBuf;
+
+/**
+ * @author Eric Zhao
+ * @since 1.7.0
+ */
+public class BatchFlowResponseDataDecoder implements EntityDecoder<ByteBuf, BatchFlowTokenResponseData> {
+
+    @Override
+    public BatchFlowTokenResponseData decode(ByteBuf source) {
+        BatchFlowTokenResponseData data = new BatchFlowTokenResponseData();
+
+        if (source.readableBytes() >= 4) {
+            data.setWaitInMs(source.readInt());
+            if (source.readableBytes() == 8) {
+                data.setBlockId(source.readLong());
+            }
+        }
+        return data;
+    }
+}

--- a/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/codec/data/BatchParamFlowRequestDataWriter.java
+++ b/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/codec/data/BatchParamFlowRequestDataWriter.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.cluster.client.codec.data;
+
+import java.util.Map;
+
+import com.alibaba.csp.sentinel.cluster.client.config.ClusterClientGlobalConfig;
+import com.alibaba.csp.sentinel.cluster.codec.EntityWriter;
+import com.alibaba.csp.sentinel.cluster.request.data.BatchParamFlowRequestData;
+import com.alibaba.csp.sentinel.log.RecordLog;
+import com.alibaba.csp.sentinel.util.AssertUtil;
+
+import io.netty.buffer.ByteBuf;
+
+/**
+ * <p>The encoding format of the {@link BatchParamFlowRequestData}:</p>
+ * <pre>
+ * +-------------+----------------+-----------+
+ * | Flow ID Set | Count(4 bytes) | Param Map |
+ * +-------------+----------------+-----------+
+ * </pre>
+ *
+ * <p>The layout of flow ID set:</p>
+ * <pre>
+ * +-----------------+------------------------------+
+ * | Amount(4 bytes) | repeated: FlowId(8 bytes)... |
+ * +-----------------+------------------------------+
+ * </pre>
+ *
+ * <p>The layout of the parameter map:</p>
+ * <pre>
+ * +----------------------+------------------------+
+ * | ParamAmount(4 bytes) | repeated: ParamItem... |
+ * +----------------------+------------------------+
+ * </pre>
+ *
+ * <p>The layout of a single parameter item (excluding String):</p>
+ * <pre>
+ * +-------------------+-------------------+----------+
+ * | ParamIdx(4 bytes) | ParamType(1 byte) | ParamObj |
+ * +-------------------+-------------------+----------+
+ * </pre>
+ *
+ * <p>The layout of a single String item:</p>
+ * <pre>
+ * +-------------------+-------------------+-----------------+----------+
+ * | ParamIdx(4 bytes) | ParamType(1 byte) | StrLen(4 bytes) | StrBytes |
+ * +-------------------+-------------------+-----------------+----------+
+ * </pre>
+ *
+ * @author Eric Zhao
+ * @since 1.7.0
+ */
+public class BatchParamFlowRequestDataWriter implements EntityWriter<BatchParamFlowRequestData, ByteBuf> {
+
+    private final ParamRequestEncoder encoder;
+
+    public BatchParamFlowRequestDataWriter() {
+        this(ClusterClientGlobalConfig.DEFAULT_PARAM_MAX_SIZE);
+    }
+
+    public BatchParamFlowRequestDataWriter(int maxParamByteSize) {
+        AssertUtil.isTrue(maxParamByteSize > 0, "maxParamByteSize should be positive");
+        this.encoder = new ParamRequestEncoder(maxParamByteSize);
+    }
+
+    @Override
+    public void writeTo(BatchParamFlowRequestData entity, ByteBuf target) {
+        if (entity.getFlowIds() == null || entity.getFlowIds().isEmpty()) {
+            RecordLog.warn("[BatchParamFlowRequestDataWriter] Flow ID set is empty, ignoring the request");
+            return;
+        }
+        int ruleAmount = entity.getFlowIds().size();
+        // Write the amount of rule IDs.
+        target.writeInt(ruleAmount);
+        for (Long id : entity.getFlowIds()) {
+            target.writeLong(id);
+        }
+
+        target.writeInt(entity.getCount());
+
+        Map<Integer, Object> params = encoder.resolveValidParamMap(entity.getParamMap());
+        // Write the amount of the parameter list.
+        target.writeInt(params.size());
+
+        // Serialize parameters with type flag.
+        for (Map.Entry<Integer, Object> e : params.entrySet()) {
+            // Write paramIdx.
+            target.writeInt(e.getKey());
+            encoder.encodeValue(e.getValue(), target);
+        }
+    }
+}

--- a/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/codec/data/FlowRequestDataWriter.java
+++ b/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/codec/data/FlowRequestDataWriter.java
@@ -21,9 +21,11 @@ import com.alibaba.csp.sentinel.cluster.request.data.FlowRequestData;
 import io.netty.buffer.ByteBuf;
 
 /**
- * +-------------------+--------------+----------------+---------------+------------------+
- * | RequestID(8 byte) | Type(1 byte) | FlowID(4 byte) | Count(4 byte) | PriorityFlag (1) |
- * +-------------------+--------------+----------------+---------------+------------------+
+ * <pre>
+ * +----------------+---------------+------------------+
+ * | FlowID(8 byte) | Count(4 byte) | PriorityFlag (1) |
+ * +----------------+---------------+------------------+
+ * </pre>
  *
  * @author Eric Zhao
  * @since 1.4.0

--- a/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/codec/data/ParamFlowRequestDataWriter.java
+++ b/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/codec/data/ParamFlowRequestDataWriter.java
@@ -15,15 +15,13 @@
  */
 package com.alibaba.csp.sentinel.cluster.client.codec.data;
 
-import com.alibaba.csp.sentinel.cluster.ClusterConstants;
+import com.alibaba.csp.sentinel.cluster.client.config.ClusterClientGlobalConfig;
 import com.alibaba.csp.sentinel.cluster.codec.EntityWriter;
 import com.alibaba.csp.sentinel.cluster.request.data.ParamFlowRequestData;
-import com.alibaba.csp.sentinel.log.RecordLog;
 import com.alibaba.csp.sentinel.util.AssertUtil;
+
 import io.netty.buffer.ByteBuf;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -33,15 +31,15 @@ import java.util.List;
  */
 public class ParamFlowRequestDataWriter implements EntityWriter<ParamFlowRequestData, ByteBuf> {
 
-    private final int maxParamByteSize;
+    private final ParamRequestEncoder encoder;
 
     public ParamFlowRequestDataWriter() {
-        this(DEFAULT_PARAM_MAX_SIZE);
+        this(ClusterClientGlobalConfig.DEFAULT_PARAM_MAX_SIZE);
     }
 
     public ParamFlowRequestDataWriter(int maxParamByteSize) {
         AssertUtil.isTrue(maxParamByteSize > 0, "maxParamByteSize should be positive");
-        this.maxParamByteSize = maxParamByteSize;
+        this.encoder = new ParamRequestEncoder(maxParamByteSize);
     }
 
     @Override
@@ -49,112 +47,13 @@ public class ParamFlowRequestDataWriter implements EntityWriter<ParamFlowRequest
         target.writeLong(entity.getFlowId());
         target.writeInt(entity.getCount());
 
-        Collection<Object> params = entity.getParams();
-
-        params = resolveValidParams(params);
+        List<Object> params = encoder.resolveValidParams(entity.getParams());
+        // Write the amount of the parameter list.
         target.writeInt(params.size());
 
         // Serialize parameters with type flag.
         for (Object param : params) {
-            encodeValue(param, target);
+            encoder.encodeValue(param, target);
         }
     }
-
-    /**
-     * Get valid parameters in provided parameter list
-     *
-     * @param params
-     * @return
-     */
-    public List<Object> resolveValidParams(Collection<Object> params) {
-        List<Object> validParams = new ArrayList<>();
-        int size = 0;
-        for (Object param : params) {
-            int s = calculateParamTransportSize(param);
-            if (s <= 0) {
-                RecordLog.warn("[ParamFlowRequestDataWriter] WARN: Non-primitive type detected in params of "
-                        + "cluster parameter flow control, which is not supported: " + param);
-                continue;
-            }
-            if (size + s > maxParamByteSize) {
-                RecordLog.warn("[ParamFlowRequestDataWriter] WARN: params size is too big." +
-                        " the configure value is : " + maxParamByteSize + ", the params size is: " + params.size());
-                break;
-            }
-            size += s;
-            validParams.add(param);
-        }
-        return validParams;
-    }
-
-    private void encodeValue(Object param, ByteBuf target) {
-        // Handle primitive type.
-        if (param instanceof Integer || int.class.isInstance(param)) {
-            target.writeByte(ClusterConstants.PARAM_TYPE_INTEGER);
-            target.writeInt((Integer) param);
-        } else if (param instanceof String) {
-            encodeString((String) param, target);
-        } else if (boolean.class.isInstance(param) || param instanceof Boolean) {
-            target.writeByte(ClusterConstants.PARAM_TYPE_BOOLEAN);
-            target.writeBoolean((Boolean) param);
-        } else if (long.class.isInstance(param) || param instanceof Long) {
-            target.writeByte(ClusterConstants.PARAM_TYPE_LONG);
-            target.writeLong((Long) param);
-        } else if (double.class.isInstance(param) || param instanceof Double) {
-            target.writeByte(ClusterConstants.PARAM_TYPE_DOUBLE);
-            target.writeDouble((Double) param);
-        } else if (float.class.isInstance(param) || param instanceof Float) {
-            target.writeByte(ClusterConstants.PARAM_TYPE_FLOAT);
-            target.writeFloat((Float) param);
-        } else if (byte.class.isInstance(param) || param instanceof Byte) {
-            target.writeByte(ClusterConstants.PARAM_TYPE_BYTE);
-            target.writeByte((Byte) param);
-        } else if (short.class.isInstance(param) || param instanceof Short) {
-            target.writeByte(ClusterConstants.PARAM_TYPE_SHORT);
-            target.writeShort((Short) param);
-        } else {
-            // Unexpected type, drop.
-        }
-    }
-
-    private void encodeString(String param, ByteBuf target) {
-        target.writeByte(ClusterConstants.PARAM_TYPE_STRING);
-        byte[] tmpChars = param.getBytes();
-        target.writeInt(tmpChars.length);
-        target.writeBytes(tmpChars);
-    }
-
-
-    int calculateParamTransportSize(Object value) {
-        if (value == null) {
-            return 0;
-        }
-        // Layout for primitives: |type flag(1)|value|
-        // size = original size + type flag (1)
-        if (value instanceof Integer || int.class.isInstance(value)) {
-            return 5;
-        } else if (value instanceof String) {
-            // Layout for string: |type flag(1)|length(4)|string content|
-            String tmpValue = (String) value;
-            byte[] tmpChars = tmpValue.getBytes();
-            return 1 + 4 + tmpChars.length;
-        } else if (boolean.class.isInstance(value) || value instanceof Boolean) {
-            return 2;
-        } else if (long.class.isInstance(value) || value instanceof Long) {
-            return 9;
-        } else if (double.class.isInstance(value) || value instanceof Double) {
-            return 9;
-        } else if (float.class.isInstance(value) || value instanceof Float) {
-            return 5;
-        } else if (byte.class.isInstance(value) || value instanceof Byte) {
-            return 2;
-        } else if (short.class.isInstance(value) || value instanceof Short) {
-            return 3;
-        } else {
-            // Ignore unexpected type.
-            return 0;
-        }
-    }
-
-    private static final int DEFAULT_PARAM_MAX_SIZE = 1024;
 }

--- a/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/codec/data/ParamRequestEncoder.java
+++ b/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/codec/data/ParamRequestEncoder.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.cluster.client.codec.data;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.alibaba.csp.sentinel.cluster.ClusterConstants;
+import com.alibaba.csp.sentinel.log.RecordLog;
+
+import io.netty.buffer.ByteBuf;
+
+/**
+ * @author Eric Zhao
+ * @since 1.7.0
+ */
+final class ParamRequestEncoder {
+
+    private final int maxParamByteSize;
+
+    ParamRequestEncoder(int maxParamByteSize) {
+        this.maxParamByteSize = maxParamByteSize;
+    }
+
+    /**
+     * Resolve valid parameters in provided parameter list.
+     *
+     * @param params valid parameter list
+     * @return filtered parameter list
+     */
+    List<Object> resolveValidParams(Collection<Object> params) {
+        List<Object> validParams = new ArrayList<>();
+        if (params == null) {
+            return validParams;
+        }
+        int size = 0;
+        for (Object param : params) {
+            int s = calculateParamTransportSize(param);
+            if (s <= 0) {
+                RecordLog.warn("Non-primitive type detected in params of "
+                    + "cluster parameter flow control, which is not supported: " + param);
+                continue;
+            }
+            if (size + s > maxParamByteSize) {
+                RecordLog.warn("Total param size ({0}) will exceed the threshold ({1}), "
+                        + "the pending param (size: {2}) will be dropped", size + s, maxParamByteSize, s);
+                break;
+            }
+            size += s;
+            validParams.add(param);
+        }
+        return validParams;
+    }
+
+    Map<Integer, Object> resolveValidParamMap(Map<Integer, Object> params) {
+        Map<Integer, Object> validParams = new HashMap<>(8);
+        if (params == null || params.isEmpty()) {
+            return validParams;
+        }
+        int size = 0;
+        for (Map.Entry<Integer, Object> e: params.entrySet()) {
+            Object param = e.getValue();
+            int s = calculateParamTransportSize(param);
+            if (s <= 0) {
+                RecordLog.warn("[ClusterParamRequestEncoder] Non-primitive type detected in params of "
+                    + "cluster parameter flow control, which is not supported: " + param);
+                continue;
+            }
+            if (size + s > maxParamByteSize) {
+                RecordLog.warn("[ClusterParamRequestEncoder] Total param size ({0}) will exceed the threshold ({1}), "
+                    + "the pending param (size: {2}) will be dropped", size + s, maxParamByteSize, s);
+                break;
+            }
+            size += s;
+            validParams.put(e.getKey(), param);
+        }
+        return validParams;
+    }
+
+    void encodeValue(Object param, ByteBuf target) {
+        if (param == null) {
+            return;
+        }
+        // Handle primitive type.
+        if (param instanceof Integer || int.class.isInstance(param)) {
+            target.writeByte(ClusterConstants.PARAM_TYPE_INTEGER);
+            target.writeInt((Integer) param);
+        } else if (param instanceof String) {
+            encodeString((String) param, target);
+        } else if (boolean.class.isInstance(param) || param instanceof Boolean) {
+            target.writeByte(ClusterConstants.PARAM_TYPE_BOOLEAN);
+            target.writeBoolean((Boolean) param);
+        } else if (long.class.isInstance(param) || param instanceof Long) {
+            target.writeByte(ClusterConstants.PARAM_TYPE_LONG);
+            target.writeLong((Long) param);
+        } else if (double.class.isInstance(param) || param instanceof Double) {
+            target.writeByte(ClusterConstants.PARAM_TYPE_DOUBLE);
+            target.writeDouble((Double) param);
+        } else if (float.class.isInstance(param) || param instanceof Float) {
+            target.writeByte(ClusterConstants.PARAM_TYPE_FLOAT);
+            target.writeFloat((Float) param);
+        } else if (byte.class.isInstance(param) || param instanceof Byte) {
+            target.writeByte(ClusterConstants.PARAM_TYPE_BYTE);
+            target.writeByte((Byte) param);
+        } else if (short.class.isInstance(param) || param instanceof Short) {
+            target.writeByte(ClusterConstants.PARAM_TYPE_SHORT);
+            target.writeShort((Short) param);
+        } else {
+            // Unexpected type, drop.
+        }
+    }
+
+    private void encodeString(String param, ByteBuf target) {
+        target.writeByte(ClusterConstants.PARAM_TYPE_STRING);
+        byte[] tmpChars = param.getBytes();
+        target.writeInt(tmpChars.length);
+        target.writeBytes(tmpChars);
+    }
+
+
+    int calculateParamTransportSize(Object value) {
+        if (value == null) {
+            return 0;
+        }
+        // Layout for primitives: |type flag(1)|value|
+        // size = original size + type flag (1)
+        if (value instanceof Integer || int.class.isInstance(value)) {
+            return 5;
+        } else if (value instanceof String) {
+            // Layout for string: |type flag(1)|length(4)|string content|
+            String tmpValue = (String) value;
+            byte[] tmpChars = tmpValue.getBytes();
+            return 1 + 4 + tmpChars.length;
+        } else if (boolean.class.isInstance(value) || value instanceof Boolean) {
+            return 2;
+        } else if (long.class.isInstance(value) || value instanceof Long) {
+            return 9;
+        } else if (double.class.isInstance(value) || value instanceof Double) {
+            return 9;
+        } else if (float.class.isInstance(value) || value instanceof Float) {
+            return 5;
+        } else if (byte.class.isInstance(value) || value instanceof Byte) {
+            return 2;
+        } else if (short.class.isInstance(value) || value instanceof Short) {
+            return 3;
+        } else {
+            // Ignore unexpected type.
+            return 0;
+        }
+    }
+
+    public int getMaxParamByteSize() {
+        return maxParamByteSize;
+    }
+}

--- a/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/config/ClusterClientGlobalConfig.java
+++ b/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/config/ClusterClientGlobalConfig.java
@@ -20,13 +20,15 @@ import com.alibaba.csp.sentinel.log.RecordLog;
 
 /**
  * <p>
- * this class dedicated to reading startup configurations of cluster client
+ * This class is dedicated to retrieving startup configurations for cluster token client.
  * </p>
  *
  * @author lianglin
  * @since 1.7.0
  */
-public class ClusterClientStartUpConfig {
+public final class ClusterClientGlobalConfig {
+
+    public static final int DEFAULT_PARAM_MAX_SIZE = 1024;
 
     private static final String MAX_PARAM_BYTE_SIZE = "csp.sentinel.cluster.max.param.byte.size";
 
@@ -40,10 +42,10 @@ public class ClusterClientStartUpConfig {
         try {
             return maxParamByteSize == null ? null : Integer.valueOf(maxParamByteSize);
         } catch (Exception ex) {
-            RecordLog.warn("[ClusterClientStartUpConfig] Failed to parse maxParamByteSize: " + maxParamByteSize);
+            RecordLog.warn("[ClusterClientGlobalConfig] Failed to parse maxParamByteSize: " + maxParamByteSize);
             return null;
         }
     }
 
-
+    private ClusterClientGlobalConfig() {}
 }

--- a/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/init/DefaultClusterClientInitFunc.java
+++ b/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/init/DefaultClusterClientInitFunc.java
@@ -15,7 +15,11 @@
  */
 package com.alibaba.csp.sentinel.cluster.client.init;
 
+import com.alibaba.csp.sentinel.cluster.ClusterConstants;
 import com.alibaba.csp.sentinel.cluster.client.ClientConstants;
+import com.alibaba.csp.sentinel.cluster.client.codec.data.BatchFlowRequestDataWriter;
+import com.alibaba.csp.sentinel.cluster.client.codec.data.BatchFlowResponseDataDecoder;
+import com.alibaba.csp.sentinel.cluster.client.codec.data.BatchParamFlowRequestDataWriter;
 import com.alibaba.csp.sentinel.cluster.client.codec.data.FlowRequestDataWriter;
 import com.alibaba.csp.sentinel.cluster.client.codec.data.FlowResponseDataDecoder;
 import com.alibaba.csp.sentinel.cluster.client.codec.data.ParamFlowRequestDataWriter;
@@ -23,7 +27,7 @@ import com.alibaba.csp.sentinel.cluster.client.codec.data.PingRequestDataWriter;
 import com.alibaba.csp.sentinel.cluster.client.codec.data.PingResponseDataDecoder;
 import com.alibaba.csp.sentinel.cluster.client.codec.registry.RequestDataWriterRegistry;
 import com.alibaba.csp.sentinel.cluster.client.codec.registry.ResponseDataDecodeRegistry;
-import com.alibaba.csp.sentinel.cluster.client.config.ClusterClientStartUpConfig;
+import com.alibaba.csp.sentinel.cluster.client.config.ClusterClientGlobalConfig;
 import com.alibaba.csp.sentinel.init.InitFunc;
 import com.alibaba.csp.sentinel.init.InitOrder;
 
@@ -41,19 +45,27 @@ public class DefaultClusterClientInitFunc implements InitFunc {
     }
 
     private void initDefaultEntityWriters() {
-        RequestDataWriterRegistry.addWriter(ClientConstants.TYPE_PING, new PingRequestDataWriter());
-        RequestDataWriterRegistry.addWriter(ClientConstants.TYPE_FLOW, new FlowRequestDataWriter());
-        Integer maxParamByteSize = ClusterClientStartUpConfig.getMaxParamByteSize();
+        RequestDataWriterRegistry.addWriter(ClusterConstants.MSG_TYPE_PING, new PingRequestDataWriter());
+        RequestDataWriterRegistry.addWriter(ClusterConstants.MSG_TYPE_FLOW, new FlowRequestDataWriter());
+        RequestDataWriterRegistry.addWriter(ClusterConstants.MSG_TYPE_BATCH_FLOW, new BatchFlowRequestDataWriter());
+
+        Integer maxParamByteSize = ClusterClientGlobalConfig.getMaxParamByteSize();
         if (maxParamByteSize == null) {
-            RequestDataWriterRegistry.addWriter(ClientConstants.TYPE_PARAM_FLOW, new ParamFlowRequestDataWriter());
-        } else {
-            RequestDataWriterRegistry.addWriter(ClientConstants.TYPE_PARAM_FLOW, new ParamFlowRequestDataWriter(maxParamByteSize));
+            maxParamByteSize = ClusterClientGlobalConfig.DEFAULT_PARAM_MAX_SIZE;
         }
+        RequestDataWriterRegistry.addWriter(ClusterConstants.MSG_TYPE_PARAM_FLOW,
+            new ParamFlowRequestDataWriter(maxParamByteSize));
+        RequestDataWriterRegistry.addWriter(ClusterConstants.MSG_TYPE_BATCH_PARAM_FLOW,
+            new BatchParamFlowRequestDataWriter(maxParamByteSize));
     }
 
     private void initDefaultEntityDecoders() {
-        ResponseDataDecodeRegistry.addDecoder(ClientConstants.TYPE_PING, new PingResponseDataDecoder());
-        ResponseDataDecodeRegistry.addDecoder(ClientConstants.TYPE_FLOW, new FlowResponseDataDecoder());
-        ResponseDataDecodeRegistry.addDecoder(ClientConstants.TYPE_PARAM_FLOW, new FlowResponseDataDecoder());
+        ResponseDataDecodeRegistry.addDecoder(ClusterConstants.MSG_TYPE_PING, new PingResponseDataDecoder());
+        ResponseDataDecodeRegistry.addDecoder(ClusterConstants.MSG_TYPE_FLOW, new FlowResponseDataDecoder());
+        ResponseDataDecodeRegistry.addDecoder(ClusterConstants.MSG_TYPE_PARAM_FLOW, new FlowResponseDataDecoder());
+        ResponseDataDecodeRegistry.addDecoder(ClusterConstants.MSG_TYPE_BATCH_FLOW,
+            new BatchFlowResponseDataDecoder());
+        ResponseDataDecodeRegistry.addDecoder(ClusterConstants.MSG_TYPE_BATCH_PARAM_FLOW,
+            new BatchFlowResponseDataDecoder());
     }
 }

--- a/sentinel-cluster/sentinel-cluster-client-default/src/test/java/com/alibaba/csp/sentinel/cluster/client/codec/data/BatchFlowRequestDataWriterTest.java
+++ b/sentinel-cluster/sentinel-cluster-client-default/src/test/java/com/alibaba/csp/sentinel/cluster/client/codec/data/BatchFlowRequestDataWriterTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.cluster.client.codec.data;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.alibaba.csp.sentinel.cluster.request.data.BatchFlowRequestData;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Eric Zhao
+ */
+public class BatchFlowRequestDataWriterTest {
+
+    @Test
+    public void testEncodeBatchFlowRequestData() {
+        ByteBuf buf = Unpooled.buffer();
+        BatchFlowRequestDataWriter writer = new BatchFlowRequestDataWriter();
+
+        // Test for empty ID set.
+        writer.writeTo(new BatchFlowRequestData().setCount(1).setPriority(false), buf);
+        assertThat(buf.readableBytes()).isZero();
+
+        Set<Long> ids = new HashSet<>();
+        ids.add(13L);
+        ids.add(177L);
+        BatchFlowRequestData data = new BatchFlowRequestData()
+            .setCount(19)
+            .setPriority(true)
+            .setFlowIds(ids);
+        writer.writeTo(data, buf);
+
+        assertThat(buf.readInt()).isEqualTo(ids.size());
+        for (int i = 0; i < ids.size(); i++) {
+            assertThat(ids.contains(buf.readLong())).isTrue();
+        }
+        assertThat(buf.readInt()).isEqualTo(19);
+        assertThat(buf.readBoolean()).isEqualTo(true);
+
+        buf.release();
+    }
+}

--- a/sentinel-cluster/sentinel-cluster-client-default/src/test/java/com/alibaba/csp/sentinel/cluster/client/codec/data/ParamRequestEncoderTest.java
+++ b/sentinel-cluster/sentinel-cluster-client-default/src/test/java/com/alibaba/csp/sentinel/cluster/client/codec/data/ParamRequestEncoderTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.cluster.client.codec.data;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.alibaba.csp.sentinel.cluster.client.config.ClusterClientGlobalConfig;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Eric Zhao
+ * @author lianglin
+ */
+public class ParamRequestEncoderTest {
+
+    @Test
+    public void testCalculateParamTransportSize() {
+        ParamRequestEncoder encoder = new ParamRequestEncoder(ClusterClientGlobalConfig.DEFAULT_PARAM_MAX_SIZE);
+        // POJO (non-primitive type) should not be regarded as a valid parameter.
+        assertEquals(0, encoder.calculateParamTransportSize(new SomePojo().setParam1("abc")));
+
+        assertEquals(4 + 1, encoder.calculateParamTransportSize(1));
+        assertEquals(1 + 1, encoder.calculateParamTransportSize((byte)1));
+        assertEquals(1 + 1, encoder.calculateParamTransportSize(false));
+        assertEquals(8 + 1, encoder.calculateParamTransportSize(2L));
+        assertEquals(8 + 1, encoder.calculateParamTransportSize(4.0d));
+        final String paramStr = "Sentinel";
+        assertEquals(1 + 4 + paramStr.getBytes().length, encoder.calculateParamTransportSize(paramStr));
+    }
+
+    @Test
+    public void testResolveValidParams() {
+        final int maxSize = 15;
+        ParamRequestEncoder encoder = new ParamRequestEncoder(maxSize);
+
+        ArrayList<Object> params = new ArrayList<Object>() {{
+            add(1);
+            add(64);
+            add(3);
+        }};
+
+        List<Object> validParams = encoder.resolveValidParams(params);
+        assertEquals(3, validParams.size());
+        assertEquals(params.get(0), 1);
+        assertEquals(params.get(1), 64);
+        assertEquals(params.get(2), 3);
+
+        // When exceeding maxSize, the parameter will not be included.
+        params.add(5);
+        validParams = encoder.resolveValidParams(params);
+        assertEquals(3, validParams.size());
+        assertFalse(validParams.contains(5));
+
+        // POJO (non-primitive type) should not be regarded as a valid parameter
+        assertEquals(0, encoder.resolveValidParams(new ArrayList<Object>() {{
+            add(new SomePojo());
+        }}).size());
+    }
+
+    @Test
+    public void testResolveValidParamMap() {
+        final int maxSize = 15;
+        ParamRequestEncoder encoder = new ParamRequestEncoder(maxSize);
+
+        Map<Integer, Object> paramMap = new HashMap<>();
+        paramMap.put(0, 1);
+        paramMap.put(2, 64);
+        paramMap.put(3, 3);
+
+        Map<Integer, Object> params = encoder.resolveValidParamMap(paramMap);
+        assertEquals(3, params.size());
+        assertEquals(params.get(0), 1);
+        assertEquals(params.get(2), 64);
+        assertEquals(params.get(3), 3);
+
+        // When exceeding maxSize, the parameter will not be included.
+        paramMap.put(4, 5L);
+        params = encoder.resolveValidParamMap(paramMap);
+        assertEquals(3, params.size());
+        assertFalse(params.containsKey(4));
+
+        // POJO (non-primitive type) should not be regarded as a valid parameter
+        assertEquals(0, encoder.resolveValidParamMap(new HashMap<Integer, Object>() {{
+            put(0, new SomePojo());
+        }}).size());
+    }
+
+    private static class SomePojo {
+        private String param1;
+
+        public String getParam1() {
+            return param1;
+        }
+
+        public SomePojo setParam1(String param1) {
+            this.param1 = param1;
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return "SomePojo{" +
+                "param1='" + param1 + '\'' +
+                '}';
+        }
+    }
+}

--- a/sentinel-cluster/sentinel-cluster-common-default/src/main/java/com/alibaba/csp/sentinel/cluster/ClusterConstants.java
+++ b/sentinel-cluster/sentinel-cluster-common-default/src/main/java/com/alibaba/csp/sentinel/cluster/ClusterConstants.java
@@ -24,6 +24,8 @@ public final class ClusterConstants {
     public static final int MSG_TYPE_PING = 0;
     public static final int MSG_TYPE_FLOW = 1;
     public static final int MSG_TYPE_PARAM_FLOW = 2;
+    public static final int MSG_TYPE_BATCH_FLOW = 3;
+    public static final int MSG_TYPE_BATCH_PARAM_FLOW = 4;
 
     public static final int RESPONSE_STATUS_BAD = -1;
     public static final int RESPONSE_STATUS_OK = 0;

--- a/sentinel-cluster/sentinel-cluster-common-default/src/main/java/com/alibaba/csp/sentinel/cluster/request/data/BatchFlowRequestData.java
+++ b/sentinel-cluster/sentinel-cluster-common-default/src/main/java/com/alibaba/csp/sentinel/cluster/request/data/BatchFlowRequestData.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,28 +15,24 @@
  */
 package com.alibaba.csp.sentinel.cluster.request.data;
 
-import java.util.Collection;
+import java.util.Set;
 
 /**
  * @author Eric Zhao
- * @since 1.4.0
+ * @since 1.7.0
  */
-public class ParamFlowRequestData {
+public class BatchFlowRequestData {
 
-    private long flowId;
+    private Set<Long> flowIds;
     private int count;
+    private boolean priority;
 
-    /**
-     * The collection should be ordered.
-     */
-    private Collection<Object> params;
-
-    public long getFlowId() {
-        return flowId;
+    public Set<Long> getFlowIds() {
+        return flowIds;
     }
 
-    public ParamFlowRequestData setFlowId(long flowId) {
-        this.flowId = flowId;
+    public BatchFlowRequestData setFlowIds(Set<Long> flowIds) {
+        this.flowIds = flowIds;
         return this;
     }
 
@@ -44,26 +40,26 @@ public class ParamFlowRequestData {
         return count;
     }
 
-    public ParamFlowRequestData setCount(int count) {
+    public BatchFlowRequestData setCount(int count) {
         this.count = count;
         return this;
     }
 
-    public Collection<Object> getParams() {
-        return params;
+    public boolean isPriority() {
+        return priority;
     }
 
-    public ParamFlowRequestData setParams(Collection<Object> params) {
-        this.params = params;
+    public BatchFlowRequestData setPriority(boolean priority) {
+        this.priority = priority;
         return this;
     }
 
     @Override
     public String toString() {
-        return "ParamFlowRequestData{" +
-            "flowId=" + flowId +
+        return "BatchFlowRequestData{" +
+            "flowIds=" + flowIds +
             ", count=" + count +
-            ", params=" + params +
+            ", priority=" + priority +
             '}';
     }
 }

--- a/sentinel-cluster/sentinel-cluster-common-default/src/main/java/com/alibaba/csp/sentinel/cluster/request/data/BatchParamFlowRequestData.java
+++ b/sentinel-cluster/sentinel-cluster-common-default/src/main/java/com/alibaba/csp/sentinel/cluster/request/data/BatchParamFlowRequestData.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,28 +15,28 @@
  */
 package com.alibaba.csp.sentinel.cluster.request.data;
 
-import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Eric Zhao
- * @since 1.4.0
+ * @since 1.7.0
  */
-public class ParamFlowRequestData {
+public class BatchParamFlowRequestData {
 
-    private long flowId;
+    private Set<Long> flowIds;
     private int count;
-
     /**
-     * The collection should be ordered.
+     * Pair: (paramIdx, paramObj)
      */
-    private Collection<Object> params;
+    private Map<Integer, Object> paramMap;
 
-    public long getFlowId() {
-        return flowId;
+    public Set<Long> getFlowIds() {
+        return flowIds;
     }
 
-    public ParamFlowRequestData setFlowId(long flowId) {
-        this.flowId = flowId;
+    public BatchParamFlowRequestData setFlowIds(Set<Long> flowIds) {
+        this.flowIds = flowIds;
         return this;
     }
 
@@ -44,26 +44,26 @@ public class ParamFlowRequestData {
         return count;
     }
 
-    public ParamFlowRequestData setCount(int count) {
+    public BatchParamFlowRequestData setCount(int count) {
         this.count = count;
         return this;
     }
 
-    public Collection<Object> getParams() {
-        return params;
+    public Map<Integer, Object> getParamMap() {
+        return paramMap;
     }
 
-    public ParamFlowRequestData setParams(Collection<Object> params) {
-        this.params = params;
+    public BatchParamFlowRequestData setParamMap(Map<Integer, Object> paramMap) {
+        this.paramMap = paramMap;
         return this;
     }
 
     @Override
     public String toString() {
-        return "ParamFlowRequestData{" +
-            "flowId=" + flowId +
+        return "BatchParamFlowRequestData{" +
+            "flowIds=" + flowIds +
             ", count=" + count +
-            ", params=" + params +
+            ", paramMap=" + paramMap +
             '}';
     }
 }

--- a/sentinel-cluster/sentinel-cluster-common-default/src/main/java/com/alibaba/csp/sentinel/cluster/response/data/BatchFlowTokenResponseData.java
+++ b/sentinel-cluster/sentinel-cluster-common-default/src/main/java/com/alibaba/csp/sentinel/cluster/response/data/BatchFlowTokenResponseData.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.cluster.response.data;
+
+/**
+ * @author Eric Zhao
+ * @since 1.7.0
+ */
+public class BatchFlowTokenResponseData {
+
+    private int waitInMs;
+
+    /**
+     * Flow ID of the rule that triggered flow control.
+     */
+    private Long blockId;
+
+    public int getWaitInMs() {
+        return waitInMs;
+    }
+
+    public BatchFlowTokenResponseData setWaitInMs(int waitInMs) {
+        this.waitInMs = waitInMs;
+        return this;
+    }
+
+    public Long getBlockId() {
+        return blockId;
+    }
+
+    public BatchFlowTokenResponseData setBlockId(Long blockId) {
+        this.blockId = blockId;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "BatchFlowTokenResponseData{" +
+            "waitInMs=" + waitInMs +
+            ", blockId=" + blockId +
+            '}';
+    }
+}

--- a/sentinel-cluster/sentinel-cluster-server-default/pom.xml
+++ b/sentinel-cluster/sentinel-cluster-server-default/pom.xml
@@ -38,6 +38,12 @@
 
         <dependency>
             <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-cluster-client-default</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
             <artifactId>sentinel-datasource-nacos</artifactId>
             <scope>test</scope>
         </dependency>
@@ -55,6 +61,16 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/DefaultEmbeddedTokenServer.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/DefaultEmbeddedTokenServer.java
@@ -16,6 +16,8 @@
 package com.alibaba.csp.sentinel.cluster.server;
 
 import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
 
 import com.alibaba.csp.sentinel.cluster.TokenResult;
 import com.alibaba.csp.sentinel.cluster.TokenResultStatus;
@@ -55,6 +57,22 @@ public class DefaultEmbeddedTokenServer implements EmbeddedClusterTokenServer {
     public TokenResult requestParamToken(Long ruleId, int acquireCount, Collection<Object> params) {
         if (tokenService != null) {
             return tokenService.requestParamToken(ruleId, acquireCount, params);
+        }
+        return new TokenResult(TokenResultStatus.FAIL);
+    }
+
+    @Override
+    public TokenResult batchRequestToken(Set<Long> ruleIds, int acquireCount, boolean prioritized) {
+        if (tokenService != null) {
+            return tokenService.batchRequestToken(ruleIds, acquireCount, prioritized);
+        }
+        return new TokenResult(TokenResultStatus.FAIL);
+    }
+
+    @Override
+    public TokenResult batchRequestParamToken(Set<Long> ruleIds, int acquireCount, Map<Integer, Object> paramMap) {
+        if (tokenService != null) {
+            return tokenService.batchRequestParamToken(ruleIds, acquireCount, paramMap);
         }
         return new TokenResult(TokenResultStatus.FAIL);
     }

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/ServerConstants.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/ServerConstants.java
@@ -27,5 +27,7 @@ public final class ServerConstants {
 
     public static final String DEFAULT_NAMESPACE = "default";
 
+    public static final String ATTR_KEY_BLOCK_ID = "blockId";
+
     private ServerConstants() {}
 }

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/codec/data/BatchFlowResponseDataWriter.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/codec/data/BatchFlowResponseDataWriter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.cluster.server.codec.data;
+
+import com.alibaba.csp.sentinel.cluster.codec.EntityWriter;
+import com.alibaba.csp.sentinel.cluster.response.data.BatchFlowTokenResponseData;
+
+import io.netty.buffer.ByteBuf;
+
+/**
+ * <p>The encoding format of the batch flow response data:</p>
+ * <pre>
+ * +--------------------+-------------------+----------------------------+
+ * | Remaining(4 bytes) | WaitTime(4 bytes) | BlockId(8 bytes, optional) |
+ * +--------------------+-------------------+----------------------------+
+ *
+ * @author Eric Zhao
+ * @since 1.7.0
+ */
+public class BatchFlowResponseDataWriter implements EntityWriter<BatchFlowTokenResponseData, ByteBuf> {
+
+    @Override
+    public void writeTo(BatchFlowTokenResponseData entity, ByteBuf out) {
+        if (entity == null) {
+            return;
+        }
+        out.writeInt(entity.getWaitInMs());
+        if (entity.getBlockId() != null) {
+            out.writeLong(entity.getBlockId());
+        }
+    }
+}

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/codec/data/BatchParamFlowRequestDataDecoder.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/codec/data/BatchParamFlowRequestDataDecoder.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.cluster.server.codec.data;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.alibaba.csp.sentinel.cluster.codec.EntityDecoder;
+import com.alibaba.csp.sentinel.cluster.request.data.BatchParamFlowRequestData;
+
+import io.netty.buffer.ByteBuf;
+
+/**
+ * @author Eric Zhao
+ * @since 1.7.0
+ */
+public class BatchParamFlowRequestDataDecoder implements EntityDecoder<ByteBuf, BatchParamFlowRequestData> {
+
+    @Override
+    public BatchParamFlowRequestData decode(ByteBuf source) {
+        if (source.readableBytes() >= 4) {
+            int batchSize = source.readInt();
+            if (batchSize <= 0) {
+                return null;
+            }
+            Set<Long> idSet = new HashSet<>();
+            for (int i = 0; i < batchSize; i++) {
+                idSet.add(source.readLong());
+            }
+
+            BatchParamFlowRequestData requestData = new BatchParamFlowRequestData()
+                .setFlowIds(idSet)
+                .setCount(source.readInt());
+
+            Map<Integer, Object> paramMap = ParamDecodeUtils.decodeParamMap(source);
+            requestData.setParamMap(paramMap);
+            return requestData;
+        }
+        return null;
+    }
+
+}

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/codec/data/ParamDecodeUtils.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/codec/data/ParamDecodeUtils.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.cluster.server.codec.data;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.alibaba.csp.sentinel.cluster.ClusterConstants;
+
+import io.netty.buffer.ByteBuf;
+
+/**
+ * @author Eric Zhao
+ * @since 1.7.0
+ */
+final class ParamDecodeUtils {
+
+    static Map<Integer, Object> decodeParamMap(ByteBuf source) {
+        int amount = source.readInt();
+        Map<Integer, Object> paramMap = new HashMap<>();
+        if (amount > 0) {
+            for (int i = 0; i < amount; i++) {
+                int paramIdx = source.readInt();
+                Object param = decodeSingleParam(source);
+                if (param != null) {
+                    paramMap.put(paramIdx, param);
+                }
+            }
+        }
+        return paramMap;
+    }
+
+    static List<Object> decodeParams(ByteBuf source) {
+        int amount = source.readInt();
+        List<Object> params = new ArrayList<>();
+        if (amount > 0) {
+            for (int i = 0; i < amount; i++) {
+                Object param = decodeSingleParam(source);
+                if (param != null) {
+                    params.add(param);
+                }
+            }
+        }
+        return params;
+    }
+
+    private static Object decodeSingleParam(ByteBuf source) {
+        byte paramType = source.readByte();
+
+        switch (paramType) {
+            case ClusterConstants.PARAM_TYPE_INTEGER:
+                return source.readInt();
+            case ClusterConstants.PARAM_TYPE_STRING:
+                int length = source.readInt();
+                byte[] bytes = new byte[length];
+                source.readBytes(bytes);
+                // TODO: take care of charset?
+                return new String(bytes);
+            case ClusterConstants.PARAM_TYPE_BOOLEAN:
+                return source.readBoolean();
+            case ClusterConstants.PARAM_TYPE_DOUBLE:
+                return source.readDouble();
+            case ClusterConstants.PARAM_TYPE_LONG:
+                return source.readLong();
+            case ClusterConstants.PARAM_TYPE_FLOAT:
+                return source.readFloat();
+            case ClusterConstants.PARAM_TYPE_BYTE:
+                return source.readByte();
+            case ClusterConstants.PARAM_TYPE_SHORT:
+                return source.readShort();
+            default:
+                return null;
+        }
+    }
+
+    private ParamDecodeUtils() {}
+}

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/codec/data/ParamFlowRequestDataDecoder.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/codec/data/ParamFlowRequestDataDecoder.java
@@ -15,10 +15,8 @@
  */
 package com.alibaba.csp.sentinel.cluster.server.codec.data;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import com.alibaba.csp.sentinel.cluster.ClusterConstants;
 import com.alibaba.csp.sentinel.cluster.codec.EntityDecoder;
 import com.alibaba.csp.sentinel.cluster.request.data.ParamFlowRequestData;
 
@@ -38,54 +36,11 @@ public class ParamFlowRequestDataDecoder implements EntityDecoder<ByteBuf, Param
                 .setFlowId(source.readLong())
                 .setCount(source.readInt());
 
-            int amount = source.readInt();
-            if (amount > 0) {
-                List<Object> params = new ArrayList<>(amount);
-                for (int i = 0; i < amount; i++) {
-                    decodeParam(source, params);
-                }
-
-                requestData.setParams(params);
-                return requestData;
-            }
+            List<Object> params = ParamDecodeUtils.decodeParams(source);
+            requestData.setParams(params);
+            return requestData;
         }
         return null;
     }
 
-    private boolean decodeParam(ByteBuf source, List<Object> params) {
-        byte paramType = source.readByte();
-
-        switch (paramType) {
-            case ClusterConstants.PARAM_TYPE_INTEGER:
-                params.add(source.readInt());
-                return true;
-            case ClusterConstants.PARAM_TYPE_STRING:
-                int length = source.readInt();
-                byte[] bytes = new byte[length];
-                source.readBytes(bytes);
-                // TODO: take care of charset?
-                params.add(new String(bytes));
-                return true;
-            case ClusterConstants.PARAM_TYPE_BOOLEAN:
-                params.add(source.readBoolean());
-                return true;
-            case ClusterConstants.PARAM_TYPE_DOUBLE:
-                params.add(source.readDouble());
-                return true;
-            case ClusterConstants.PARAM_TYPE_LONG:
-                params.add(source.readLong());
-                return true;
-            case ClusterConstants.PARAM_TYPE_FLOAT:
-                params.add(source.readFloat());
-                return true;
-            case ClusterConstants.PARAM_TYPE_BYTE:
-                params.add(source.readByte());
-                return true;
-            case ClusterConstants.PARAM_TYPE_SHORT:
-                params.add(source.readShort());
-                return true;
-            default:
-                return false;
-        }
-    }
 }

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/init/DefaultClusterServerInitFunc.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/init/DefaultClusterServerInitFunc.java
@@ -17,6 +17,9 @@ package com.alibaba.csp.sentinel.cluster.server.init;
 
 import com.alibaba.csp.sentinel.cluster.ClusterConstants;
 import com.alibaba.csp.sentinel.cluster.server.TokenServiceProvider;
+import com.alibaba.csp.sentinel.cluster.server.codec.data.BatchFlowRequestDataDecoder;
+import com.alibaba.csp.sentinel.cluster.server.codec.data.BatchFlowResponseDataWriter;
+import com.alibaba.csp.sentinel.cluster.server.codec.data.BatchParamFlowRequestDataDecoder;
 import com.alibaba.csp.sentinel.cluster.server.codec.data.FlowRequestDataDecoder;
 import com.alibaba.csp.sentinel.cluster.server.codec.data.FlowResponseDataWriter;
 import com.alibaba.csp.sentinel.cluster.server.codec.data.ParamFlowRequestDataDecoder;
@@ -51,12 +54,22 @@ public class DefaultClusterServerInitFunc implements InitFunc {
         ResponseDataWriterRegistry.addWriter(ClusterConstants.MSG_TYPE_PING, new PingResponseDataWriter());
         ResponseDataWriterRegistry.addWriter(ClusterConstants.MSG_TYPE_FLOW, new FlowResponseDataWriter());
         ResponseDataWriterRegistry.addWriter(ClusterConstants.MSG_TYPE_PARAM_FLOW, new FlowResponseDataWriter());
+
+        ResponseDataWriterRegistry.addWriter(ClusterConstants.MSG_TYPE_BATCH_FLOW,
+            new BatchFlowResponseDataWriter());
+        ResponseDataWriterRegistry.addWriter(ClusterConstants.MSG_TYPE_BATCH_PARAM_FLOW,
+            new BatchFlowResponseDataWriter());
     }
 
     private void initDefaultEntityDecoders() {
         RequestDataDecodeRegistry.addDecoder(ClusterConstants.MSG_TYPE_PING, new PingRequestDataDecoder());
         RequestDataDecodeRegistry.addDecoder(ClusterConstants.MSG_TYPE_FLOW, new FlowRequestDataDecoder());
         RequestDataDecodeRegistry.addDecoder(ClusterConstants.MSG_TYPE_PARAM_FLOW, new ParamFlowRequestDataDecoder());
+
+        RequestDataDecodeRegistry.addDecoder(ClusterConstants.MSG_TYPE_BATCH_FLOW,
+            new BatchFlowRequestDataDecoder());
+        RequestDataDecodeRegistry.addDecoder(ClusterConstants.MSG_TYPE_BATCH_PARAM_FLOW,
+            new BatchParamFlowRequestDataDecoder());
     }
 
     private void initDefaultProcessors() {

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/processor/BatchFlowRequestProcessor.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/processor/BatchFlowRequestProcessor.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,34 +15,38 @@
  */
 package com.alibaba.csp.sentinel.cluster.server.processor;
 
-import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 import com.alibaba.csp.sentinel.cluster.ClusterConstants;
 import com.alibaba.csp.sentinel.cluster.TokenResult;
 import com.alibaba.csp.sentinel.cluster.TokenService;
 import com.alibaba.csp.sentinel.cluster.annotation.RequestType;
 import com.alibaba.csp.sentinel.cluster.request.ClusterRequest;
-import com.alibaba.csp.sentinel.cluster.request.data.ParamFlowRequestData;
+import com.alibaba.csp.sentinel.cluster.request.data.BatchFlowRequestData;
 import com.alibaba.csp.sentinel.cluster.response.ClusterResponse;
-import com.alibaba.csp.sentinel.cluster.response.data.FlowTokenResponseData;
+import com.alibaba.csp.sentinel.cluster.response.data.BatchFlowTokenResponseData;
 import com.alibaba.csp.sentinel.cluster.server.TokenServiceProvider;
 
 /**
  * @author Eric Zhao
- * @since 1.4.0
+ * @since 1.7.0
  */
-@RequestType(ClusterConstants.MSG_TYPE_PARAM_FLOW)
-public class ParamFlowRequestProcessor implements RequestProcessor<ParamFlowRequestData, FlowTokenResponseData> {
+@RequestType(ClusterConstants.MSG_TYPE_BATCH_FLOW)
+public class BatchFlowRequestProcessor implements RequestProcessor<BatchFlowRequestData, BatchFlowTokenResponseData> {
 
     @Override
-    public ClusterResponse<FlowTokenResponseData> processRequest(ClusterRequest<ParamFlowRequestData> request) {
+    public ClusterResponse<BatchFlowTokenResponseData> processRequest(ClusterRequest<BatchFlowRequestData> request) {
         TokenService tokenService = TokenServiceProvider.getService();
 
-        long flowId = request.getData().getFlowId();
+        // The flow ID set should be valid.
+        Set<Long> flowIds = request.getData().getFlowIds();
         int count = request.getData().getCount();
-        Collection<Object> args = request.getData().getParams();
+        boolean prioritized = request.getData().isPriority();
 
-        TokenResult result = tokenService.requestParamToken(flowId, count, args);
-        return ClusterResponseGenerator.toFlowResponse(result, request);
+        TokenResult result = tokenService.batchRequestToken(flowIds, count, prioritized);
+
+        return ClusterResponseGenerator.toBatchFlowResponse(result, request);
     }
 }

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/processor/BatchParamFlowRequestProcessor.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/processor/BatchParamFlowRequestProcessor.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,34 +15,36 @@
  */
 package com.alibaba.csp.sentinel.cluster.server.processor;
 
-import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
 
 import com.alibaba.csp.sentinel.cluster.ClusterConstants;
 import com.alibaba.csp.sentinel.cluster.TokenResult;
 import com.alibaba.csp.sentinel.cluster.TokenService;
 import com.alibaba.csp.sentinel.cluster.annotation.RequestType;
 import com.alibaba.csp.sentinel.cluster.request.ClusterRequest;
-import com.alibaba.csp.sentinel.cluster.request.data.ParamFlowRequestData;
+import com.alibaba.csp.sentinel.cluster.request.data.BatchParamFlowRequestData;
 import com.alibaba.csp.sentinel.cluster.response.ClusterResponse;
-import com.alibaba.csp.sentinel.cluster.response.data.FlowTokenResponseData;
+import com.alibaba.csp.sentinel.cluster.response.data.BatchFlowTokenResponseData;
 import com.alibaba.csp.sentinel.cluster.server.TokenServiceProvider;
 
 /**
  * @author Eric Zhao
- * @since 1.4.0
+ * @since 1.7.0
  */
-@RequestType(ClusterConstants.MSG_TYPE_PARAM_FLOW)
-public class ParamFlowRequestProcessor implements RequestProcessor<ParamFlowRequestData, FlowTokenResponseData> {
+@RequestType(ClusterConstants.MSG_TYPE_BATCH_PARAM_FLOW)
+public class BatchParamFlowRequestProcessor implements RequestProcessor<BatchParamFlowRequestData, BatchFlowTokenResponseData> {
 
     @Override
-    public ClusterResponse<FlowTokenResponseData> processRequest(ClusterRequest<ParamFlowRequestData> request) {
+    public ClusterResponse<BatchFlowTokenResponseData> processRequest(ClusterRequest<BatchParamFlowRequestData> request) {
         TokenService tokenService = TokenServiceProvider.getService();
 
-        long flowId = request.getData().getFlowId();
+        // The flow ID set should be valid.
+        Set<Long> flowIds = request.getData().getFlowIds();
         int count = request.getData().getCount();
-        Collection<Object> args = request.getData().getParams();
+        Map<Integer, Object> paramMap = request.getData().getParamMap();
 
-        TokenResult result = tokenService.requestParamToken(flowId, count, args);
-        return ClusterResponseGenerator.toFlowResponse(result, request);
+        TokenResult result = tokenService.batchRequestParamToken(flowIds, count, paramMap);
+        return ClusterResponseGenerator.toBatchFlowResponse(result, request);
     }
 }

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/processor/ClusterResponseGenerator.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/processor/ClusterResponseGenerator.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.cluster.server.processor;
+
+import java.util.Map;
+
+import com.alibaba.csp.sentinel.cluster.TokenResult;
+import com.alibaba.csp.sentinel.cluster.TokenResultStatus;
+import com.alibaba.csp.sentinel.cluster.request.ClusterRequest;
+import com.alibaba.csp.sentinel.cluster.response.ClusterResponse;
+import com.alibaba.csp.sentinel.cluster.response.data.BatchFlowTokenResponseData;
+import com.alibaba.csp.sentinel.cluster.response.data.FlowTokenResponseData;
+import com.alibaba.csp.sentinel.cluster.server.ServerConstants;
+
+/**
+ * @author Eric Zhao
+ * @since 1.7.0
+ */
+final class ClusterResponseGenerator {
+
+    /**
+     * Generate a cluster response with "bad request" status.
+     *
+     * @param request the corresponding request
+     * @param <R>     arbitrary data type
+     * @return generated response
+     */
+    static <R> ClusterResponse<R> badRequest(ClusterRequest request) {
+        return new ClusterResponse<>(request.getId(), request.getType(), TokenResultStatus.BAD_REQUEST, null);
+    }
+
+    static ClusterResponse<FlowTokenResponseData> toFlowResponse(TokenResult result, ClusterRequest request) {
+        return new ClusterResponse<>(request.getId(), request.getType(), result.getStatus(),
+            new FlowTokenResponseData()
+                .setRemainingCount(result.getRemaining())
+                .setWaitInMs(result.getWaitInMs())
+        );
+    }
+
+    static ClusterResponse<BatchFlowTokenResponseData> toBatchFlowResponse(TokenResult result, ClusterRequest request) {
+        Map<String, Object> attachments = result.getAttachments();
+        Long blockId = attachments == null ? null : (Long) attachments.get(ServerConstants.ATTR_KEY_BLOCK_ID);
+        return new ClusterResponse<>(request.getId(), request.getType(), result.getStatus(),
+            new BatchFlowTokenResponseData()
+                .setWaitInMs(result.getWaitInMs())
+                .setBlockId(blockId)
+        );
+    }
+
+    //static ClusterResponse<BatchFlowTokenResponseData> toBatchFlowResponse(Map<Long, TokenResult> resultMap,
+    //                                                                       ClusterRequest request) {
+    //    int waitInMs = 0;
+    //    for (Map.Entry<Long, TokenResult> e : resultMap.entrySet()) {
+    //        TokenResult result = e.getValue();
+    //        switch (result.getStatus()) {
+    //            case TokenResultStatus.OK:
+    //                continue;
+    //            case TokenResultStatus.SHOULD_WAIT:
+    //                waitInMs = Math.max(waitInMs, result.getWaitInMs());
+    //                continue;
+    //            default:
+    //                return new ClusterResponse<>(request.getId(), request.getType(), result.getStatus(),
+    //                    new BatchFlowTokenResponseData().setBlockId(e.getKey())
+    //                );
+    //        }
+    //
+    //    }
+    //
+    //    int status = waitInMs > 0 ? TokenResultStatus.SHOULD_WAIT : TokenResultStatus.OK;
+    //    return new ClusterResponse<>(request.getId(), request.getType(), status,
+    //        new BatchFlowTokenResponseData().setWaitInMs(waitInMs)
+    //    );
+    //}
+
+    private ClusterResponseGenerator() {}
+}

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/processor/FlowRequestProcessor.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/processor/FlowRequestProcessor.java
@@ -41,14 +41,6 @@ public class FlowRequestProcessor implements RequestProcessor<FlowRequestData, F
         boolean prioritized = request.getData().isPriority();
 
         TokenResult result = tokenService.requestToken(flowId, count, prioritized);
-        return toResponse(result, request);
-    }
-
-    private ClusterResponse<FlowTokenResponseData> toResponse(TokenResult result, ClusterRequest request) {
-        return new ClusterResponse<>(request.getId(), request.getType(), result.getStatus(),
-            new FlowTokenResponseData()
-                .setRemainingCount(result.getRemaining())
-                .setWaitInMs(result.getWaitInMs())
-        );
+        return ClusterResponseGenerator.toFlowResponse(result, request);
     }
 }

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/resources/META-INF/services/com.alibaba.csp.sentinel.cluster.server.processor.RequestProcessor
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/resources/META-INF/services/com.alibaba.csp.sentinel.cluster.server.processor.RequestProcessor
@@ -1,2 +1,4 @@
 com.alibaba.csp.sentinel.cluster.server.processor.FlowRequestProcessor
 com.alibaba.csp.sentinel.cluster.server.processor.ParamFlowRequestProcessor
+com.alibaba.csp.sentinel.cluster.server.processor.BatchFlowRequestProcessor
+com.alibaba.csp.sentinel.cluster.server.processor.BatchParamFlowRequestProcessor

--- a/sentinel-cluster/sentinel-cluster-server-default/src/test/java/com/alibaba/csp/sentinel/cluster/ClusterFlowTestUtil.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/test/java/com/alibaba/csp/sentinel/cluster/ClusterFlowTestUtil.java
@@ -26,6 +26,8 @@ import static org.junit.Assert.*;
  */
 public final class ClusterFlowTestUtil {
 
+    public static final String TEST_NAMESPACE = "$sentinel_unit_test";
+
     public static void assertResultPass(TokenResult result) {
         assertNotNull(result);
         assertEquals(TokenResultStatus.OK, (int) result.getStatus());

--- a/sentinel-cluster/sentinel-cluster-server-default/src/test/java/com/alibaba/csp/sentinel/cluster/flow/ClusterFlowCheckerTest.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/test/java/com/alibaba/csp/sentinel/cluster/flow/ClusterFlowCheckerTest.java
@@ -15,17 +15,16 @@
  */
 package com.alibaba.csp.sentinel.cluster.flow;
 
+import java.util.ArrayList;
+
 import com.alibaba.csp.sentinel.cluster.TokenResult;
-import com.alibaba.csp.sentinel.cluster.flow.statistic.ClusterMetricStatistics;
-import com.alibaba.csp.sentinel.cluster.flow.statistic.metric.ClusterMetric;
-import com.alibaba.csp.sentinel.slots.block.ClusterRuleConstant;
-import com.alibaba.csp.sentinel.slots.block.flow.ClusterFlowConfig;
+import com.alibaba.csp.sentinel.cluster.flow.rule.ClusterFlowRuleManager;
 import com.alibaba.csp.sentinel.slots.block.flow.FlowRule;
 
-import org.junit.Ignore;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
 import static com.alibaba.csp.sentinel.cluster.ClusterFlowTestUtil.*;
 
 /**
@@ -34,42 +33,16 @@ import static com.alibaba.csp.sentinel.cluster.ClusterFlowTestUtil.*;
  */
 public class ClusterFlowCheckerTest {
 
-    //@Test
-    public void testAcquireClusterTokenOccupyPass() {
-        long flowId = 98765L;
-        final int threshold = 5;
-        FlowRule clusterRule = new FlowRule("abc")
-            .setCount(threshold)
-            .setClusterMode(true)
-            .setClusterConfig(new ClusterFlowConfig()
-                .setFlowId(flowId)
-                .setThresholdType(ClusterRuleConstant.FLOW_THRESHOLD_GLOBAL));
-        int sampleCount = 5;
-        int intervalInMs = 1000;
-        int bucketLength = intervalInMs / sampleCount;
-        ClusterMetric metric = new ClusterMetric(sampleCount, intervalInMs);
-        ClusterMetricStatistics.putMetric(flowId, metric);
+    @Before
+    public void setUp() throws Exception {
+        ClusterFlowRuleManager.removeProperty(TEST_NAMESPACE);
+        ClusterFlowRuleManager.loadRules(TEST_NAMESPACE, new ArrayList<FlowRule>());
+    }
 
-        System.out.println(System.currentTimeMillis());
-        assertResultPass(tryAcquire(clusterRule, false));
-        assertResultPass(tryAcquire(clusterRule, false));
-        sleep(bucketLength);
-        assertResultPass(tryAcquire(clusterRule, false));
-        sleep(bucketLength);
-        assertResultPass(tryAcquire(clusterRule, true));
-        assertResultPass(tryAcquire(clusterRule, false));
-        assertResultBlock(tryAcquire(clusterRule, true));
-        sleep(bucketLength);
-        assertResultBlock(tryAcquire(clusterRule, false));
-        assertResultBlock(tryAcquire(clusterRule, false));
-        sleep(bucketLength);
-        assertResultBlock(tryAcquire(clusterRule, false));
-        assertResultWait(tryAcquire(clusterRule, true), bucketLength);
-        assertResultBlock(tryAcquire(clusterRule, false));
-        sleep(bucketLength);
-        assertResultPass(tryAcquire(clusterRule, false));
-
-        ClusterMetricStatistics.removeMetric(flowId);
+    @After
+    public void tearDown() throws Exception {
+        ClusterFlowRuleManager.removeProperty(TEST_NAMESPACE);
+        ClusterFlowRuleManager.loadRules(TEST_NAMESPACE, new ArrayList<FlowRule>());
     }
 
     private TokenResult tryAcquire(FlowRule clusterRule, boolean occupy) {

--- a/sentinel-cluster/sentinel-cluster-server-default/src/test/java/com/alibaba/csp/sentinel/cluster/flow/DefaultTokenServiceTest.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/test/java/com/alibaba/csp/sentinel/cluster/flow/DefaultTokenServiceTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.cluster.flow;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.alibaba.csp.sentinel.cluster.TokenResult;
+import com.alibaba.csp.sentinel.cluster.TokenResultStatus;
+import com.alibaba.csp.sentinel.cluster.server.ServerConstants;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Eric Zhao
+ */
+public class DefaultTokenServiceTest {
+
+    private final DefaultTokenService tokenService = new DefaultTokenService();
+
+    @Before
+    public void setUp() throws Exception {
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void testGenerateBatchSuccessTokenResult() {
+        Map<Long, TokenResult> resultMap = new HashMap<>();
+        resultMap.put(1996L, new TokenResult().setStatus(TokenResultStatus.OK).setRemaining(12));
+        resultMap.put(1997L, new TokenResult().setStatus(TokenResultStatus.OK).setRemaining(19));
+        resultMap.put(1998L, new TokenResult().setStatus(TokenResultStatus.OK).setRemaining(7));
+
+        TokenResult result = tokenService.generateBatchTokenResult(resultMap);
+        assertThat(result.getStatus()).isEqualTo(TokenResultStatus.OK);
+        assertThat(result.getWaitInMs()).isZero();
+        assertThat(result.getAttachments()).isNull();
+    }
+
+    @Test
+    public void testGenerateBatchWaitTokenResult() {
+        Map<Long, TokenResult> resultMap = new HashMap<>();
+        // 2 pass, 2 wait
+        resultMap.put(1996L, new TokenResult().setStatus(TokenResultStatus.SHOULD_WAIT).setWaitInMs(350));
+        resultMap.put(1997L, new TokenResult().setStatus(TokenResultStatus.OK).setRemaining(19));
+        resultMap.put(1998L, new TokenResult().setStatus(TokenResultStatus.SHOULD_WAIT).setWaitInMs(200));
+        resultMap.put(1999L, new TokenResult().setStatus(TokenResultStatus.OK).setRemaining(7));
+
+        TokenResult result = tokenService.generateBatchTokenResult(resultMap);
+        assertThat(result.getStatus()).isEqualTo(TokenResultStatus.SHOULD_WAIT);
+        assertThat(result.getWaitInMs()).isEqualTo(350);
+        assertThat(result.getAttachments()).isNull();
+    }
+
+    @Test
+    public void testGenerateBatchBlockedTokenResult() {
+        Map<Long, TokenResult> resultMap = new HashMap<>();
+        long blockId = 2997L;
+        resultMap.put(2996L, new TokenResult().setStatus(TokenResultStatus.OK).setRemaining(12));
+        resultMap.put(blockId, new TokenResult().setStatus(TokenResultStatus.BLOCKED).setRemaining(0));
+        resultMap.put(2998L, new TokenResult().setStatus(TokenResultStatus.OK).setRemaining(7));
+
+        TokenResult result = tokenService.generateBatchTokenResult(resultMap);
+        assertThat(result.getStatus()).isEqualTo(TokenResultStatus.BLOCKED);
+        assertThat(result.getWaitInMs()).isZero();
+        assertThat(result.getAttachments()).isNotNull();
+        assertThat(result.getAttachments())
+            .extracting(ServerConstants.ATTR_KEY_BLOCK_ID)
+            .contains(blockId);
+    }
+}

--- a/sentinel-cluster/sentinel-cluster-server-default/src/test/java/com/alibaba/csp/sentinel/cluster/server/codec/data/BatchFlowRequestDataDecoderIntegrationTest.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/test/java/com/alibaba/csp/sentinel/cluster/server/codec/data/BatchFlowRequestDataDecoderIntegrationTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.cluster.server.codec.data;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.alibaba.csp.sentinel.cluster.client.codec.data.BatchFlowRequestDataWriter;
+import com.alibaba.csp.sentinel.cluster.request.data.BatchFlowRequestData;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Eric Zhao
+ */
+public class BatchFlowRequestDataDecoderIntegrationTest {
+
+    @Test
+    public void testDecodeBatchFlowRequestData() {
+        EmbeddedChannel embeddedChannel = new EmbeddedChannel();
+        ByteBuf buf = Unpooled.buffer();
+        BatchFlowRequestDataWriter writer = new BatchFlowRequestDataWriter();
+        BatchFlowRequestDataDecoder decoder = new BatchFlowRequestDataDecoder();
+
+        Set<Long> ids = new HashSet<>();
+        ids.add(12L);
+        ids.add(23L);
+        BatchFlowRequestData requestData = new BatchFlowRequestData()
+            .setFlowIds(ids)
+            .setCount(10)
+            .setPriority(true);
+
+        writer.writeTo(requestData, buf);
+        embeddedChannel.writeInbound(buf);
+
+        BatchFlowRequestData decoded = decoder.decode((ByteBuf)embeddedChannel.readInbound());
+        assertThat(decoded.getFlowIds()).isEqualTo(ids);
+        assertThat(decoded.getCount()).isEqualTo(10);
+        assertThat(decoded.isPriority()).isEqualTo(true);
+
+        buf.release();
+        embeddedChannel.close();
+    }
+}

--- a/sentinel-cluster/sentinel-cluster-server-default/src/test/java/com/alibaba/csp/sentinel/cluster/server/codec/data/BatchParamFlowRequestDataDecoderIntegrationTest.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/test/java/com/alibaba/csp/sentinel/cluster/server/codec/data/BatchParamFlowRequestDataDecoderIntegrationTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.cluster.server.codec.data;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.alibaba.csp.sentinel.cluster.client.codec.data.BatchParamFlowRequestDataWriter;
+import com.alibaba.csp.sentinel.cluster.request.data.BatchParamFlowRequestData;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Eric Zhao
+ */
+public class BatchParamFlowRequestDataDecoderIntegrationTest {
+
+    @Test
+    public void testDecodeBatchParamFlowRequestData() {
+        EmbeddedChannel embeddedChannel = new EmbeddedChannel();
+        ByteBuf buf = Unpooled.buffer();
+        BatchParamFlowRequestDataWriter writer = new BatchParamFlowRequestDataWriter();
+        BatchParamFlowRequestDataDecoder decoder = new BatchParamFlowRequestDataDecoder();
+
+        Set<Long> ids = new HashSet<>();
+        ids.add(144L);
+        ids.add(27712L);
+        Map<Integer, Object> params = new HashMap<>();
+        params.put(0, 1L);
+        params.put(1, 3.1f);
+        params.put(2, "foo");
+        params.put(3, new Object());
+        params.put(4, false);
+        BatchParamFlowRequestData requestData = new BatchParamFlowRequestData()
+            .setFlowIds(ids)
+            .setCount(10)
+            .setParamMap(params);
+
+        writer.writeTo(requestData, buf);
+        embeddedChannel.writeInbound(buf);
+
+        BatchParamFlowRequestData decoded = decoder.decode((ByteBuf) embeddedChannel.readInbound());
+        assertThat(decoded.getFlowIds()).isEqualTo(ids);
+        assertThat(decoded.getCount()).isEqualTo(10);
+        assertThat(decoded.getParamMap().size()).isEqualTo(params.size() - 1);
+        assertThat(decoded.getParamMap().values()).isSubsetOf(params.values());
+        assertThat(decoded.getParamMap()).doesNotContainKey(3);
+
+        buf.release();
+        embeddedChannel.close();
+    }
+}

--- a/sentinel-cluster/sentinel-cluster-server-default/src/test/java/com/alibaba/csp/sentinel/cluster/server/processor/ClusterResponseGeneratorTest.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/test/java/com/alibaba/csp/sentinel/cluster/server/processor/ClusterResponseGeneratorTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.cluster.server.processor;
+
+import java.util.HashMap;
+
+import com.alibaba.csp.sentinel.cluster.TokenResult;
+import com.alibaba.csp.sentinel.cluster.TokenResultStatus;
+import com.alibaba.csp.sentinel.cluster.request.ClusterRequest;
+import com.alibaba.csp.sentinel.cluster.response.ClusterResponse;
+import com.alibaba.csp.sentinel.cluster.response.data.BatchFlowTokenResponseData;
+import com.alibaba.csp.sentinel.cluster.response.data.FlowTokenResponseData;
+import com.alibaba.csp.sentinel.cluster.server.ServerConstants;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Eric Zhao
+ */
+public class ClusterResponseGeneratorTest {
+
+    @Test
+    public void testGenerateForBadRequest() {
+        int tid = 337788;
+        int type = 33;
+        ClusterRequest<?> request = new ClusterRequest<>(tid, type, null);
+        ClusterResponse<?> response = ClusterResponseGenerator.badRequest(request);
+        assertThat(response.getId()).isEqualTo(tid);
+        assertThat(response.getType()).isEqualTo(type);
+        assertThat(response.getStatus()).isEqualTo(TokenResultStatus.BAD_REQUEST);
+    }
+
+    @Test
+    public void testGenerateFlowResponse() {
+        int tid = 337789;
+        int type = 34;
+        ClusterRequest<?> request = new ClusterRequest<>(tid, type, null);
+
+        TokenResult result = new TokenResult().setStatus(TokenResultStatus.OK)
+            .setRemaining(127)
+            .setWaitInMs(0);
+        ClusterResponse<FlowTokenResponseData> response = ClusterResponseGenerator.toFlowResponse(result, request);
+        assertThat(response.getId()).isEqualTo(tid);
+        assertThat(response.getType()).isEqualTo(type);
+        assertThat(response.getStatus()).isEqualTo(TokenResultStatus.OK);
+        assertThat(response.getData().getRemainingCount()).isEqualTo(127);
+    }
+
+    @Test
+    public void testGenerateBatchSuccessResponse() {
+        int tid = 337789;
+        int type = 34;
+        ClusterRequest<?> request = new ClusterRequest<>(tid, type, null);
+
+        TokenResult result = new TokenResult(TokenResultStatus.OK).setRemaining(12);
+
+        ClusterResponse<BatchFlowTokenResponseData> response = ClusterResponseGenerator
+            .toBatchFlowResponse(result, request);
+        assertThat(response.getId()).isEqualTo(tid);
+        assertThat(response.getType()).isEqualTo(type);
+        assertThat(response.getStatus()).isEqualTo(TokenResultStatus.OK);
+        assertThat(response.getData().getWaitInMs()).isZero();
+        assertThat(response.getData().getBlockId()).isNull();
+    }
+
+    @Test
+    public void testGenerateBatchBlockResponse() {
+        int tid = 337789;
+        int type = 34;
+        ClusterRequest<?> request = new ClusterRequest<>(tid, type, null);
+
+        final long blockId = 123L;
+        TokenResult result = new TokenResult(TokenResultStatus.BLOCKED).setRemaining(12)
+            .setAttachments(new HashMap<String, Object>() {{ put(ServerConstants.ATTR_KEY_BLOCK_ID, blockId); }});
+
+        ClusterResponse<BatchFlowTokenResponseData> response = ClusterResponseGenerator
+            .toBatchFlowResponse(result, request);
+        assertThat(response.getId()).isEqualTo(tid);
+        assertThat(response.getType()).isEqualTo(type);
+        assertThat(response.getStatus()).isEqualTo(TokenResultStatus.BLOCKED);
+        assertThat(response.getData().getWaitInMs()).isZero();
+        assertThat(response.getData().getBlockId()).isEqualTo(blockId);
+    }
+}

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/cluster/TokenResult.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/cluster/TokenResult.java
@@ -30,7 +30,7 @@ public class TokenResult {
     private int remaining;
     private int waitInMs;
 
-    private Map<String, String> attachments;
+    private Map<String, Object> attachments;
 
     public TokenResult() {}
 
@@ -65,11 +65,11 @@ public class TokenResult {
         return this;
     }
 
-    public Map<String, String> getAttachments() {
+    public Map<String, Object> getAttachments() {
         return attachments;
     }
 
-    public TokenResult setAttachments(Map<String, String> attachments) {
+    public TokenResult setAttachments(Map<String, Object> attachments) {
         this.attachments = attachments;
         return this;
     }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/cluster/TokenService.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/cluster/TokenService.java
@@ -16,6 +16,8 @@
 package com.alibaba.csp.sentinel.cluster;
 
 import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Service interface of flow control.
@@ -28,9 +30,9 @@ public interface TokenService {
     /**
      * Request tokens from remote token server.
      *
-     * @param ruleId the unique rule ID
+     * @param ruleId       the unique rule ID
      * @param acquireCount token count to acquire
-     * @param prioritized whether the request is prioritized
+     * @param prioritized  whether the request is prioritized
      * @return result of the token request
      */
     TokenResult requestToken(Long ruleId, int acquireCount, boolean prioritized);
@@ -38,10 +40,32 @@ public interface TokenService {
     /**
      * Request tokens for a specific parameter from remote token server.
      *
-     * @param ruleId the unique rule ID
+     * @param ruleId       the unique rule ID
      * @param acquireCount token count to acquire
-     * @param params parameter list
+     * @param params       parameter list of the single rule
      * @return result of the token request
      */
     TokenResult requestParamToken(Long ruleId, int acquireCount, Collection<Object> params);
+
+    /**
+     * Request tokens in batch.
+     *
+     * @param ruleIds      the ID set of target rules
+     * @param acquireCount token count to acquire
+     * @param prioritized  whether the request is prioritized
+     * @return result of the token request
+     * @since 1.7.0
+     */
+    TokenResult batchRequestToken(Set<Long> ruleIds, int acquireCount, boolean prioritized);
+
+    /**
+     * Request tokens in batch for a specific list of parameters.
+     *
+     * @param ruleIds      the ID set of target rules
+     * @param acquireCount token count to acquire
+     * @param paramMap     parameter map for all available paramIdx of given cluster rules
+     * @return result of the token request
+     * @since 1.7.0
+     */
+    TokenResult batchRequestParamToken(Set<Long> ruleIds, int acquireCount, Map<Integer, Object> paramMap);
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/SpiLoader.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/SpiLoader.java
@@ -100,6 +100,9 @@ public final class SpiLoader {
      * @since 1.6.0
      */
     public static <T> List<T> loadInstanceList(Class<T> clazz) {
+        if (clazz == null) {
+            return new ArrayList<>();
+        }
         try {
             String key = clazz.getName();
             // Not thread-safe, as it's expected to be resolved in a thread-safe context.
@@ -115,7 +118,7 @@ public final class SpiLoader {
             }
             return list;
         } catch (Throwable t) {
-            RecordLog.warn("[SpiLoader] ERROR: loadInstanceListSorted failed", t);
+            RecordLog.warn("[SpiLoader] ERROR: loadInstanceList failed for class: " + clazz.getSimpleName(), t);
             t.printStackTrace();
             return new ArrayList<>();
         }


### PR DESCRIPTION
### Describe what this PR does / why we need it

Add batch request support for transport of cluster flow control to reduce network overhead in some circumstances.

### Does this pull request fix one issue?

Resolves #849

### Describe how you did it

- Add two batch APIs (`batchRequestToken` and `batchRequestParamToken`) in TokenService to support batch requests in cluster flow control:
- Change attachment type in `TokenResult` to `Map<String, Object>`
- Add batch token request and response entity in cluster common module
- Add codec, client and server implementation for batch cluster token request/response
  - Add batch token request/response decoder and writers respectively
  - Update `DefaultClusterTokenClient` to support batch requests
  - Add request processors for batch token request in token server module
  - Polish the `DefaultTokenService` in cluster server module
- Other code refinement

### Describe how to verify it

Run the test cases.

### Special notes for reviews

Please take care of the new marshalling and unmarshalling logic.