### PR TITLE
Add the feature of excluding unused URLs in CommonFilter (#287)

### DIFF
--- a/sentinel-adapter/sentinel-web-servlet/README.md
+++ b/sentinel-adapter/sentinel-web-servlet/README.md
@@ -51,6 +51,8 @@ block handler (the `UrlBlockHandler` interface) and register to `WebCallbackMana
 The `UrlCleaner` interface is designed for clean and unify the URL resource.
 For REST APIs, you have to clean the URL resource (e.g. `/foo/1` and `/foo/2` -> `/foo/:id`), or
 the amount of context and resources will exceed the threshold.
+The `UrlCleaner` interface can also exclude unused URLs(e.g. `/exclude/1` -> `/exclude/:id` -> `""`).
+The URLs will be filtered and not be resource in this way.
 
 `RequestOriginParser` interface is useful for extracting request origin (e.g. IP or appName from HTTP Header)
 from HTTP request. You can implement your own `RequestOriginParser` and register to `WebCallbackManager`.

--- a/sentinel-adapter/sentinel-web-servlet/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/CommonFilter.java
+++ b/sentinel-adapter/sentinel-web-servlet/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/CommonFilter.java
@@ -73,19 +73,19 @@ public class CommonFilter implements Filter {
                 target = urlCleaner.clean(target);
             }
 
-            // Parse the request origin using registered origin parser.
-            String origin = parseOrigin(sRequest);
-
-            ContextUtil.enter(target, origin);
-            entry = SphU.entry(target, EntryType.IN);
-
-
-            // Add method specification if necessary
-            if (httpMethodSpecify) {
-                methodEntry = SphU.entry(sRequest.getMethod().toUpperCase() + COLON + target,
-                        EntryType.IN);
+            // If you intend to exclude some URLs, you can convert the URLs to the empty string ""
+            // in the UrlCleaner implementation.
+            if (target != "") {
+                // Parse the request origin using registered origin parser.
+                String origin = parseOrigin(sRequest);
+                ContextUtil.enter(target, origin);
+                entry = SphU.entry(target, EntryType.IN);
+                // Add method specification if necessary
+                if (httpMethodSpecify) {
+                    methodEntry = SphU.entry(sRequest.getMethod().toUpperCase() + COLON + target,
+                            EntryType.IN);
+                }
             }
-
             chain.doFilter(request, response);
         } catch (BlockException e) {
             HttpServletResponse sResponse = (HttpServletResponse) response;
@@ -107,7 +107,9 @@ public class CommonFilter implements Filter {
             if (entry != null) {
                 entry.exit();
             }
-            ContextUtil.exit();
+            if (ContextUtil.getContext() != null) {
+                ContextUtil.exit();
+            }
         }
     }
 

--- a/sentinel-adapter/sentinel-web-servlet/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/CommonFilter.java
+++ b/sentinel-adapter/sentinel-web-servlet/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/CommonFilter.java
@@ -75,7 +75,7 @@ public class CommonFilter implements Filter {
 
             // If you intend to exclude some URLs, you can convert the URLs to the empty string ""
             // in the UrlCleaner implementation.
-            if (target != "") {
+            if (StringUtil.isEmpty(target)) {
                 // Parse the request origin using registered origin parser.
                 String origin = parseOrigin(sRequest);
                 ContextUtil.enter(target, origin);
@@ -107,9 +107,7 @@ public class CommonFilter implements Filter {
             if (entry != null) {
                 entry.exit();
             }
-            if (ContextUtil.getContext() != null) {
-                ContextUtil.exit();
-            }
+            ContextUtil.exit();
         }
     }
 

--- a/sentinel-adapter/sentinel-web-servlet/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/CommonFilter.java
+++ b/sentinel-adapter/sentinel-web-servlet/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/CommonFilter.java
@@ -75,7 +75,7 @@ public class CommonFilter implements Filter {
 
             // If you intend to exclude some URLs, you can convert the URLs to the empty string ""
             // in the UrlCleaner implementation.
-            if (StringUtil.isEmpty(target)) {
+            if (!StringUtil.isEmpty(target)) {
                 // Parse the request origin using registered origin parser.
                 String origin = parseOrigin(sRequest);
                 ContextUtil.enter(target, origin);

--- a/sentinel-adapter/sentinel-web-servlet/src/test/java/com/alibaba/csp/sentinel/adapter/servlet/CommonFilterTest.java
+++ b/sentinel-adapter/sentinel-web-servlet/src/test/java/com/alibaba/csp/sentinel/adapter/servlet/CommonFilterTest.java
@@ -89,7 +89,7 @@ public class CommonFilterTest {
 
         // Test for url cleaner.
         testUrlCleaner();
-
+        testUrlExclusion();
         testCustomOriginParser();
     }
 
@@ -136,6 +136,25 @@ public class CommonFilterTest {
         assertNull(ClusterBuilderSlot.getClusterNode(url1));
         assertNull(ClusterBuilderSlot.getClusterNode(url2));
 
+        WebCallbackManager.setUrlCleaner(new DefaultUrlCleaner());
+    }
+
+    private void testUrlExclusion() throws Exception {
+        final String excludePrefix = "/exclude/";
+        String url = excludePrefix + 1;
+        WebCallbackManager.setUrlCleaner(new UrlCleaner() {
+            @Override
+            public String clean(String originUrl) {
+                if(originUrl.startsWith(excludePrefix)) {
+                    return "";
+                }
+                return originUrl;
+            }
+        });
+        this.mvc.perform(get(url).accept(MediaType.TEXT_PLAIN))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Exclude 1"));
+        assertNull(ClusterBuilderSlot.getClusterNode(url));
         WebCallbackManager.setUrlCleaner(new DefaultUrlCleaner());
     }
 

--- a/sentinel-adapter/sentinel-web-servlet/src/test/java/com/alibaba/csp/sentinel/adapter/servlet/TestController.java
+++ b/sentinel-adapter/sentinel-web-servlet/src/test/java/com/alibaba/csp/sentinel/adapter/servlet/TestController.java
@@ -39,4 +39,9 @@ public class TestController {
     public String apiFoo(@PathVariable("id") Long id) {
         return "Hello " + id;
     }
+
+    @GetMapping("/exclude/{id}")
+    public String apiExclude(@PathVariable("id") Long id) {
+        return "Exclude " + id;
+    }
 }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Why we need it
We need to support filtering urls that don't want to be resource in `CommonFilter`.

### Does this pull request fix one issue?

Resolves #287 

### Describe how you did it
As there's already a UrlCleaner interface, we could just reuse the interface and improve the logic of unifying the resource name with UrlCleaner. If developers are going to exclude some URLs, they can convert the URLs to the empty string "" in their `UrlCleaner` implementation, and in `CommonFilter` we could check whether the cleaned resource name is empty. If it's empty, then it should be excluded and won't go through the logic of Sentinel `SphU.entry`.

### Describe how to verify it
We can get the statistic node of the resource via `ClusterBuilderSlot.getClusterNode(res)` method, and if the `ClusterNode` of the target URL is absent, then we think it has been excluded.

### Special notes for reviews
