### PR TITLE
Fix the bug of getting wrong cluster flow QPS in ClusterFlowChecker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <packaging>pom</packaging>
 
     <name>${project.artifactId}</name>
-    <description>The parent project of Sentinel ttt</description>
+    <description>The parent project of Sentinel</description>
     <url>https://github.com/alibaba/Sentinel</url>
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <packaging>pom</packaging>
 
     <name>${project.artifactId}</name>
-    <description>The parent project of Sentinel</description>
+    <description>The parent project of Sentinel ttt</description>
     <url>https://github.com/alibaba/Sentinel</url>
     <licenses>
         <license>

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/ClusterFlowChecker.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/ClusterFlowChecker.java
@@ -64,7 +64,7 @@ final class ClusterFlowChecker {
             return new TokenResult(TokenResultStatus.FAIL);
         }
 
-        double latestQps = metric.getAvg(ClusterFlowEvent.PASS_REQUEST);
+        double latestQps = metric.getAvg(ClusterFlowEvent.PASS);
         double globalThreshold = calcGlobalThreshold(rule) * ClusterServerConfigManager.getExceedCount();
         double nextRemaining = globalThreshold - latestQps - acquireCount;
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Fix the bug when getting current cluster flow QPS in `ClusterFlowChecker`.

The QPS should be calculated with `PASS` rather than `PASS_REQUEST`. The `PASS_REQUEST` will ignore the `acquireCount`.


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
