### PR TITLE
optimize:unnecessary duplicate check 

### DIFF
--- a/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/SentinelResourceAspect.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/SentinelResourceAspect.java
@@ -64,7 +64,7 @@ public class SentinelResourceAspect extends AbstractSentinelAspectSupport {
                 throw ex;
             }
             if (exceptionBelongsTo(ex, annotation.exceptionsToTrace())) {
-                traceException(ex, annotation);
+                traceException(ex);
                 return handleFallback(pjp, annotation, ex);
             }
 

--- a/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/SentinelResourceAspect.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/SentinelResourceAspect.java
@@ -64,7 +64,7 @@ public class SentinelResourceAspect extends AbstractSentinelAspectSupport {
                 throw ex;
             }
             if (exceptionBelongsTo(ex, annotation.exceptionsToTrace())) {
-                traceException(ex);
+                traceException(ex);//ex not belongsTo exceptionsToIgnore && belongsTo exceptionsToTrace
                 return handleFallback(pjp, annotation, ex);
             }
 


### PR DESCRIPTION
when codes execute here ,we can make sure that the exception is not belongsTo exceptionsToIgnore and is belongsTo exceptionsToTrace!
so,we do not need check the exception again
instead,we should call the traceException method directly