### PR TITLE
Fix the order problem of SentinelGatewayFilter and other bugs

### DIFF
--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/GatewayParamParser.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/GatewayParamParser.java
@@ -103,7 +103,7 @@ public class GatewayParamParser<T> {
     private String parseClientIp(/*@Valid*/ GatewayParamFlowItem item, T request) {
         String clientIp = requestItemParser.getRemoteAddress(request);
         String pattern = item.getPattern();
-        if (pattern == null) {
+        if (StringUtil.isEmpty(pattern)) {
             return clientIp;
         }
         return parseWithMatchStrategyInternal(item.getMatchStrategy(), clientIp, pattern);
@@ -114,7 +114,7 @@ public class GatewayParamParser<T> {
         String pattern = item.getPattern();
         // TODO: what if the header has multiple values?
         String headerValue = requestItemParser.getHeader(request, headerKey);
-        if (pattern == null) {
+        if (StringUtil.isEmpty(pattern)) {
             return headerValue;
         }
         // Match value according to regex pattern or exact mode.
@@ -124,7 +124,7 @@ public class GatewayParamParser<T> {
     private String parseHost(/*@Valid*/ GatewayParamFlowItem item, T request) {
         String pattern = item.getPattern();
         String host = requestItemParser.getHeader(request, "Host");
-        if (pattern == null) {
+        if (StringUtil.isEmpty(pattern)) {
             return host;
         }
         // Match value according to regex pattern or exact mode.
@@ -135,7 +135,7 @@ public class GatewayParamParser<T> {
         String paramName = item.getFieldName();
         String pattern = item.getPattern();
         String param = requestItemParser.getUrlParam(request, paramName);
-        if (pattern == null) {
+        if (StringUtil.isEmpty(pattern)) {
             return param;
         }
         // Match value according to regex pattern or exact mode.
@@ -146,7 +146,7 @@ public class GatewayParamParser<T> {
         String cookieName = item.getFieldName();
         String pattern = item.getPattern();
         String param = requestItemParser.getCookieValue(request, cookieName);
-        if (pattern == null) {
+        if (StringUtil.isEmpty(pattern)) {
             return param;
         }
         // Match value according to regex pattern or exact mode.

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/GatewayParamParserTest.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/GatewayParamParserTest.java
@@ -187,6 +187,35 @@ public class GatewayParamParserTest {
     }
 
     @Test
+    public void testParseParametersWithEmptyItemPattern() {
+        RequestItemParser<Object> itemParser = mock(RequestItemParser.class);
+        GatewayParamParser<Object> paramParser = new GatewayParamParser<>(itemParser);
+        // Create a fake request.
+        Object request = new Object();
+        // Prepare gateway rules.
+        Set<GatewayFlowRule> rules = new HashSet<>();
+        final String routeId = "my_test_route_DS(*H";
+        final String headerName = "X-Sentinel-Flag";
+        GatewayFlowRule routeRule1 = new GatewayFlowRule(routeId)
+            .setCount(10)
+            .setIntervalSec(2)
+            .setParamItem(new GatewayParamFlowItem()
+                .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_HEADER)
+                .setFieldName(headerName)
+                .setPattern("")
+                .setMatchStrategy(SentinelGatewayConstants.PARAM_MATCH_STRATEGY_EXACT)
+            );
+        rules.add(routeRule1);
+        GatewayRuleManager.loadRules(rules);
+
+        mockSingleHeader(itemParser, headerName, "Sent1nel");
+        Object[] params = paramParser.parseParameterFor(routeId, request, routeIdPredicate);
+        assertThat(params.length).isEqualTo(1);
+        // Empty pattern should not take effect.
+        assertThat(params[routeRule1.getParamItem().getIndex()]).isEqualTo("Sent1nel");
+    }
+
+    @Test
     public void testParseParametersWithItemPatternMatching() {
         RequestItemParser<Object> itemParser = mock(RequestItemParser.class);
         GatewayParamParser<Object> paramParser = new GatewayParamParser<>(itemParser);

--- a/sentinel-adapter/sentinel-spring-cloud-gateway-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/sc/SentinelGatewayFilter.java
+++ b/sentinel-adapter/sentinel-spring-cloud-gateway-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/sc/SentinelGatewayFilter.java
@@ -34,6 +34,7 @@ import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.cloud.gateway.route.Route;
 import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
+import org.springframework.core.Ordered;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
@@ -41,7 +42,17 @@ import reactor.core.publisher.Mono;
  * @author Eric Zhao
  * @since 1.6.0
  */
-public class SentinelGatewayFilter implements GatewayFilter, GlobalFilter {
+public class SentinelGatewayFilter implements GatewayFilter, GlobalFilter, Ordered {
+
+    private final int order;
+
+    public SentinelGatewayFilter() {
+        this(Ordered.HIGHEST_PRECEDENCE);
+    }
+
+    public SentinelGatewayFilter(int order) {
+        this.order = order;
+    }
 
     private final GatewayParamParser<ServerWebExchange> paramParser = new GatewayParamParser<>(
         new ServerWebExchangeItemParser());
@@ -86,5 +97,10 @@ public class SentinelGatewayFilter implements GatewayFilter, GlobalFilter {
             .filter(m -> m.test(exchange))
             .map(WebExchangeApiMatcher::getApiName)
             .collect(Collectors.toSet());
+    }
+
+    @Override
+    public int getOrder() {
+        return order;
     }
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it

Fix some problems in API gateway adapter common and SC Gateway adapter module.

### Does this pull request fix one issue?

Fixes #764 

### Describe how you did it

-  Fix the empty value matching bug in `GatewayParamParser`.
-  There might be some problems when handling Spring `@Order` annotation in Spring Cloud Gateway, so here I added `Ordered` support for Spring Cloud Gateway filter. By default the order is `HIGHEST_PRECEDENCE`. (Related to #764, cc @fangjian0423)

### Describe how to verify it

Run the test cases and demo.

### Special notes for reviews

NONE