### PR TITLE
Add customized biz exception log support in Tracer

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/logger/LogSlot.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/logger/LogSlot.java
@@ -25,22 +25,25 @@ import com.alibaba.csp.sentinel.slots.block.BlockException;
 /**
  * A {@link com.alibaba.csp.sentinel.slotchain.ProcessorSlot} that is response for logging block exceptions
  * to provide concrete logs for troubleshooting.
+ *
+ * @author jialiang.linjl
+ * @author Eric Zhao
  */
 public class LogSlot extends AbstractLinkedProcessorSlot<DefaultNode> {
 
     @Override
-    public void entry(Context context, ResourceWrapper resourceWrapper, DefaultNode obj, int count, boolean prioritized, Object... args)
+    public void entry(Context context, ResourceWrapper resourceWrapper, DefaultNode obj, int count, boolean prioritized,
+                      Object... args)
         throws Throwable {
         try {
             fireEntry(context, resourceWrapper, obj, count, prioritized, args);
         } catch (BlockException e) {
-            EagleEyeLogUtil.log(resourceWrapper.getName(), e.getClass().getSimpleName(), e.getRuleLimitApp(),
+            SentinelBlockLogUtil.log(resourceWrapper.getName(), e.getClass().getSimpleName(), e.getRuleLimitApp(),
                 context.getOrigin(), count);
             throw e;
         } catch (Throwable e) {
             RecordLog.warn("Unexpected entry exception", e);
         }
-
     }
 
     @Override

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/logger/SentinelBlockLogUtil.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/logger/SentinelBlockLogUtil.java
@@ -19,7 +19,7 @@ import com.alibaba.csp.sentinel.eagleeye.EagleEye;
 import com.alibaba.csp.sentinel.eagleeye.StatLogger;
 import com.alibaba.csp.sentinel.log.LogBase;
 
-public class EagleEyeLogUtil {
+public class SentinelBlockLogUtil {
 
     public static final String FILE_NAME = "sentinel-block.log";
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/logger/SentinelExceptionLogUtil.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/logger/SentinelExceptionLogUtil.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.slots.logger;
+
+import com.alibaba.csp.sentinel.eagleeye.EagleEye;
+import com.alibaba.csp.sentinel.eagleeye.StatLogger;
+import com.alibaba.csp.sentinel.log.LogBase;
+
+/**
+ * @author Eric Zhao
+ * @since 1.6.3
+ */
+public final class SentinelExceptionLogUtil {
+
+    public static final String LOG_FILE_NAME = "sentinel-biz-exception.log";
+
+    private static StatLogger statLogger;
+
+    static {
+        String path = LogBase.getLogBaseDir() + LOG_FILE_NAME;
+
+        statLogger = EagleEye.statLoggerBuilder("sentinel-biz-exception-logger")
+            .intervalSeconds(10)
+            .entryDelimiter('|')
+            .keyDelimiter(',')
+            .valueDelimiter(',')
+            .maxEntryCount(5000)
+            .configLogFilePath(path)
+            .maxFileSizeMB(300)
+            .maxBackupIndex(3)
+            .buildSingleton();
+    }
+
+    public static void log(String resourceName, String exceptionName) {
+        statLogger.stat(resourceName, exceptionName).count();
+    }
+
+    public static void log(String resourceName, String exceptionName, int count) {
+        statLogger.stat(resourceName, exceptionName).count(count);
+    }
+
+    private SentinelExceptionLogUtil() {}
+}

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/logger/SentinelBlockLogUtilTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/logger/SentinelBlockLogUtilTest.java
@@ -15,13 +15,13 @@ import static org.awaitility.Awaitility.await;
 /**
  * @author Carpenter Lee
  */
-public class EagleEyeLogUtilTest {
+public class SentinelBlockLogUtilTest {
 
     @Test
     public void testWriteLog() throws Exception {
-        EagleEyeLogUtil.log("resourceName", "BlockException", "app1", "origin", 1);
+        SentinelBlockLogUtil.log("resourceName", "BlockException", "app1", "origin", 1);
 
-        final File file = new File(RecordLog.getLogBaseDir() + EagleEyeLogUtil.FILE_NAME);
+        final File file = new File(RecordLog.getLogBaseDir() + SentinelBlockLogUtil.FILE_NAME);
         await().timeout(2, TimeUnit.SECONDS)
             .until(new Callable<File>() {
                 @Override
@@ -31,18 +31,18 @@ public class EagleEyeLogUtilTest {
             }, FileMatchers.anExistingFile());
     }
 
-    //Change LogBase It is not not work when integration Testing
-    //Because LogBase.LOG_DIR can be just static init for once and it will not be changed
+    // Change LogBase It is not not work when integration Testing
+    // Because LogBase.LOG_DIR can be just static init for once and it will not be changed
     //@Test
     public void testChangeLogBase() throws Exception {
         String userHome = System.getProperty("user.home");
         String newLogBase = userHome + File.separator + "tmpLogDir" + System.currentTimeMillis();
         System.setProperty(LogBase.LOG_DIR, newLogBase);
 
-        EagleEyeLogUtil.log("resourceName", "BlockException", "app1", "origin", 1);
+        SentinelBlockLogUtil.log("resourceName", "BlockException", "app1", "origin", 1);
 
 
-        final File file = new File(RecordLog.getLogBaseDir() + EagleEyeLogUtil.FILE_NAME);
+        final File file = new File(RecordLog.getLogBaseDir() + SentinelBlockLogUtil.FILE_NAME);
         await().timeout(2, TimeUnit.SECONDS)
                 .until(new Callable<File>() {
                     @Override


### PR DESCRIPTION
### Describe what this PR does / why we need it

Add customized business exception log support in `Tracer`, which is useful for troubleshooting.

### Does this pull request fix one issue?

NONE

### Describe how you did it

- Add a `SentinelExceptionLogUtil` for biz exception logging (just like the `sentinel-block.log`). By default, it will flush the log every 10s.
- Update the `Tracer` to record the exception log via every `trace` invocation.
- Other code refinements

### Describe how to verify it

Run the demo.

### Special notes for reviews

NONE