### PR TITLE
Enhancement/passCount in DegradeRule to LongAdder

### DIFF
--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/compare/slots/block/degrade/passcount/atomic/DegradeRule.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/compare/slots/block/degrade/passcount/atomic/DegradeRule.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.compare.slots.block.degrade.passcount.atomic;
+
+import com.alibaba.csp.sentinel.concurrent.NamedThreadFactory;
+import com.alibaba.csp.sentinel.context.Context;
+import com.alibaba.csp.sentinel.node.ClusterNode;
+import com.alibaba.csp.sentinel.node.DefaultNode;
+import com.alibaba.csp.sentinel.slots.block.AbstractRule;
+import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+import com.alibaba.csp.sentinel.slots.clusterbuilder.ClusterBuilderSlot;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * <p>
+ * Degrade is used when the resources are in an unstable state, these resources
+ * will be degraded within the next defined time window. There are two ways to
+ * measure whether a resource is stable or not:
+ * </p>
+ * <ul>
+ * <li>
+ * Average response time ({@code DEGRADE_GRADE_RT}): When
+ * the average RT exceeds the threshold ('count' in 'DegradeRule', in milliseconds), the
+ * resource enters a quasi-degraded state. If the RT of next coming 5
+ * requests still exceed this threshold, this resource will be downgraded, which
+ * means that in the next time window (defined in 'timeWindow', in seconds) all the
+ * access to this resource will be blocked.
+ * </li>
+ * <li>
+ * Exception ratio: When the ratio of exception count per second and the
+ * success qps exceeds the threshold, access to the resource will be blocked in
+ * the coming window.
+ * </li>
+ * </ul>
+ *
+ * @author jialiang.linjl
+ */
+public class DegradeRule extends AbstractRule {
+
+    @SuppressWarnings("PMD.ThreadPoolCreationRule")
+    private static ScheduledExecutorService pool = Executors.newScheduledThreadPool(
+            Runtime.getRuntime().availableProcessors(), new NamedThreadFactory("sentinel-degrade-reset-task", true));
+
+    public DegradeRule() {}
+
+    public DegradeRule(String resourceName) {
+        setResource(resourceName);
+    }
+
+    /**
+     * RT threshold or exception ratio threshold count.
+     */
+    private double count;
+
+    /**
+     * Degrade recover timeout (in seconds) when degradation occurs.
+     */
+    private int timeWindow;
+
+    /**
+     * Degrade strategy (0: average RT, 1: exception ratio, 2: exception count).
+     */
+    private int grade = RuleConstant.DEGRADE_GRADE_RT;
+
+    /**
+     * Minimum number of consecutive slow requests that can trigger RT circuit breaking.
+     *
+     * @since 1.7.0
+     */
+    private int rtSlowRequestAmount = RuleConstant.DEGRADE_DEFAULT_SLOW_REQUEST_AMOUNT;
+
+    /**
+     * Minimum number of requests (in an active statistic time span) that can trigger circuit breaking.
+     *
+     * @since 1.7.0
+     */
+    private int minRequestAmount = RuleConstant.DEGRADE_DEFAULT_MIN_REQUEST_AMOUNT;
+
+    public int getGrade() {
+        return grade;
+    }
+
+    public DegradeRule setGrade(int grade) {
+        this.grade = grade;
+        return this;
+    }
+
+    public double getCount() {
+        return count;
+    }
+
+    public DegradeRule setCount(double count) {
+        this.count = count;
+        return this;
+    }
+
+    public long getPassCount() {
+        return passCount.get();
+    }
+
+    public int getTimeWindow() {
+        return timeWindow;
+    }
+
+    public DegradeRule setTimeWindow(int timeWindow) {
+        this.timeWindow = timeWindow;
+        return this;
+    }
+
+    public int getRtSlowRequestAmount() {
+        return rtSlowRequestAmount;
+    }
+
+    public DegradeRule setRtSlowRequestAmount(int rtSlowRequestAmount) {
+        this.rtSlowRequestAmount = rtSlowRequestAmount;
+        return this;
+    }
+
+    public int getMinRequestAmount() {
+        return minRequestAmount;
+    }
+
+    public DegradeRule setMinRequestAmount(int minRequestAmount) {
+        this.minRequestAmount = minRequestAmount;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+        if (!super.equals(o)) { return false; }
+        DegradeRule that = (DegradeRule) o;
+        return Double.compare(that.count, count) == 0 &&
+                timeWindow == that.timeWindow &&
+                grade == that.grade &&
+                rtSlowRequestAmount == that.rtSlowRequestAmount &&
+                minRequestAmount == that.minRequestAmount;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + new Double(count).hashCode();
+        result = 31 * result + timeWindow;
+        result = 31 * result + grade;
+        result = 31 * result + rtSlowRequestAmount;
+        result = 31 * result + minRequestAmount;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "DegradeRule{" +
+                "resource=" + getResource() +
+                ", grade=" + grade +
+                ", count=" + count +
+                ", limitApp=" + getLimitApp() +
+                ", timeWindow=" + timeWindow +
+                ", rtSlowRequestAmount=" + rtSlowRequestAmount +
+                ", minRequestAmount=" + minRequestAmount +
+                "}";
+    }
+
+    // Internal implementation (will be deprecated and moved outside).
+
+    private AtomicLong passCount = new AtomicLong(0);
+    private final AtomicBoolean cut = new AtomicBoolean(false);
+
+    @Override
+    public boolean passCheck(Context context, DefaultNode node, int acquireCount, Object... args) {
+        if (cut.get()) {
+            return false;
+        }
+
+        ClusterNode clusterNode = ClusterBuilderSlot.getClusterNode(this.getResource());
+        if (clusterNode == null) {
+            return true;
+        }
+
+        if (grade == RuleConstant.DEGRADE_GRADE_RT) {
+            double rt = clusterNode.avgRt();
+            if (rt < this.count) {
+                passCount.set(0);
+                return true;
+            }
+
+            // Sentinel will degrade the service only if count exceeds.
+            if (passCount.incrementAndGet() < rtSlowRequestAmount) {
+                return true;
+            }
+        } else if (grade == RuleConstant.DEGRADE_GRADE_EXCEPTION_RATIO) {
+            double exception = clusterNode.exceptionQps();
+            double success = clusterNode.successQps();
+            double total = clusterNode.totalQps();
+            // If total amount is less than minRequestAmount, the request will pass.
+            if (total < minRequestAmount) {
+                return true;
+            }
+
+            // In the same aligned statistic time window,
+            // "success" (aka. completed count) = exception count + non-exception count (realSuccess)
+            double realSuccess = success - exception;
+            if (realSuccess <= 0 && exception < minRequestAmount) {
+                return true;
+            }
+
+            if (exception / success < count) {
+                return true;
+            }
+        } else if (grade == RuleConstant.DEGRADE_GRADE_EXCEPTION_COUNT) {
+            double exception = clusterNode.totalException();
+            if (exception < count) {
+                return true;
+            }
+        }
+
+        if (cut.compareAndSet(false, true)) {
+            ResetTask resetTask = new ResetTask(this);
+            pool.schedule(resetTask, timeWindow, TimeUnit.SECONDS);
+        }
+
+        return false;
+    }
+
+    private static final class ResetTask implements Runnable {
+
+        private DegradeRule rule;
+
+        ResetTask(DegradeRule rule) {
+            this.rule = rule;
+        }
+
+        @Override
+        public void run() {
+            rule.passCount.set(0);
+            rule.cut.set(false);
+        }
+    }
+
+}

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/compare/slots/block/degrade/passcount/atomic/DegradeTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/compare/slots/block/degrade/passcount/atomic/DegradeTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.compare.slots.block.degrade.passcount.atomic;
+
+import com.alibaba.csp.sentinel.EntryType;
+import com.alibaba.csp.sentinel.context.Context;
+import com.alibaba.csp.sentinel.node.ClusterNode;
+import com.alibaba.csp.sentinel.node.DefaultNode;
+import com.alibaba.csp.sentinel.slotchain.StringResourceWrapper;
+import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+import com.alibaba.csp.sentinel.slots.clusterbuilder.ClusterBuilderSlot;
+import com.alibaba.csp.sentinel.util.TimeUtil;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DegradeTest {
+
+    @Test
+    public void testAverageRtDegrade() throws InterruptedException {
+        String key = "test_degrade_average_rt";
+        ClusterNode cn = mock(ClusterNode.class);
+        ClusterBuilderSlot.getClusterNodeMap().put(new StringResourceWrapper(key, EntryType.IN), cn);
+
+        final Context context = mock(Context.class);
+        final DefaultNode node = mock(DefaultNode.class);
+        when(node.getClusterNode()).thenReturn(cn);
+        when(cn.avgRt()).thenReturn(2d);
+
+        int rtSlowRequestAmount = 10000;
+        final DegradeRule rule = new DegradeRule();
+        rule.setCount(1);
+        rule.setResource(key);
+        rule.setTimeWindow(2);
+        rule.setGrade(RuleConstant.DEGRADE_GRADE_RT);
+        rule.setRtSlowRequestAmount(rtSlowRequestAmount);
+
+        final int nThreads = 8000;
+        final CountDownLatch latch = new CountDownLatch(nThreads);
+        final long time = TimeUtil.currentTimeMillis();
+
+        Runnable task = new Runnable() {
+            @Override
+            public void run() {
+                rule.passCheck(context, node, 1);
+                latch.countDown();
+            }
+        };
+
+        for (int i = 0; i < nThreads; i++) {
+            new Thread(task).start();
+        }
+
+        latch.await();
+
+        assertEquals(nThreads, rule.getPassCount());
+        System.out.format("Run Degrade passCheck with Atomic passCount: %dms", TimeUtil.currentTimeMillis() - time);
+    }
+
+}

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/compare/slots/block/degrade/passcount/atomic/DegradeTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/compare/slots/block/degrade/passcount/atomic/DegradeTest.java
@@ -31,6 +31,9 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+/**
+ * @author Jobs Wang
+ */
 public class DegradeTest {
 
     @Test

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/compare/slots/block/degrade/passcount/longadder/DegradeRule.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/compare/slots/block/degrade/passcount/longadder/DegradeRule.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.compare.slots.block.degrade.passcount.longadder;
+
+import com.alibaba.csp.sentinel.concurrent.NamedThreadFactory;
+import com.alibaba.csp.sentinel.context.Context;
+import com.alibaba.csp.sentinel.node.ClusterNode;
+import com.alibaba.csp.sentinel.node.DefaultNode;
+import com.alibaba.csp.sentinel.slots.block.AbstractRule;
+import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+import com.alibaba.csp.sentinel.slots.clusterbuilder.ClusterBuilderSlot;
+import com.alibaba.csp.sentinel.slots.statistic.base.LongAdder;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * <p>
+ * Degrade is used when the resources are in an unstable state, these resources
+ * will be degraded within the next defined time window. There are two ways to
+ * measure whether a resource is stable or not:
+ * </p>
+ * <ul>
+ * <li>
+ * Average response time ({@code DEGRADE_GRADE_RT}): When
+ * the average RT exceeds the threshold ('count' in 'DegradeRule', in milliseconds), the
+ * resource enters a quasi-degraded state. If the RT of next coming 5
+ * requests still exceed this threshold, this resource will be downgraded, which
+ * means that in the next time window (defined in 'timeWindow', in seconds) all the
+ * access to this resource will be blocked.
+ * </li>
+ * <li>
+ * Exception ratio: When the ratio of exception count per second and the
+ * success qps exceeds the threshold, access to the resource will be blocked in
+ * the coming window.
+ * </li>
+ * </ul>
+ *
+ * @author jialiang.linjl
+ */
+public class DegradeRule extends AbstractRule {
+
+    @SuppressWarnings("PMD.ThreadPoolCreationRule")
+    private static ScheduledExecutorService pool = Executors.newScheduledThreadPool(
+        Runtime.getRuntime().availableProcessors(), new NamedThreadFactory("sentinel-degrade-reset-task", true));
+
+    public DegradeRule() {}
+
+    public DegradeRule(String resourceName) {
+        setResource(resourceName);
+    }
+
+    /**
+     * RT threshold or exception ratio threshold count.
+     */
+    private double count;
+
+    /**
+     * Degrade recover timeout (in seconds) when degradation occurs.
+     */
+    private int timeWindow;
+
+    /**
+     * Degrade strategy (0: average RT, 1: exception ratio, 2: exception count).
+     */
+    private int grade = RuleConstant.DEGRADE_GRADE_RT;
+
+    /**
+     * Minimum number of consecutive slow requests that can trigger RT circuit breaking.
+     *
+     * @since 1.7.0
+     */
+    private int rtSlowRequestAmount = RuleConstant.DEGRADE_DEFAULT_SLOW_REQUEST_AMOUNT;
+
+    /**
+     * Minimum number of requests (in an active statistic time span) that can trigger circuit breaking.
+     *
+     * @since 1.7.0
+     */
+    private int minRequestAmount = RuleConstant.DEGRADE_DEFAULT_MIN_REQUEST_AMOUNT;
+
+    public int getGrade() {
+        return grade;
+    }
+
+    public DegradeRule setGrade(int grade) {
+        this.grade = grade;
+        return this;
+    }
+
+    public double getCount() {
+        return count;
+    }
+
+    public DegradeRule setCount(double count) {
+        this.count = count;
+        return this;
+    }
+
+    public long getPassCount() {
+        return passCount.sum();
+    }
+
+    public int getTimeWindow() {
+        return timeWindow;
+    }
+
+    public DegradeRule setTimeWindow(int timeWindow) {
+        this.timeWindow = timeWindow;
+        return this;
+    }
+
+    public int getRtSlowRequestAmount() {
+        return rtSlowRequestAmount;
+    }
+
+    public DegradeRule setRtSlowRequestAmount(int rtSlowRequestAmount) {
+        this.rtSlowRequestAmount = rtSlowRequestAmount;
+        return this;
+    }
+
+    public int getMinRequestAmount() {
+        return minRequestAmount;
+    }
+
+    public DegradeRule setMinRequestAmount(int minRequestAmount) {
+        this.minRequestAmount = minRequestAmount;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+        if (!super.equals(o)) { return false; }
+        DegradeRule that = (DegradeRule) o;
+        return Double.compare(that.count, count) == 0 &&
+            timeWindow == that.timeWindow &&
+            grade == that.grade &&
+            rtSlowRequestAmount == that.rtSlowRequestAmount &&
+            minRequestAmount == that.minRequestAmount;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + new Double(count).hashCode();
+        result = 31 * result + timeWindow;
+        result = 31 * result + grade;
+        result = 31 * result + rtSlowRequestAmount;
+        result = 31 * result + minRequestAmount;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "DegradeRule{" +
+            "resource=" + getResource() +
+            ", grade=" + grade +
+            ", count=" + count +
+            ", limitApp=" + getLimitApp() +
+            ", timeWindow=" + timeWindow +
+            ", rtSlowRequestAmount=" + rtSlowRequestAmount +
+            ", minRequestAmount=" + minRequestAmount +
+            "}";
+    }
+
+    // Internal implementation (will be deprecated and moved outside).
+
+    private LongAdder passCount = new LongAdder();
+    private final AtomicBoolean cut = new AtomicBoolean(false);
+
+    @Override
+    public boolean passCheck(Context context, DefaultNode node, int acquireCount, Object... args) {
+        if (cut.get()) {
+            return false;
+        }
+
+        ClusterNode clusterNode = ClusterBuilderSlot.getClusterNode(this.getResource());
+        if (clusterNode == null) {
+            return true;
+        }
+
+        if (grade == RuleConstant.DEGRADE_GRADE_RT) {
+            double rt = clusterNode.avgRt();
+            if (rt < this.count) {
+                passCount.reset();
+                return true;
+            }
+
+            // Sentinel will degrade the service only if count exceeds.
+            passCount.increment();
+            if (passCount.sum() < rtSlowRequestAmount) {
+                return true;
+            }
+        } else if (grade == RuleConstant.DEGRADE_GRADE_EXCEPTION_RATIO) {
+            double exception = clusterNode.exceptionQps();
+            double success = clusterNode.successQps();
+            double total = clusterNode.totalQps();
+            // If total amount is less than minRequestAmount, the request will pass.
+            if (total < minRequestAmount) {
+                return true;
+            }
+
+            // In the same aligned statistic time window,
+            // "success" (aka. completed count) = exception count + non-exception count (realSuccess)
+            double realSuccess = success - exception;
+            if (realSuccess <= 0 && exception < minRequestAmount) {
+                return true;
+            }
+
+            if (exception / success < count) {
+                return true;
+            }
+        } else if (grade == RuleConstant.DEGRADE_GRADE_EXCEPTION_COUNT) {
+            double exception = clusterNode.totalException();
+            if (exception < count) {
+                return true;
+            }
+        }
+
+        if (cut.compareAndSet(false, true)) {
+            ResetTask resetTask = new ResetTask(this);
+            pool.schedule(resetTask, timeWindow, TimeUnit.SECONDS);
+        }
+
+        return false;
+    }
+
+    private static final class ResetTask implements Runnable {
+
+        private DegradeRule rule;
+
+        ResetTask(DegradeRule rule) {
+            this.rule = rule;
+        }
+
+        @Override
+        public void run() {
+            rule.passCount.reset();
+            rule.cut.set(false);
+        }
+    }
+}

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/compare/slots/block/degrade/passcount/longadder/DegradeTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/compare/slots/block/degrade/passcount/longadder/DegradeTest.java
@@ -31,6 +31,9 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+/**
+ * @author Jobs Wang
+ */
 public class DegradeTest {
 
     @Test

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/compare/slots/block/degrade/passcount/longadder/DegradeTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/compare/slots/block/degrade/passcount/longadder/DegradeTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.compare.slots.block.degrade.passcount.longadder;
+
+import com.alibaba.csp.sentinel.EntryType;
+import com.alibaba.csp.sentinel.context.Context;
+import com.alibaba.csp.sentinel.node.ClusterNode;
+import com.alibaba.csp.sentinel.node.DefaultNode;
+import com.alibaba.csp.sentinel.slotchain.StringResourceWrapper;
+import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+import com.alibaba.csp.sentinel.slots.clusterbuilder.ClusterBuilderSlot;
+import com.alibaba.csp.sentinel.util.TimeUtil;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DegradeTest {
+
+    @Test
+    public void testAverageRtDegrade() throws InterruptedException {
+        String key = "test_degrade_average_rt";
+        ClusterNode cn = mock(ClusterNode.class);
+        ClusterBuilderSlot.getClusterNodeMap().put(new StringResourceWrapper(key, EntryType.IN), cn);
+
+        final Context context = mock(Context.class);
+        final DefaultNode node = mock(DefaultNode.class);
+        when(node.getClusterNode()).thenReturn(cn);
+        when(cn.avgRt()).thenReturn(2d);
+
+        int rtSlowRequestAmount = 10000;
+        final DegradeRule rule = new DegradeRule();
+        rule.setCount(1);
+        rule.setResource(key);
+        rule.setTimeWindow(2);
+        rule.setGrade(RuleConstant.DEGRADE_GRADE_RT);
+        rule.setRtSlowRequestAmount(rtSlowRequestAmount);
+
+        final int nThreads = 8000;
+        final CountDownLatch latch = new CountDownLatch(nThreads);
+        final long time = TimeUtil.currentTimeMillis();
+
+        Runnable task = new Runnable() {
+            @Override
+            public void run() {
+                rule.passCheck(context, node, 1);
+                latch.countDown();
+            }
+        };
+
+        for (int i = 0; i < nThreads; i++) {
+            new Thread(task).start();
+        }
+
+        latch.await();
+
+        assertEquals(nThreads, rule.getPassCount());
+        System.out.format("Run Degrade passCheck with LongAdder passCount: %dms", TimeUtil.currentTimeMillis() - time);
+    }
+
+}


### PR DESCRIPTION
Describe what this PR does / why we need it
To improve the performance for counting passCount in degrade scenario.

Does this pull request fix one issue?
Features #861 

Describe how you did it
Change `passCount` in `DegradeRule` from `AtomicLong` to `LongAdder`

Describe how to verify it
Run ut `DegradeTest` below `compare.slots.block.degrade.passcount` package.
`DegradeTest` below `compare.slots.block.degrade.passcount.atomic` for `AtomicLong` Test.
`DegradeTest` below `compare.slots.block.degrade.passcount.longadder` for `LongAdder` Test.
