### PR TITLE
Add timeout "cut-down" mechanism in @SentinelResource annotation

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/annotation/SentinelResource.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/annotation/SentinelResource.java
@@ -70,6 +70,8 @@ public @interface SentinelResource {
      */
     String defaultFallback() default "";
 
+    int timeOut() default 0;
+
     /**
      * The {@code fallback} is located in the same class with the original method by default.
      * However, if some methods share the same signature and intend to set the same fallback,

--- a/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/SentinelResourceAspect.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/SentinelResourceAspect.java
@@ -26,6 +26,10 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 
 import java.lang.reflect.Method;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Aspect for methods with {@link SentinelResource} annotation.
@@ -40,7 +44,7 @@ public class SentinelResourceAspect extends AbstractSentinelAspectSupport {
     }
 
     @Around("sentinelResourceAnnotationPointcut()")
-    public Object invokeResourceWithSentinel(ProceedingJoinPoint pjp) throws Throwable {
+    public Object invokeResourceWithSentinel(final ProceedingJoinPoint pjp) throws Throwable {
         Method originMethod = resolveMethod(pjp);
 
         SentinelResource annotation = originMethod.getAnnotation(SentinelResource.class);
@@ -53,10 +57,43 @@ public class SentinelResourceAspect extends AbstractSentinelAspectSupport {
         Entry entry = null;
         try {
             entry = SphU.entry(resourceName, entryType, 1, pjp.getArgs());
-            Object result = pjp.proceed();
+            Object result=null;
+            int timeOut=annotation.timeOut();
+            if (timeOut<0){
+                timeOut=0;
+            }
+            if (timeOut!=0) {
+
+
+                Future<Object> future = ThreadPoolUtil.newSingleThreadExecutor().submit(new Callable<Object>() {
+                    @Override
+                    public Object call() {
+                        Object result = null;
+
+
+                        try {
+                            result = pjp.proceed();
+                        } catch (Throwable throwable) {
+                            throwable.printStackTrace();
+                        }
+
+
+                        return result;
+                    }
+                });
+                result = future.get(timeOut, TimeUnit.MILLISECONDS);
+            }else{
+                result= pjp.proceed();
+            }
             return result;
         } catch (BlockException ex) {
             return handleBlockException(pjp, annotation, ex);
+        } catch (TimeoutException ex) {
+
+            return handleFallback(pjp, annotation, ex);
+
+            // No fallback function can handle the exception, so throw it out.
+
         } catch (Throwable ex) {
             Class<? extends Throwable>[] exceptionsToIgnore = annotation.exceptionsToIgnore();
             // The ignore list will be checked first.

--- a/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/ThreadPoolUtil.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/ThreadPoolUtil.java
@@ -1,0 +1,29 @@
+package com.alibaba.csp.sentinel.annotation.aspectj;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class ThreadPoolUtil {
+    private static int threadPools;
+
+    private ThreadPoolUtil() {
+
+    }
+
+    private static ExecutorService executor;
+
+    static {
+        threadPools = Runtime.getRuntime().availableProcessors() * 2;
+    }
+
+    public synchronized static ExecutorService newSingleThreadExecutor() {
+        if (executor == null) {
+            executor = new ThreadPoolExecutor(threadPools, threadPools,
+                    0L, TimeUnit.MILLISECONDS,
+                    new LinkedBlockingQueue<Runnable>());
+        }
+        return executor;
+    }
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Sometimes the system can't respond in time for some reason, like fast failure, service downgrade, user's request will not block all the time.
### Does this pull request fix one issue?
Service downgrade with @SentinelResource without timeout, plus timeout service downgrade
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Use the get() time parameter of the future to determine whether it times out

### Describe how to verify it
  @SentinelResource(value = "hello", fallback = "helloFallback",timeOut = 1000)

### Special notes for reviews
