### PR TITLE
Adaptive flow control (Suitable for user peak and callback peak)

### DIFF
--- a/sentinel-adapter/sentinel-web-servlet/README.md
+++ b/sentinel-adapter/sentinel-web-servlet/README.md
@@ -51,6 +51,8 @@ block handler (the `UrlBlockHandler` interface) and register to `WebCallbackMana
 The `UrlCleaner` interface is designed for clean and unify the URL resource.
 For REST APIs, you have to clean the URL resource (e.g. `/foo/1` and `/foo/2` -> `/foo/:id`), or
 the amount of context and resources will exceed the threshold.
+The `UrlCleaner` interface can also exclude unused URLs(e.g. `/exclude/1` -> `/exclude/:id` -> `""`).
+The URLs will be filtered and not be resource in this way.
 
 `RequestOriginParser` interface is useful for extracting request origin (e.g. IP or appName from HTTP Header)
 from HTTP request. You can implement your own `RequestOriginParser` and register to `WebCallbackManager`.

--- a/sentinel-adapter/sentinel-web-servlet/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/CommonFilter.java
+++ b/sentinel-adapter/sentinel-web-servlet/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/CommonFilter.java
@@ -73,19 +73,19 @@ public class CommonFilter implements Filter {
                 target = urlCleaner.clean(target);
             }
 
-            // Parse the request origin using registered origin parser.
-            String origin = parseOrigin(sRequest);
-
-            ContextUtil.enter(target, origin);
-            entry = SphU.entry(target, EntryType.IN);
-
-
-            // Add method specification if necessary
-            if (httpMethodSpecify) {
-                methodEntry = SphU.entry(sRequest.getMethod().toUpperCase() + COLON + target,
-                        EntryType.IN);
+            // If you intend to exclude some URLs, you can convert the URLs to the empty string ""
+            // in the UrlCleaner implementation.
+            if (target != "") {
+                // Parse the request origin using registered origin parser.
+                String origin = parseOrigin(sRequest);
+                ContextUtil.enter(target, origin);
+                entry = SphU.entry(target, EntryType.IN);
+                // Add method specification if necessary
+                if (httpMethodSpecify) {
+                    methodEntry = SphU.entry(sRequest.getMethod().toUpperCase() + COLON + target,
+                            EntryType.IN);
+                }
             }
-
             chain.doFilter(request, response);
         } catch (BlockException e) {
             HttpServletResponse sResponse = (HttpServletResponse) response;
@@ -107,7 +107,9 @@ public class CommonFilter implements Filter {
             if (entry != null) {
                 entry.exit();
             }
-            ContextUtil.exit();
+            if (ContextUtil.getContext() != null) {
+                ContextUtil.exit();
+            }
         }
     }
 

--- a/sentinel-adapter/sentinel-web-servlet/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/CommonFilter.java
+++ b/sentinel-adapter/sentinel-web-servlet/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/CommonFilter.java
@@ -75,7 +75,7 @@ public class CommonFilter implements Filter {
 
             // If you intend to exclude some URLs, you can convert the URLs to the empty string ""
             // in the UrlCleaner implementation.
-            if (target != "") {
+            if (StringUtil.isEmpty(target)) {
                 // Parse the request origin using registered origin parser.
                 String origin = parseOrigin(sRequest);
                 ContextUtil.enter(target, origin);
@@ -107,9 +107,7 @@ public class CommonFilter implements Filter {
             if (entry != null) {
                 entry.exit();
             }
-            if (ContextUtil.getContext() != null) {
-                ContextUtil.exit();
-            }
+            ContextUtil.exit();
         }
     }
 

--- a/sentinel-adapter/sentinel-web-servlet/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/CommonFilter.java
+++ b/sentinel-adapter/sentinel-web-servlet/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/CommonFilter.java
@@ -75,7 +75,7 @@ public class CommonFilter implements Filter {
 
             // If you intend to exclude some URLs, you can convert the URLs to the empty string ""
             // in the UrlCleaner implementation.
-            if (StringUtil.isEmpty(target)) {
+            if (!StringUtil.isEmpty(target)) {
                 // Parse the request origin using registered origin parser.
                 String origin = parseOrigin(sRequest);
                 ContextUtil.enter(target, origin);

--- a/sentinel-adapter/sentinel-web-servlet/src/test/java/com/alibaba/csp/sentinel/adapter/servlet/CommonFilterTest.java
+++ b/sentinel-adapter/sentinel-web-servlet/src/test/java/com/alibaba/csp/sentinel/adapter/servlet/CommonFilterTest.java
@@ -89,7 +89,7 @@ public class CommonFilterTest {
 
         // Test for url cleaner.
         testUrlCleaner();
-
+        testUrlExclusion();
         testCustomOriginParser();
     }
 
@@ -136,6 +136,25 @@ public class CommonFilterTest {
         assertNull(ClusterBuilderSlot.getClusterNode(url1));
         assertNull(ClusterBuilderSlot.getClusterNode(url2));
 
+        WebCallbackManager.setUrlCleaner(new DefaultUrlCleaner());
+    }
+
+    private void testUrlExclusion() throws Exception {
+        final String excludePrefix = "/exclude/";
+        String url = excludePrefix + 1;
+        WebCallbackManager.setUrlCleaner(new UrlCleaner() {
+            @Override
+            public String clean(String originUrl) {
+                if(originUrl.startsWith(excludePrefix)) {
+                    return "";
+                }
+                return originUrl;
+            }
+        });
+        this.mvc.perform(get(url).accept(MediaType.TEXT_PLAIN))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Exclude 1"));
+        assertNull(ClusterBuilderSlot.getClusterNode(url));
         WebCallbackManager.setUrlCleaner(new DefaultUrlCleaner());
     }
 

--- a/sentinel-adapter/sentinel-web-servlet/src/test/java/com/alibaba/csp/sentinel/adapter/servlet/TestController.java
+++ b/sentinel-adapter/sentinel-web-servlet/src/test/java/com/alibaba/csp/sentinel/adapter/servlet/TestController.java
@@ -39,4 +39,9 @@ public class TestController {
     public String apiFoo(@PathVariable("id") Long id) {
         return "Hello " + id;
     }
+
+    @GetMapping("/exclude/{id}")
+    public String apiExclude(@PathVariable("id") Long id) {
+        return "Exclude " + id;
+    }
 }

--- a/sentinel-core/pom.xml
+++ b/sentinel-core/pom.xml
@@ -67,6 +67,14 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/Node.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/Node.java
@@ -116,11 +116,25 @@ public interface Node extends OccupySupport, DebugSupport {
     double avgRt();
 
     /**
+     * Get average rt per minute.
+     *
+     * @return average response time per minute
+     */
+    double longTermRt();
+
+    /**
      * Get minimal response time.
      *
      * @return recorded minimal response time
      */
     double minRt();
+
+    /**
+     * Get maximal response time.
+     *
+     * @return recorded maximal response time
+     */
+    double maxRt();
 
     /**
      * Get current active thread count.

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/StatisticNode.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/StatisticNode.java
@@ -102,6 +102,11 @@ public class StatisticNode implements Node {
     private transient Metric rollingCounterInMinute = new ArrayMetric(60, 60 * 1000, false);
 
     /**
+     * Holds statistics of the recent 10 seconds. The windowLengthInMs is deliberately set to 1000 milliseconds.
+     */
+    private transient Metric rollingCounterInTenSeconds = new ArrayMetric(10, 5 * 1000, false);
+
+    /**
      * The counter for thread count.
      */
     private LongAdder curThreadNum = new LongAdder();
@@ -226,8 +231,23 @@ public class StatisticNode implements Node {
     }
 
     @Override
+    public double longTermRt() {
+        long successCount = rollingCounterInTenSeconds.success();
+        if (successCount == 0) {
+            return 0;
+        }
+
+        return rollingCounterInTenSeconds.rt() * 1.0 / successCount;
+    }
+
+    @Override
     public double minRt() {
         return rollingCounterInSecond.minRt();
+    }
+
+    @Override
+    public double maxRt() {
+        return rollingCounterInSecond.maxRt();
     }
 
     @Override
@@ -248,6 +268,9 @@ public class StatisticNode implements Node {
 
         rollingCounterInMinute.addSuccess(successCount);
         rollingCounterInMinute.addRT(rt);
+
+        rollingCounterInTenSeconds.addSuccess(successCount);
+        rollingCounterInTenSeconds.addRT(rt);
     }
 
     @Override

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/DefaultSlotChainBuilder.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/DefaultSlotChainBuilder.java
@@ -18,6 +18,7 @@ package com.alibaba.csp.sentinel.slots;
 import com.alibaba.csp.sentinel.slotchain.DefaultProcessorSlotChain;
 import com.alibaba.csp.sentinel.slotchain.ProcessorSlotChain;
 import com.alibaba.csp.sentinel.slotchain.SlotChainBuilder;
+import com.alibaba.csp.sentinel.slots.block.adaptive.AdaptiveSlot;
 import com.alibaba.csp.sentinel.slots.block.authority.AuthoritySlot;
 import com.alibaba.csp.sentinel.slots.block.degrade.DegradeSlot;
 import com.alibaba.csp.sentinel.slots.block.flow.FlowSlot;
@@ -45,6 +46,7 @@ public class DefaultSlotChainBuilder implements SlotChainBuilder {
         chain.addLast(new SystemSlot());
         chain.addLast(new AuthoritySlot());
         chain.addLast(new FlowSlot());
+        chain.addLast(new AdaptiveSlot());
         chain.addLast(new DegradeSlot());
 
         return chain;

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/RuleConstant.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/RuleConstant.java
@@ -25,6 +25,7 @@ public final class RuleConstant {
 
     public static final int FLOW_GRADE_THREAD = 0;
     public static final int FLOW_GRADE_QPS = 1;
+    public static final int FLOW_ADAPTIVE_PID = 2;
 
     public static final int DEGRADE_GRADE_RT = 0;
     /**

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveException.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveException.java
@@ -1,0 +1,33 @@
+package com.alibaba.csp.sentinel.slots.block.adaptive;
+
+import com.alibaba.csp.sentinel.slots.block.BlockException;
+
+/**
+ * @author Liu Yiming
+ * @date 2019-07-16 21:05
+ */
+public class AdaptiveException extends BlockException {
+
+    public AdaptiveException(String ruleLimitApp) { super(ruleLimitApp); }
+
+    public AdaptiveException(String ruleLimitApp, AdaptiveRule rule) {
+        super(ruleLimitApp, rule);
+    }
+
+    public AdaptiveException(String message, Throwable cause) { super(message, cause); }
+
+    public AdaptiveException(String ruleLimitApp, String message) { super(ruleLimitApp, message); }
+
+    @Override
+    public Throwable fillInStackTrace() { return this; }
+
+    /**
+     * Get triggered rule.
+     * Note: the rule result is a reference to rule map and SHOULD NOT be modified.
+     *
+     * @return triggered rule
+     * @since 1.4.2
+     */
+    @Override
+    public AdaptiveRule getRule() { return rule.as(AdaptiveRule.class); }
+}

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRule.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRule.java
@@ -17,6 +17,8 @@ public class AdaptiveRule extends AbstractRule {
         setResource(resourceName);
     }
 
+    private int grade = -1;
+
     private double count;
 
     private int maxToken;
@@ -26,6 +28,15 @@ public class AdaptiveRule extends AbstractRule {
     private double expectRt;
 
     private TrafficShapingController controller;
+
+    public int getGrade() {
+        return grade;
+    }
+
+    public AdaptiveRule setGrade(int grade) {
+        this.grade = grade;
+        return this;
+    }
 
     public double getCount() {
         return count;

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRule.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRule.java
@@ -20,6 +20,8 @@ public class AdaptiveRule extends AbstractRule {
 
     private int maxToken;
 
+    private double targetRadio;
+
     public double getCount() {
         return count;
     }
@@ -33,6 +35,13 @@ public class AdaptiveRule extends AbstractRule {
 
     public AdaptiveRule setMaxToken(int maxToken) {
         this.maxToken = maxToken;
+        return this;
+    }
+
+    public double getTargetRadio() { return targetRadio; }
+
+    public AdaptiveRule setTargetRadio(double targetRadio) {
+        this.targetRadio = targetRadio;
         return this;
     }
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRule.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRule.java
@@ -1,0 +1,42 @@
+package com.alibaba.csp.sentinel.slots.block.adaptive;
+
+import com.alibaba.csp.sentinel.context.Context;
+import com.alibaba.csp.sentinel.node.DefaultNode;
+import com.alibaba.csp.sentinel.slots.block.AbstractRule;
+
+/**
+ * @author Liu Yiming
+ * @date 2019-07-16 16:31
+ */
+public class AdaptiveRule extends AbstractRule {
+
+    public AdaptiveRule() {}
+
+    public AdaptiveRule(String resourceName) {
+        setResource(resourceName);
+    }
+
+    private double count;
+
+    private int maxToken;
+
+    public double getCount() {
+        return count;
+    }
+
+    public AdaptiveRule setCount(double count) {
+        this.count = count;
+        return this;
+    }
+
+    public int getMaxToken() { return maxToken; }
+
+    public AdaptiveRule setMaxToken(int maxToken) {
+        this.maxToken = maxToken;
+        return this;
+    }
+
+    @Override
+    public boolean passCheck(Context context, DefaultNode node, int acquireCount, Object... args) { return true; }
+
+}

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRule.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRule.java
@@ -20,7 +20,9 @@ public class AdaptiveRule extends AbstractRule {
 
     private int maxToken;
 
-    private double targetRadio;
+    private double targetRatio;
+
+    private double expectRt;
 
     public double getCount() {
         return count;
@@ -38,10 +40,17 @@ public class AdaptiveRule extends AbstractRule {
         return this;
     }
 
-    public double getTargetRadio() { return targetRadio; }
+    public double getTargetRatio() { return targetRatio; }
 
-    public AdaptiveRule setTargetRadio(double targetRadio) {
-        this.targetRadio = targetRadio;
+    public AdaptiveRule setTargetRatio(double targetRatio) {
+        this.targetRatio = targetRatio;
+        return this;
+    }
+
+    public double getExpectRt() { return expectRt; }
+
+    public AdaptiveRule setExpectRt(double expectRt) {
+        this.expectRt = expectRt;
         return this;
     }
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRule.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRule.java
@@ -3,6 +3,7 @@ package com.alibaba.csp.sentinel.slots.block.adaptive;
 import com.alibaba.csp.sentinel.context.Context;
 import com.alibaba.csp.sentinel.node.DefaultNode;
 import com.alibaba.csp.sentinel.slots.block.AbstractRule;
+import com.alibaba.csp.sentinel.slots.block.flow.TrafficShapingController;
 
 /**
  * @author Liu Yiming
@@ -23,6 +24,8 @@ public class AdaptiveRule extends AbstractRule {
     private double targetRatio;
 
     private double expectRt;
+
+    private TrafficShapingController controller;
 
     public double getCount() {
         return count;
@@ -51,6 +54,15 @@ public class AdaptiveRule extends AbstractRule {
 
     public AdaptiveRule setExpectRt(double expectRt) {
         this.expectRt = expectRt;
+        return this;
+    }
+
+    TrafficShapingController getRater() {
+        return controller;
+    }
+
+    AdaptiveRule setRater(TrafficShapingController rater) {
+        this.controller = rater;
         return this;
     }
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRuleChecker.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRuleChecker.java
@@ -1,0 +1,93 @@
+package com.alibaba.csp.sentinel.slots.block.adaptive;
+
+import com.alibaba.csp.sentinel.context.Context;
+import com.alibaba.csp.sentinel.node.DefaultNode;
+import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
+import com.alibaba.csp.sentinel.slots.block.BlockException;
+import com.alibaba.csp.sentinel.slots.system.SystemStatusListener;
+import com.alibaba.csp.sentinel.util.TimeUtil;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * @author Liu Yiming
+ * @date 2019-07-16 16:28
+ */
+public class AdaptiveRuleChecker {
+
+    protected AtomicLong storedTokens = new AtomicLong(0);
+    protected AtomicLong lastFilledTime = new AtomicLong(0);
+
+    private static SystemStatusListener statusListener = null;
+
+    public void checkAdaptive(ResourceWrapper resource, Context context, DefaultNode node, int count)
+        throws BlockException {
+
+        Set<AdaptiveRule> rules = AdaptiveRuleManager.getRules(resource);
+        if (rules == null || resource == null) {
+            return;
+        }
+
+        for (AdaptiveRule rule : rules) {
+            if (!canPassCheck(rule, context, node, count)) {
+                throw new AdaptiveException(rule.getLimitApp(), rule);
+            }
+        }
+    }
+
+    public boolean canPassCheck(AdaptiveRule rule, Context context, DefaultNode node, int acquireCount) {
+        long count = (long)(rule.getCount());
+        long passQps = (long)(node.getClusterNode().passQps());
+        long previousQps = (long)(node.getClusterNode().previousBlockQps());
+        int maxToken = rule.getMaxToken();
+        syncToken(previousQps, count, maxToken);
+
+        long restToken = storedTokens.get();
+        if (passQps + acquireCount <= restToken || passQps + acquireCount <= count) {
+            return true;
+        }
+        return false;
+    }
+
+    protected void syncToken(long passQps, long count, int maxToken) {
+        long currentTime = TimeUtil.currentTimeMillis();
+        currentTime = currentTime - currentTime % 1000;
+        long oldLastFillTime = lastFilledTime.get();
+        if (currentTime <= oldLastFillTime) {
+            return;
+        }
+
+        long oldValue = storedTokens.get();
+        long newValue = addTokens(currentTime, passQps, count, maxToken);
+
+        if (storedTokens.compareAndSet(oldValue, newValue)) {
+            long currentValue = storedTokens.addAndGet(0 - passQps);
+            if (currentValue < 0) {
+                storedTokens.set(0L);
+            }
+            lastFilledTime.set(currentTime);
+        }
+
+    }
+
+    private long addTokens(long currentTime, long passQps, long count, int maxToken) {
+        long oldValue = storedTokens.get();
+        long newValue = oldValue;
+
+        if (oldValue < maxToken) {
+            if (lastFilledTime.get() == 0) {
+                newValue = count;
+            } else {
+                newValue = (long)(oldValue + (currentTime - lastFilledTime.get()) * count / 1000);
+            }
+
+        }
+
+        return Math.min(newValue, maxToken);
+    }
+
+    public static double getCurrentCpuUsage() {
+        return statusListener.getCpuUsage();
+    }
+}

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRuleChecker.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRuleChecker.java
@@ -4,6 +4,7 @@ import com.alibaba.csp.sentinel.concurrent.NamedThreadFactory;
 import com.alibaba.csp.sentinel.context.Context;
 import com.alibaba.csp.sentinel.node.ClusterNode;
 import com.alibaba.csp.sentinel.node.DefaultNode;
+import com.alibaba.csp.sentinel.node.Node;
 import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
 import com.alibaba.csp.sentinel.slots.system.SystemStatusListener;
@@ -21,34 +22,6 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class AdaptiveRuleChecker {
 
-    // 剩余存储令牌数
-    protected AtomicLong storedTokens = new AtomicLong(0);
-
-    // 上一次存令牌的时间
-    protected AtomicLong lastFilledTime = new AtomicLong(0);
-
-    // 上一次更新令牌发放速率的时间
-    protected AtomicLong lastCountTime = new AtomicLong(0);
-
-    // 令牌发放速率
-    protected AtomicLong bucketCount = new AtomicLong(2000);
-
-    // 令牌桶容量
-    protected AtomicLong maxTokens = new AtomicLong(4000);
-
-    // cpu占用率大于0.6的请求数
-    protected AtomicLong cpuFull = new AtomicLong(0);
-
-    @SuppressWarnings("PMD.ThreadPoolCreationRule")
-    private final static ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1,
-            new NamedThreadFactory("sentinel-system-status-record-task", true));
-    private static SystemStatusListener statusListener = null;
-
-    static {
-        statusListener = new SystemStatusListener();
-        scheduler.scheduleAtFixedRate(statusListener, 5, 1, TimeUnit.SECONDS);
-    }
-
     public void checkAdaptive(ResourceWrapper resource, Context context, DefaultNode node, int count)
         throws BlockException {
 
@@ -65,139 +38,11 @@ public class AdaptiveRuleChecker {
     }
 
     public boolean canPassCheck(AdaptiveRule rule, Context context, DefaultNode node, int acquireCount) {
-        double targetRatio = rule.getTargetRatio(); // 目标通过率
-        double expectRt = rule.getExpectRt();
 
-        double cpuUsage = getCurrentCpuUsage();
+        Node selectedNode = node.getClusterNode();
+        if (selectedNode == null) { return true; }
 
-        long previousQps = (long)(node.getClusterNode().previousPassQps());
-        long passQps = (long)(node.getClusterNode().passQps());
-
-        if (cpuUsage > 0.6) {
-            cpuFull.incrementAndGet();
-        }
-
-        syncBucketCount(node.getClusterNode(), targetRatio, expectRt);
-
-        long newCount = bucketCount.get();
-        syncToken(previousQps, newCount, maxTokens.get());
-
-        long restToken = storedTokens.get();
-
-        if (passQps + acquireCount <= restToken || passQps + acquireCount <= newCount) {
-            return true;
-        }
-        return false;
+        return rule.getRater().canPass(selectedNode, acquireCount, false);
     }
 
-    protected synchronized void syncBucketCount(ClusterNode node, double targetRatio, double expectRt) {
-        long currentTime = TimeUtil.currentTimeMillis();
-        currentTime = currentTime - currentTime % 1000;
-        long oldCountTime = lastCountTime.get();
-        if (currentTime <= oldCountTime) { return; }
-        if (oldCountTime == 0) {
-            lastCountTime.compareAndSet(oldCountTime, lastFilledTime.get());
-            return;
-        }
-        if ((currentTime - oldCountTime) / 1000 > 0.9) {
-            double ratio;
-            long newCount = bucketCount.get();
-
-            double smoothing = 0.2;
-
-            long previousQps = (long)(node.previousPassQps());
-            long previousTotalQps = (long)(node.previousBlockQps()) + previousQps;
-            long passQps = (long)(node.passQps());
-            long totalQps = (long)(node.totalQps());
-            if (totalQps != 0) {
-                ratio = passQps / totalQps;
-                // 如果newCount比用户预设的通过率小很多，就让其快速增加
-                if (newCount < totalQps * targetRatio / 2) {
-                    bucketCount.compareAndSet(newCount, (long)(totalQps * targetRatio / 2));
-                    newCount = bucketCount.get();
-                }
-                //System.out.println("statistic");
-                // 计算限制范围[1.0, 5.0]的梯度
-                // 实际通过率越小，梯度值越大，以增加后续通过数
-                double gradientRatio = Math.max(1.0, Math.min(2.0, targetRatio / ratio));
-
-                double avgRt = node.avgRt();
-                double longTermRt = node.longTermRt();
-                double gradientRt;
-                if (avgRt == 0) {
-                    gradientRt = 1;
-                } else {
-                    // 计算限制范围[0.5, 1.0]的梯度以过滤异常值
-                    // 实际 avgRt 越大，梯度值越小，说明需要限制通过数
-                    double needRt = Math.min(longTermRt, expectRt);
-                    gradientRt = Math.max(0.5, Math.min(1.0, needRt / avgRt));
-                }
-
-                long currentCount = bucketCount.get();
-                //System.out.println("gradientRadio: " + gradientRatio + " ;gradientRt: " + gradientRt);
-
-
-                // 最后的令牌发放速度由通过率和 Rt 共同决定
-                newCount = (long)(gradientRatio * gradientRt * currentCount);
-                // 使用平滑因子更新令牌发放速度（默认为0.2）
-                newCount = (long)(currentCount * (1 - smoothing) + newCount * smoothing);
-
-                bucketCount.compareAndSet(currentCount, newCount);
-
-
-            }
-            long newMaxToken = Math.max(newCount, (long)(previousTotalQps * targetRatio));
-            long oldMaxToken = maxTokens.get();
-            if (newMaxToken > oldMaxToken) {
-                maxTokens.compareAndSet(oldMaxToken, newMaxToken);
-            }
-            lastCountTime.compareAndSet(oldCountTime, currentTime);
-        }
-    }
-
-    protected void syncToken(long passQps, long count, long maxToken) {
-        long currentTime = TimeUtil.currentTimeMillis();
-        currentTime = currentTime - currentTime % 1000;
-        long oldLastFillTime = lastFilledTime.get();
-        if (currentTime <= oldLastFillTime) {
-            return;
-        }
-
-        long oldValue = storedTokens.get();
-        long newValue = addTokens(currentTime, passQps, count, maxToken);
-
-        if (storedTokens.compareAndSet(oldValue, newValue)) {
-            long currentValue = storedTokens.addAndGet(0 - passQps);
-            if (currentValue < 0) {
-                storedTokens.set(0L);
-            }
-            lastFilledTime.set(currentTime);
-        }
-
-    }
-
-    private long addTokens(long currentTime, long passQps, long count, long maxToken) {
-        long oldValue = storedTokens.get();
-        long newValue = oldValue;
-
-        if (oldValue < maxToken) {
-            if (lastFilledTime.get() == 0) {
-                newValue = count;
-            } else {
-                newValue = (long)(oldValue + (currentTime - lastFilledTime.get()) * count / 1000);
-            }
-
-        }
-
-        return Math.min(newValue, maxToken);
-    }
-
-    public static double getCurrentCpuUsage() {
-        try {
-            return statusListener.getCpuUsage();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        return 0;
-    }
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRuleChecker.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRuleChecker.java
@@ -1,6 +1,8 @@
 package com.alibaba.csp.sentinel.slots.block.adaptive;
 
+import com.alibaba.csp.sentinel.concurrent.NamedThreadFactory;
 import com.alibaba.csp.sentinel.context.Context;
+import com.alibaba.csp.sentinel.node.ClusterNode;
 import com.alibaba.csp.sentinel.node.DefaultNode;
 import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
@@ -8,6 +10,9 @@ import com.alibaba.csp.sentinel.slots.system.SystemStatusListener;
 import com.alibaba.csp.sentinel.util.TimeUtil;
 
 import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -16,11 +21,33 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class AdaptiveRuleChecker {
 
+    // 剩余存储令牌数
     protected AtomicLong storedTokens = new AtomicLong(0);
+
+    // 上一次存令牌的时间
     protected AtomicLong lastFilledTime = new AtomicLong(0);
-    protected AtomicLong bucketCount = new AtomicLong(20000);
-    //protected long bucketCount = 2000;
+
+    // 上一次更新令牌发放速率的时间
+    protected AtomicLong lastCountTime = new AtomicLong(0);
+
+    // 令牌发放速率
+    protected AtomicLong bucketCount = new AtomicLong(2000);
+
+    // 令牌桶容量
+    protected AtomicLong maxTokens = new AtomicLong(4000);
+
+    // cpu占用率大于0.6的请求数
+    protected AtomicLong cpuFull = new AtomicLong(0);
+
+    @SuppressWarnings("PMD.ThreadPoolCreationRule")
+    private final static ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1,
+            new NamedThreadFactory("sentinel-system-status-record-task", true));
     private static SystemStatusListener statusListener = null;
+
+    static {
+        statusListener = new SystemStatusListener();
+        scheduler.scheduleAtFixedRate(statusListener, 5, 1, TimeUnit.SECONDS);
+    }
 
     public void checkAdaptive(ResourceWrapper resource, Context context, DefaultNode node, int count)
         throws BlockException {
@@ -38,56 +65,97 @@ public class AdaptiveRuleChecker {
     }
 
     public boolean canPassCheck(AdaptiveRule rule, Context context, DefaultNode node, int acquireCount) {
-        double targetRadio = rule.getTargetRadio(); //目标通过率
-        int maxToken = rule.getMaxToken();
-        double smoothing = 0.2;
+        double targetRatio = rule.getTargetRatio(); // 目标通过率
+        double expectRt = rule.getExpectRt();
 
-        long previousQps = (long)(node.getClusterNode().previousBlockQps());
+        double cpuUsage = getCurrentCpuUsage();
+
+        long previousQps = (long)(node.getClusterNode().previousPassQps());
         long passQps = (long)(node.getClusterNode().passQps());
-        long totalQps = (long)(node.getClusterNode().totalQps());
 
-        double radio;
-        long newCount = bucketCount.get();
-        if (totalQps != 0) {
-            radio = passQps / totalQps;
-            if (Math.random() < (1 / totalQps)) {
-
-                // 计算限制范围[1.0, 2.0]的梯度
-                // 实际通过率越小，梯度值越大，以增加后续通过数
-                double gradientRadio = Math.max(1.0, Math.min(2.0, targetRadio / radio));
-
-                long avgRt = (long)(node.getClusterNode().avgRt());
-                long longTermRt = (long)(node.getClusterNode().longTermRt());
-                double gradientRt;
-                if (avgRt == 0) {
-                    gradientRt = 1;
-                } else {
-                    // 计算限制范围[0.5, 1.0]的梯度以过滤异常值
-                    // 实际 avgRt 越大，梯度值越小，说明需要限制通过数
-                    gradientRt = Math.max(0.5, Math.min(1.0, longTermRt / avgRt));
-                }
-
-                long currentCount = bucketCount.get();
-
-                // 最后的令牌发放速度由通过率和 Rt 共同决定
-                newCount = (long)(gradientRadio * gradientRt * currentCount);
-                // 使用平滑因子更新令牌发放速度（默认为0.2）
-                newCount = (long)(currentCount * (1 - smoothing) + newCount * smoothing);
-                bucketCount.compareAndSet(currentCount, newCount);
-            }
+        if (cpuUsage > 0.6) {
+            cpuFull.incrementAndGet();
         }
 
-        syncToken(previousQps, newCount, maxToken);
+        syncBucketCount(node.getClusterNode(), targetRatio, expectRt);
+
+        long newCount = bucketCount.get();
+        syncToken(previousQps, newCount, maxTokens.get());
 
         long restToken = storedTokens.get();
-        //newCount = Math.max(newCount, restToken);
+
         if (passQps + acquireCount <= restToken || passQps + acquireCount <= newCount) {
             return true;
         }
         return false;
     }
 
-    protected void syncToken(long passQps, long count, int maxToken) {
+    protected synchronized void syncBucketCount(ClusterNode node, double targetRatio, double expectRt) {
+        long currentTime = TimeUtil.currentTimeMillis();
+        currentTime = currentTime - currentTime % 1000;
+        long oldCountTime = lastCountTime.get();
+        if (currentTime <= oldCountTime) { return; }
+        if (oldCountTime == 0) {
+            lastCountTime.compareAndSet(oldCountTime, lastFilledTime.get());
+            return;
+        }
+        if ((currentTime - oldCountTime) / 1000 > 0.9) {
+            double ratio;
+            long newCount = bucketCount.get();
+
+            double smoothing = 0.2;
+
+            long previousQps = (long)(node.previousPassQps());
+            long previousTotalQps = (long)(node.previousBlockQps()) + previousQps;
+            long passQps = (long)(node.passQps());
+            long totalQps = (long)(node.totalQps());
+            if (totalQps != 0) {
+                ratio = passQps / totalQps;
+                // 如果newCount比用户预设的通过率小很多，就让其快速增加
+                if (newCount < totalQps * targetRatio / 2) {
+                    bucketCount.compareAndSet(newCount, (long)(totalQps * targetRatio / 2));
+                    newCount = bucketCount.get();
+                }
+                //System.out.println("statistic");
+                // 计算限制范围[1.0, 5.0]的梯度
+                // 实际通过率越小，梯度值越大，以增加后续通过数
+                double gradientRatio = Math.max(1.0, Math.min(2.0, targetRatio / ratio));
+
+                double avgRt = node.avgRt();
+                double longTermRt = node.longTermRt();
+                double gradientRt;
+                if (avgRt == 0) {
+                    gradientRt = 1;
+                } else {
+                    // 计算限制范围[0.5, 1.0]的梯度以过滤异常值
+                    // 实际 avgRt 越大，梯度值越小，说明需要限制通过数
+                    double needRt = Math.min(longTermRt, expectRt);
+                    gradientRt = Math.max(0.5, Math.min(1.0, needRt / avgRt));
+                }
+
+                long currentCount = bucketCount.get();
+                //System.out.println("gradientRadio: " + gradientRatio + " ;gradientRt: " + gradientRt);
+
+
+                // 最后的令牌发放速度由通过率和 Rt 共同决定
+                newCount = (long)(gradientRatio * gradientRt * currentCount);
+                // 使用平滑因子更新令牌发放速度（默认为0.2）
+                newCount = (long)(currentCount * (1 - smoothing) + newCount * smoothing);
+
+                bucketCount.compareAndSet(currentCount, newCount);
+
+
+            }
+            long newMaxToken = Math.max(newCount, (long)(previousTotalQps * targetRatio));
+            long oldMaxToken = maxTokens.get();
+            if (newMaxToken > oldMaxToken) {
+                maxTokens.compareAndSet(oldMaxToken, newMaxToken);
+            }
+            lastCountTime.compareAndSet(oldCountTime, currentTime);
+        }
+    }
+
+    protected void syncToken(long passQps, long count, long maxToken) {
         long currentTime = TimeUtil.currentTimeMillis();
         currentTime = currentTime - currentTime % 1000;
         long oldLastFillTime = lastFilledTime.get();
@@ -108,7 +176,7 @@ public class AdaptiveRuleChecker {
 
     }
 
-    private long addTokens(long currentTime, long passQps, long count, int maxToken) {
+    private long addTokens(long currentTime, long passQps, long count, long maxToken) {
         long oldValue = storedTokens.get();
         long newValue = oldValue;
 
@@ -125,6 +193,11 @@ public class AdaptiveRuleChecker {
     }
 
     public static double getCurrentCpuUsage() {
-        return statusListener.getCpuUsage();
+        try {
+            return statusListener.getCpuUsage();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return 0;
     }
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRuleManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRuleManager.java
@@ -1,0 +1,90 @@
+package com.alibaba.csp.sentinel.slots.block.adaptive;
+
+import com.alibaba.csp.sentinel.log.RecordLog;
+import com.alibaba.csp.sentinel.property.DynamicSentinelProperty;
+import com.alibaba.csp.sentinel.property.PropertyListener;
+import com.alibaba.csp.sentinel.property.SentinelProperty;
+import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
+import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+import com.alibaba.csp.sentinel.util.StringUtil;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author Liu Yiming
+ * @date 2019-07-14 22:28
+ */
+public final class AdaptiveRuleManager {
+
+    private static final Map<String, Set<AdaptiveRule>> adaptiveRules = new ConcurrentHashMap<String, Set<AdaptiveRule>>();
+
+    private static final RulePropertyListener LISTENER = new RulePropertyListener();
+    private static SentinelProperty<List<AdaptiveRule>> currentProperty = new DynamicSentinelProperty<>();
+
+    static {
+        currentProperty.addListener(LISTENER);
+    }
+
+
+    public static Set<AdaptiveRule> getRules(ResourceWrapper resource) {
+        return adaptiveRules.get(resource.getName());
+    }
+
+    public static void loadRules(List<AdaptiveRule> rules) {
+        try{
+            currentProperty.updateValue(rules);
+        } catch (Throwable e) {
+            RecordLog.warn("[AdaptiveRuleManager] Unexpected error when loading degrade rules", e);
+        }
+    }
+
+    private static class RulePropertyListener implements PropertyListener<List<AdaptiveRule>> {
+
+        @Override
+        public void configUpdate(List<AdaptiveRule> conf) {
+            Map<String, Set<AdaptiveRule>> rules = loadAdaptiveConf(conf);
+            if (rules != null) {
+                adaptiveRules.clear();
+                adaptiveRules.putAll(rules);
+            }
+            RecordLog.info("[AdaptiveRuleManager] Adaptive rules received: " + adaptiveRules);
+        }
+
+        @Override
+        public void configLoad(List<AdaptiveRule> conf) {
+            Map<String, Set<AdaptiveRule>> rules = loadAdaptiveConf(conf);
+            if (rules != null) {
+                adaptiveRules.clear();
+                adaptiveRules.putAll(rules);
+            }
+            RecordLog.info("[AdaptiveRuleManager] Adaptive rules received: " + adaptiveRules);
+        }
+
+        private Map<String, Set<AdaptiveRule>> loadAdaptiveConf(List<AdaptiveRule> list) {
+            Map<String, Set<AdaptiveRule>> newRuleMap = new ConcurrentHashMap<>();
+
+            if (list == null || list.isEmpty()) {
+                return newRuleMap;
+            }
+
+            for (AdaptiveRule rule : list) {
+                if (StringUtil.isBlank(rule.getLimitApp())) {
+                    rule.setLimitApp(RuleConstant.LIMIT_APP_DEFAULT);
+                }
+
+                String identity = rule.getResource();
+                Set<AdaptiveRule> ruleSet = newRuleMap.get(identity);
+                if (ruleSet == null) {
+                    ruleSet = new HashSet<>();
+                    newRuleMap.put(identity, ruleSet);
+                }
+                ruleSet.add(rule);
+            }
+            return newRuleMap;
+        }
+    }
+}

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRuleManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRuleManager.java
@@ -38,7 +38,7 @@ public final class AdaptiveRuleManager {
         try{
             currentProperty.updateValue(rules);
         } catch (Throwable e) {
-            RecordLog.warn("[AdaptiveRuleManager] Unexpected error when loading degrade rules", e);
+            RecordLog.warn("[AdaptiveRuleManager] Unexpected error when loading adaptive rules", e);
         }
     }
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRuleManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRuleManager.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * @author Liu Yiming
@@ -46,7 +47,7 @@ public final class AdaptiveRuleManager {
 
         @Override
         public void configUpdate(List<AdaptiveRule> conf) {
-            Map<String, Set<AdaptiveRule>> rules = loadAdaptiveConf(conf);
+            Map<String, Set<AdaptiveRule>> rules = AdaptiveRuleUtil.buildAdaptiveRuleMap(conf);
             if (rules != null) {
                 adaptiveRules.clear();
                 adaptiveRules.putAll(rules);
@@ -56,35 +57,12 @@ public final class AdaptiveRuleManager {
 
         @Override
         public void configLoad(List<AdaptiveRule> conf) {
-            Map<String, Set<AdaptiveRule>> rules = loadAdaptiveConf(conf);
+            Map<String, Set<AdaptiveRule>> rules = AdaptiveRuleUtil.buildAdaptiveRuleMap(conf);
             if (rules != null) {
                 adaptiveRules.clear();
                 adaptiveRules.putAll(rules);
             }
             RecordLog.info("[AdaptiveRuleManager] Adaptive rules received: " + adaptiveRules);
-        }
-
-        private Map<String, Set<AdaptiveRule>> loadAdaptiveConf(List<AdaptiveRule> list) {
-            Map<String, Set<AdaptiveRule>> newRuleMap = new ConcurrentHashMap<>();
-
-            if (list == null || list.isEmpty()) {
-                return newRuleMap;
-            }
-
-            for (AdaptiveRule rule : list) {
-                if (StringUtil.isBlank(rule.getLimitApp())) {
-                    rule.setLimitApp(RuleConstant.LIMIT_APP_DEFAULT);
-                }
-
-                String identity = rule.getResource();
-                Set<AdaptiveRule> ruleSet = newRuleMap.get(identity);
-                if (ruleSet == null) {
-                    ruleSet = new HashSet<>();
-                    newRuleMap.put(identity, ruleSet);
-                }
-                ruleSet.add(rule);
-            }
-            return newRuleMap;
         }
     }
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRuleUtil.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRuleUtil.java
@@ -1,0 +1,63 @@
+package com.alibaba.csp.sentinel.slots.block.adaptive;
+
+import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+import com.alibaba.csp.sentinel.slots.block.adaptive.controller.AdaptiveRateController;
+import com.alibaba.csp.sentinel.slots.block.adaptive.controller.TokenBucketController;
+import com.alibaba.csp.sentinel.slots.block.flow.TrafficShapingController;
+import com.alibaba.csp.sentinel.util.StringUtil;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * @author Liu Yiming
+ * @date 2019-07-27 22:18
+ */
+public final class AdaptiveRuleUtil {
+    /**
+     * Build the adaptive rule map from raw list of adaptive rules.
+     *
+     * @param list raw list of adaptive rules
+     * @return constructed new adaptive rule map; empty map if list is null or empty, or no valid rules
+     */
+
+    public static Map<String, Set<AdaptiveRule>> buildAdaptiveRuleMap(List<AdaptiveRule> list) {
+
+        Map<String, Set<AdaptiveRule>> newRuleMap = new ConcurrentHashMap<>();
+
+        if (list == null || list.isEmpty()) {
+            return newRuleMap;
+        }
+
+        for (AdaptiveRule rule : list) {
+            if (StringUtil.isBlank(rule.getLimitApp())) {
+                rule.setLimitApp(RuleConstant.LIMIT_APP_DEFAULT);
+            }
+
+            TrafficShapingController rater = generateRater(rule);
+            rule.setRater(rater);
+
+            String identity = rule.getResource();
+            Set<AdaptiveRule> ruleSet = newRuleMap.get(identity);
+            if (ruleSet == null) {
+                ruleSet = new HashSet<>();
+                newRuleMap.put(identity, ruleSet);
+            }
+            ruleSet.add(rule);
+        }
+        return newRuleMap;
+    }
+
+    private static TrafficShapingController generateRater(AdaptiveRule rule) {
+
+        // 根据expectRt判断是适合用漏桶还是用令牌桶
+        if (rule.getExpectRt() <= 1000) {
+            return new TokenBucketController(rule.getTargetRatio(), rule.getExpectRt());
+        }
+        return new AdaptiveRateController((int)rule.getExpectRt());
+    }
+}

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRuleUtil.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRuleUtil.java
@@ -56,8 +56,9 @@ public final class AdaptiveRuleUtil {
     private static TrafficShapingController generateRater(AdaptiveRule rule) {
 
         // 根据expectRt判断是适合用漏桶还是用令牌桶
-        if (rule.getExpectRt() <= 1000) {
-            return new PidController(rule.getTargetRatio(), rule.getExpectRt());
+        if (rule.getExpectRt() <= 200) {
+            return new TokenBucketController(rule.getTargetRatio(), rule.getExpectRt());
+            //return new PidController(rule.getTargetRatio(), rule.getExpectRt());
         }
         return new AdaptiveRateController((int)rule.getExpectRt());
     }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRuleUtil.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRuleUtil.java
@@ -55,10 +55,13 @@ public final class AdaptiveRuleUtil {
 
     private static TrafficShapingController generateRater(AdaptiveRule rule) {
 
+        // 如果用户设置使用PID控制器，一律使用PidController
+        if(rule.getGrade() == 2) {
+            return new PidController(rule.getTargetRatio(), rule.getExpectRt());
+        }
         // 根据expectRt判断是适合用漏桶还是用令牌桶
         if (rule.getExpectRt() <= 200) {
             return new TokenBucketController(rule.getTargetRatio(), rule.getExpectRt());
-            //return new PidController(rule.getTargetRatio(), rule.getExpectRt());
         }
         return new AdaptiveRateController((int)rule.getExpectRt());
     }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRuleUtil.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveRuleUtil.java
@@ -2,6 +2,7 @@ package com.alibaba.csp.sentinel.slots.block.adaptive;
 
 import com.alibaba.csp.sentinel.slots.block.RuleConstant;
 import com.alibaba.csp.sentinel.slots.block.adaptive.controller.AdaptiveRateController;
+import com.alibaba.csp.sentinel.slots.block.adaptive.controller.PidController;
 import com.alibaba.csp.sentinel.slots.block.adaptive.controller.TokenBucketController;
 import com.alibaba.csp.sentinel.slots.block.flow.TrafficShapingController;
 import com.alibaba.csp.sentinel.util.StringUtil;
@@ -56,8 +57,10 @@ public final class AdaptiveRuleUtil {
 
         // 根据expectRt判断是适合用漏桶还是用令牌桶
         if (rule.getExpectRt() <= 1000) {
-            return new TokenBucketController(rule.getTargetRatio(), rule.getExpectRt());
+            return new PidController(rule.getTargetRatio(), rule.getExpectRt());
         }
         return new AdaptiveRateController((int)rule.getExpectRt());
     }
+
+
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveSlot.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/AdaptiveSlot.java
@@ -1,0 +1,43 @@
+package com.alibaba.csp.sentinel.slots.block.adaptive;
+
+import com.alibaba.csp.sentinel.context.Context;
+import com.alibaba.csp.sentinel.node.DefaultNode;
+import com.alibaba.csp.sentinel.slotchain.AbstractLinkedProcessorSlot;
+import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
+import com.alibaba.csp.sentinel.slots.block.BlockException;
+import com.alibaba.csp.sentinel.util.AssertUtil;
+
+/**
+ * @author Liu Yiming
+ * @date 2019-07-14 22:12
+ */
+public class AdaptiveSlot extends AbstractLinkedProcessorSlot<DefaultNode> {
+
+    private final AdaptiveRuleChecker checker;
+
+    public AdaptiveSlot() {
+        this(new AdaptiveRuleChecker());
+    }
+
+    AdaptiveSlot(AdaptiveRuleChecker checker) {
+        AssertUtil.notNull(checker, "Adaptive checker should not be null");
+        this.checker = checker;
+    }
+
+    @Override
+    public void entry(Context context, ResourceWrapper resourceWrapper, DefaultNode node, int count, boolean prioritized, Object... args)
+        throws Throwable {
+        checkAdaptive(resourceWrapper, context, node, count);
+        fireEntry(context, resourceWrapper, node, count, prioritized, args);
+    }
+
+    void checkAdaptive(ResourceWrapper resource, Context context, DefaultNode node, int count)
+        throws BlockException {
+        checker.checkAdaptive(resource, context, node, count);
+    }
+
+    @Override
+    public void exit(Context context, ResourceWrapper resourceWrapper, int count, Object... args) {
+        fireExit(context, resourceWrapper, count, args);
+    }
+}

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/controller/AdaptiveRateController.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/controller/AdaptiveRateController.java
@@ -1,0 +1,76 @@
+package com.alibaba.csp.sentinel.slots.block.adaptive.controller;
+
+import com.alibaba.csp.sentinel.node.Node;
+import com.alibaba.csp.sentinel.slots.block.flow.TrafficShapingController;
+import com.alibaba.csp.sentinel.util.TimeUtil;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * @author Liu Yiming
+ * @date 2019-07-28 17:34
+ */
+public class AdaptiveRateController implements TrafficShapingController {
+    private final int maxQueueingTimeMs;
+
+    private final AtomicLong bucketCount = new AtomicLong(20);
+    private final AtomicLong latestPassedTime = new AtomicLong(-1);
+
+    public AdaptiveRateController(int timeOut) {
+        this.maxQueueingTimeMs = timeOut;
+    }
+
+    @Override
+    public boolean canPass(Node node, int acquireCount) {
+        return canPass(node, acquireCount, false);
+    }
+
+    @Override
+    public boolean canPass(Node node, int acquireCount, boolean prioritized) {
+        // Pass when acquire count is less or equal than 0.
+        if (acquireCount <= 0) {
+            return true;
+        }
+
+        long count = bucketCount.get();
+
+        long currentTime = TimeUtil.currentTimeMillis();
+        // Calculate the interval between every two requests.
+        long costTime = Math.round(1.0 * (acquireCount) / count * 1000);
+
+        // Expected pass time of this request.
+        long expectedTime = costTime + latestPassedTime.get();
+
+        if (expectedTime <= currentTime) {
+            // Contention may exist here, but it's okay.
+            latestPassedTime.set(currentTime);
+            return true;
+        } else {
+            // Calculate the time to wait.
+            long waitTime = costTime + latestPassedTime.get() - TimeUtil.currentTimeMillis();
+            if (waitTime > maxQueueingTimeMs) {
+                long newCount = count * 2;
+                bucketCount.compareAndSet(count, newCount);
+                return false;
+            } else {
+                long oldTime = latestPassedTime.addAndGet(costTime);
+                try {
+                    waitTime = oldTime - TimeUtil.currentTimeMillis();
+                    if (waitTime > maxQueueingTimeMs) {
+                        latestPassedTime.addAndGet(-costTime);
+                        long newCount = count * 2;
+                        bucketCount.compareAndSet(count, newCount);
+                        return false;
+                    }
+                    // in race condition waitTime may <= 0
+                    if (waitTime > 0) {
+                        Thread.sleep(waitTime);
+                    }
+                    return true;
+                } catch (InterruptedException e) {
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/controller/PidController.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/controller/PidController.java
@@ -1,10 +1,15 @@
 package com.alibaba.csp.sentinel.slots.block.adaptive.controller;
 
+import com.alibaba.csp.sentinel.concurrent.NamedThreadFactory;
 import com.alibaba.csp.sentinel.node.ClusterNode;
 import com.alibaba.csp.sentinel.node.Node;
 import com.alibaba.csp.sentinel.slots.block.flow.TrafficShapingController;
+import com.alibaba.csp.sentinel.slots.system.SystemStatusListener;
 import com.alibaba.csp.sentinel.util.TimeUtil;
 
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class PidController implements TrafficShapingController {
@@ -13,6 +18,7 @@ public class PidController implements TrafficShapingController {
 
     protected AtomicLong err = new AtomicLong();
     protected AtomicLong err_last = new AtomicLong();
+    protected AtomicLong err_next = new AtomicLong();
     protected AtomicLong integral = new AtomicLong(); // 积分值
 
     // 令牌发放速率
@@ -29,6 +35,16 @@ public class PidController implements TrafficShapingController {
 
     // 令牌桶容量
     protected AtomicLong maxTokens = new AtomicLong(4000);
+
+    @SuppressWarnings("PMD.ThreadPoolCreationRule")
+    private final static ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1,
+            new NamedThreadFactory("sentinel-system-status-record-task", true));
+    private static SystemStatusListener statusListener = null;
+
+    static {
+        statusListener = new SystemStatusListener();
+        scheduler.scheduleAtFixedRate(statusListener, 5, 1, TimeUnit.SECONDS);
+    }
 
     public PidController(double targetRatio, double expectRt) {
         this.targetRatio = targetRatio;
@@ -62,59 +78,36 @@ public class PidController implements TrafficShapingController {
         long currentTime = TimeUtil.currentTimeMillis();
         currentTime = currentTime - currentTime % 1000;
         long oldCountTime = lastCountTime.get();
+
         if (currentTime <= oldCountTime) { return; }
         if (oldCountTime == 0) {
             lastCountTime.compareAndSet(oldCountTime, lastFilledTime.get());
             return;
         }
         if ((currentTime - oldCountTime) / 1000 > 0.9) {
-            double ratio;
             long newCount = bucketCount.get();
-
-            double smoothing = 0.2;
 
             long previousQps = (long)(node.previousPassQps());
             long previousTotalQps = (long)(node.previousBlockQps()) + previousQps;
-            long passQps = (long)(node.passQps());
             long totalQps = (long)(node.totalQps());
             if (totalQps != 0) {
-                ratio = passQps / totalQps;
                 // 如果newCount比用户预设的通过率小很多，就让其快速增加
                 if (newCount < totalQps * targetRatio / 2) {
                     bucketCount.compareAndSet(newCount, (long)(totalQps * targetRatio / 2));
-                    newCount = bucketCount.get();
-                }
-                //System.out.println("statistic");
-                // 计算限制范围[1.0, 5.0]的梯度
-                // 实际通过率越小，梯度值越大，以增加后续通过数
-                double gradientRatio = Math.max(1.0, Math.min(2.0, targetRatio / ratio));
-
-                double avgRt = node.avgRt();
-                double longTermRt = node.longTermRt();
-                double gradientRt;
-                if (avgRt == 0) {
-                    gradientRt = 1;
-                } else {
-                    // 计算限制范围[0.5, 1.0]的梯度以过滤异常值
-                    // 实际 avgRt 越大，梯度值越小，说明需要限制通过数
-                    double needRt = Math.min(longTermRt, expectRt);
-                    gradientRt = Math.max(0.5, Math.min(1.0, needRt / avgRt));
                 }
 
                 long currentCount = bucketCount.get();
 
-//                // 最后的令牌发放速度由通过率和 Rt 共同决定
-//                newCount = (long)(gradientRatio * gradientRt * currentCount);
-//                // 使用平滑因子更新令牌发放速度（默认为0.2）
-//                newCount = (long)(currentCount * (1 - smoothing) + newCount * smoothing);
-
-                newCount = currentCount + syncCountByPid(node, expectRt);
+                newCount = currentCount + syncCountByPid2(node, expectRt);
+                //newCount = currentCount + syncCountByPid2();
 
                 bucketCount.compareAndSet(currentCount, newCount);
 
 
             }
-            long newMaxToken = Math.max(newCount, (long)(previousTotalQps * targetRatio));
+
+            //Todo
+            long newMaxToken = Math.max(newCount * 5, (long)(previousTotalQps * targetRatio));
             long oldMaxToken = maxTokens.get();
             if (newMaxToken > oldMaxToken) {
                 maxTokens.compareAndSet(oldMaxToken, newMaxToken);
@@ -123,15 +116,31 @@ public class PidController implements TrafficShapingController {
         }
     }
 
+    // 位置式PID控制器
     protected long syncCountByPid(ClusterNode node, double expectRt) {
-        double Kp = 1000, Ki =5, Kd = 0;
-        double errNum = expectRt - node.avgRt();
+        double Kp = 1000, Ki = 5, Kd = 0;
+        double errNum = 0.6 - getCurrentCpuUsage();
+        //double errNum = expectRt - node.avgRt();
         err.compareAndSet(err.get(), Double.doubleToLongBits(errNum));
         double integralNum = Double.longBitsToDouble(integral.get()) + errNum;
         integral.compareAndSet(integral.get(), Double.doubleToLongBits(integralNum));
         double countNum = Kp * errNum + Ki * integralNum + Kd * (errNum - Double.longBitsToDouble(err_last.get()));
         err_last.compareAndSet(err_last.get(), Double.doubleToLongBits(errNum));
         return (long)countNum;
+    }
+
+    // 增量式PID控制器
+    protected long syncCountByPid2(ClusterNode node, double expectRt) {
+        double Kp = 1000, Ki = 2.5, Kd = 0;
+        double errNum = 0.6 - getCurrentCpuUsage();
+        //double errNum = expectRt - node.avgRt();
+        double errNextNum = Double.longBitsToDouble(err_next.get());
+        double errLastNum = Double .longBitsToDouble(err_last.get());
+        err.compareAndSet(err.get(), Double.doubleToLongBits(errNum));
+        double incrementNum = Kp * (errNum - errNextNum) + Ki * errNum + Kd * (errNum - 2 * errNextNum + errLastNum);
+        err_last.compareAndSet(err_last.get(), Double.doubleToLongBits(errNextNum));
+        err_next.compareAndSet(err_next.get(), Double.doubleToLongBits(errNum));
+        return (long)incrementNum;
     }
 
     protected void syncToken(long passQps, long count, long maxToken) {
@@ -169,5 +178,14 @@ public class PidController implements TrafficShapingController {
         }
 
         return Math.min(newValue, maxToken);
+    }
+
+    public static double getCurrentCpuUsage() {
+        try {
+            return statusListener.getCpuUsage();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return 0;
     }
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/controller/PidController.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/controller/PidController.java
@@ -98,15 +98,13 @@ public class PidController implements TrafficShapingController {
 
                 long currentCount = bucketCount.get();
 
-                newCount = currentCount + syncCountByPid2(node, expectRt);
-                //newCount = currentCount + syncCountByPid2();
+                newCount = currentCount + syncCountByPid2();
 
                 bucketCount.compareAndSet(currentCount, newCount);
 
 
             }
 
-            //Todo
             long newMaxToken = Math.max(newCount * 5, (long)(previousTotalQps * targetRatio));
             long oldMaxToken = maxTokens.get();
             if (newMaxToken > oldMaxToken) {
@@ -117,7 +115,7 @@ public class PidController implements TrafficShapingController {
     }
 
     // 位置式PID控制器
-    protected long syncCountByPid(ClusterNode node, double expectRt) {
+    protected long syncCountByPid() {
         double Kp = 1000, Ki = 5, Kd = 0;
         double errNum = 0.6 - getCurrentCpuUsage();
         //double errNum = expectRt - node.avgRt();
@@ -130,7 +128,7 @@ public class PidController implements TrafficShapingController {
     }
 
     // 增量式PID控制器
-    protected long syncCountByPid2(ClusterNode node, double expectRt) {
+    protected long syncCountByPid2() {
         double Kp = 1000, Ki = 2.5, Kd = 0;
         double errNum = 0.6 - getCurrentCpuUsage();
         //double errNum = expectRt - node.avgRt();
@@ -152,7 +150,7 @@ public class PidController implements TrafficShapingController {
         }
 
         long oldValue = storedTokens.get();
-        long newValue = addTokens(currentTime, passQps, count, maxToken);
+        long newValue = addTokens(currentTime, count, maxToken);
 
         if (storedTokens.compareAndSet(oldValue, newValue)) {
             long currentValue = storedTokens.addAndGet(0 - passQps);
@@ -164,7 +162,7 @@ public class PidController implements TrafficShapingController {
 
     }
 
-    private long addTokens(long currentTime, long passQps, long count, long maxToken) {
+    private long addTokens(long currentTime, long count, long maxToken) {
         long oldValue = storedTokens.get();
         long newValue = oldValue;
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/controller/PidController.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/controller/PidController.java
@@ -1,0 +1,173 @@
+package com.alibaba.csp.sentinel.slots.block.adaptive.controller;
+
+import com.alibaba.csp.sentinel.node.ClusterNode;
+import com.alibaba.csp.sentinel.node.Node;
+import com.alibaba.csp.sentinel.slots.block.flow.TrafficShapingController;
+import com.alibaba.csp.sentinel.util.TimeUtil;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class PidController implements TrafficShapingController {
+    private double expectRt;
+    private double targetRatio; // 目标通过率
+
+    protected AtomicLong err = new AtomicLong();
+    protected AtomicLong err_last = new AtomicLong();
+    protected AtomicLong integral = new AtomicLong(); // 积分值
+
+    // 令牌发放速率
+    protected AtomicLong bucketCount = new AtomicLong(2000);
+
+    // 剩余存储令牌数
+    protected AtomicLong storedTokens = new AtomicLong(0);
+
+    // 上一次存令牌的时间
+    protected AtomicLong lastFilledTime = new AtomicLong(0);
+
+    // 上一次更新令牌发放速率的时间
+    protected AtomicLong lastCountTime = new AtomicLong(0);
+
+    // 令牌桶容量
+    protected AtomicLong maxTokens = new AtomicLong(4000);
+
+    public PidController(double targetRatio, double expectRt) {
+        this.targetRatio = targetRatio;
+        this.expectRt = expectRt;
+    }
+
+    @Override
+    public boolean canPass(Node node, int acquireCount) {
+        return canPass(node, acquireCount, false);
+    }
+
+    @Override
+    public boolean canPass(Node node, int acquireCount, boolean prioritized) {
+        long previousQps = (long)(node.previousPassQps());
+        long passQps = (long)(node.passQps());
+
+        syncBucketCount((ClusterNode) node, targetRatio, expectRt);
+
+        long newCount = bucketCount.get();
+        syncToken(previousQps, newCount, maxTokens.get());
+
+        long restToken = storedTokens.get();
+
+        if (passQps + acquireCount <= restToken + newCount) {
+            return true;
+        }
+        return false;
+    }
+
+    protected synchronized void syncBucketCount(ClusterNode node, double targetRatio, double expectRt) {
+        long currentTime = TimeUtil.currentTimeMillis();
+        currentTime = currentTime - currentTime % 1000;
+        long oldCountTime = lastCountTime.get();
+        if (currentTime <= oldCountTime) { return; }
+        if (oldCountTime == 0) {
+            lastCountTime.compareAndSet(oldCountTime, lastFilledTime.get());
+            return;
+        }
+        if ((currentTime - oldCountTime) / 1000 > 0.9) {
+            double ratio;
+            long newCount = bucketCount.get();
+
+            double smoothing = 0.2;
+
+            long previousQps = (long)(node.previousPassQps());
+            long previousTotalQps = (long)(node.previousBlockQps()) + previousQps;
+            long passQps = (long)(node.passQps());
+            long totalQps = (long)(node.totalQps());
+            if (totalQps != 0) {
+                ratio = passQps / totalQps;
+                // 如果newCount比用户预设的通过率小很多，就让其快速增加
+                if (newCount < totalQps * targetRatio / 2) {
+                    bucketCount.compareAndSet(newCount, (long)(totalQps * targetRatio / 2));
+                    newCount = bucketCount.get();
+                }
+                //System.out.println("statistic");
+                // 计算限制范围[1.0, 5.0]的梯度
+                // 实际通过率越小，梯度值越大，以增加后续通过数
+                double gradientRatio = Math.max(1.0, Math.min(2.0, targetRatio / ratio));
+
+                double avgRt = node.avgRt();
+                double longTermRt = node.longTermRt();
+                double gradientRt;
+                if (avgRt == 0) {
+                    gradientRt = 1;
+                } else {
+                    // 计算限制范围[0.5, 1.0]的梯度以过滤异常值
+                    // 实际 avgRt 越大，梯度值越小，说明需要限制通过数
+                    double needRt = Math.min(longTermRt, expectRt);
+                    gradientRt = Math.max(0.5, Math.min(1.0, needRt / avgRt));
+                }
+
+                long currentCount = bucketCount.get();
+
+//                // 最后的令牌发放速度由通过率和 Rt 共同决定
+//                newCount = (long)(gradientRatio * gradientRt * currentCount);
+//                // 使用平滑因子更新令牌发放速度（默认为0.2）
+//                newCount = (long)(currentCount * (1 - smoothing) + newCount * smoothing);
+
+                newCount = currentCount + syncCountByPid(node, expectRt);
+
+                bucketCount.compareAndSet(currentCount, newCount);
+
+
+            }
+            long newMaxToken = Math.max(newCount, (long)(previousTotalQps * targetRatio));
+            long oldMaxToken = maxTokens.get();
+            if (newMaxToken > oldMaxToken) {
+                maxTokens.compareAndSet(oldMaxToken, newMaxToken);
+            }
+            lastCountTime.compareAndSet(oldCountTime, currentTime);
+        }
+    }
+
+    protected long syncCountByPid(ClusterNode node, double expectRt) {
+        double Kp = 1000, Ki =5, Kd = 0;
+        double errNum = expectRt - node.avgRt();
+        err.compareAndSet(err.get(), Double.doubleToLongBits(errNum));
+        double integralNum = Double.longBitsToDouble(integral.get()) + errNum;
+        integral.compareAndSet(integral.get(), Double.doubleToLongBits(integralNum));
+        double countNum = Kp * errNum + Ki * integralNum + Kd * (errNum - Double.longBitsToDouble(err_last.get()));
+        err_last.compareAndSet(err_last.get(), Double.doubleToLongBits(errNum));
+        return (long)countNum;
+    }
+
+    protected void syncToken(long passQps, long count, long maxToken) {
+        long currentTime = TimeUtil.currentTimeMillis();
+        currentTime = currentTime - currentTime % 1000;
+        long oldLastFillTime = lastFilledTime.get();
+        if (currentTime <= oldLastFillTime) {
+            return;
+        }
+
+        long oldValue = storedTokens.get();
+        long newValue = addTokens(currentTime, passQps, count, maxToken);
+
+        if (storedTokens.compareAndSet(oldValue, newValue)) {
+            long currentValue = storedTokens.addAndGet(0 - passQps);
+            if (currentValue < 0) {
+                storedTokens.set(0L);
+            }
+            lastFilledTime.set(currentTime);
+        }
+
+    }
+
+    private long addTokens(long currentTime, long passQps, long count, long maxToken) {
+        long oldValue = storedTokens.get();
+        long newValue = oldValue;
+
+        if (oldValue < maxToken) {
+            if (lastFilledTime.get() == 0) {
+                newValue = count;
+            } else {
+                newValue = (long)(oldValue + (currentTime - lastFilledTime.get()) * count / 1000);
+            }
+
+        }
+
+        return Math.min(newValue, maxToken);
+    }
+}

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/controller/TokenBucketController.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/controller/TokenBucketController.java
@@ -1,0 +1,189 @@
+package com.alibaba.csp.sentinel.slots.block.adaptive.controller;
+
+import com.alibaba.csp.sentinel.concurrent.NamedThreadFactory;
+import com.alibaba.csp.sentinel.node.ClusterNode;
+import com.alibaba.csp.sentinel.node.Node;
+import com.alibaba.csp.sentinel.slots.block.flow.TrafficShapingController;
+import com.alibaba.csp.sentinel.slots.system.SystemStatusListener;
+import com.alibaba.csp.sentinel.util.TimeUtil;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * @author Liu Yiming
+ * @date 2019-07-27 22:31
+ */
+public class TokenBucketController implements TrafficShapingController {
+    // 剩余存储令牌数
+    protected AtomicLong storedTokens = new AtomicLong(0);
+
+    // 上一次存令牌的时间
+    protected AtomicLong lastFilledTime = new AtomicLong(0);
+
+    // 上一次更新令牌发放速率的时间
+    protected AtomicLong lastCountTime = new AtomicLong(0);
+
+    // 令牌发放速率
+    protected AtomicLong bucketCount = new AtomicLong(2000);
+
+    // 令牌桶容量
+    protected AtomicLong maxTokens = new AtomicLong(4000);
+
+    // cpu占用率大于0.6的请求数
+    protected AtomicLong cpuFull = new AtomicLong(0);
+
+    private double targetRatio;// 目标通过率
+    private double expectRt;
+
+    @SuppressWarnings("PMD.ThreadPoolCreationRule")
+    private final static ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1,
+            new NamedThreadFactory("sentinel-system-status-record-task", true));
+    private static SystemStatusListener statusListener = null;
+
+    static {
+        statusListener = new SystemStatusListener();
+        scheduler.scheduleAtFixedRate(statusListener, 5, 1, TimeUnit.SECONDS);
+    }
+
+    public TokenBucketController(double targetRatio, double expectRt) {
+        this.targetRatio = targetRatio;
+        this.expectRt = expectRt;
+    }
+
+    @Override
+    public boolean canPass(Node node, int acquireCount) {
+        return canPass(node, acquireCount, false);
+    }
+
+    @Override
+    public boolean canPass(Node node, int acquireCount, boolean prioritized) {
+        long previousQps = (long)(node.previousPassQps());
+        long passQps = (long)(node.passQps());
+
+        syncBucketCount((ClusterNode) node, targetRatio, expectRt);
+
+        long newCount = bucketCount.get();
+        syncToken(previousQps, newCount, maxTokens.get());
+
+        long restToken = storedTokens.get();
+
+        if (passQps + acquireCount <= restToken + newCount) {
+            return true;
+        }
+        return false;
+    }
+
+    protected synchronized void syncBucketCount(ClusterNode node, double targetRatio, double expectRt) {
+        long currentTime = TimeUtil.currentTimeMillis();
+        currentTime = currentTime - currentTime % 1000;
+        long oldCountTime = lastCountTime.get();
+        if (currentTime <= oldCountTime) { return; }
+        if (oldCountTime == 0) {
+            lastCountTime.compareAndSet(oldCountTime, lastFilledTime.get());
+            return;
+        }
+        if ((currentTime - oldCountTime) / 1000 > 0.9) {
+            double ratio;
+            long newCount = bucketCount.get();
+
+            double smoothing = 0.2;
+
+            long previousQps = (long)(node.previousPassQps());
+            long previousTotalQps = (long)(node.previousBlockQps()) + previousQps;
+            long passQps = (long)(node.passQps());
+            long totalQps = (long)(node.totalQps());
+            if (totalQps != 0) {
+                ratio = passQps / totalQps;
+                // 如果newCount比用户预设的通过率小很多，就让其快速增加
+                if (newCount < totalQps * targetRatio / 2) {
+                    bucketCount.compareAndSet(newCount, (long)(totalQps * targetRatio / 2));
+                    newCount = bucketCount.get();
+                }
+                //System.out.println("statistic");
+                // 计算限制范围[1.0, 5.0]的梯度
+                // 实际通过率越小，梯度值越大，以增加后续通过数
+                double gradientRatio = Math.max(1.0, Math.min(2.0, targetRatio / ratio));
+
+                double avgRt = node.avgRt();
+                double longTermRt = node.longTermRt();
+                double gradientRt;
+                if (avgRt == 0) {
+                    gradientRt = 1;
+                } else {
+                    // 计算限制范围[0.5, 1.0]的梯度以过滤异常值
+                    // 实际 avgRt 越大，梯度值越小，说明需要限制通过数
+                    double needRt = Math.min(longTermRt, expectRt);
+                    gradientRt = Math.max(0.5, Math.min(1.0, needRt / avgRt));
+                }
+
+                long currentCount = bucketCount.get();
+                //System.out.println("gradientRadio: " + gradientRatio + " ;gradientRt: " + gradientRt);
+
+
+                // 最后的令牌发放速度由通过率和 Rt 共同决定
+                newCount = (long)(gradientRatio * gradientRt * currentCount);
+                // 使用平滑因子更新令牌发放速度（默认为0.2）
+                newCount = (long)(currentCount * (1 - smoothing) + newCount * smoothing);
+
+                bucketCount.compareAndSet(currentCount, newCount);
+
+
+            }
+            long newMaxToken = Math.max(newCount, (long)(previousTotalQps * targetRatio));
+            long oldMaxToken = maxTokens.get();
+            if (newMaxToken > oldMaxToken) {
+                maxTokens.compareAndSet(oldMaxToken, newMaxToken);
+            }
+            lastCountTime.compareAndSet(oldCountTime, currentTime);
+        }
+    }
+
+    protected void syncToken(long passQps, long count, long maxToken) {
+        long currentTime = TimeUtil.currentTimeMillis();
+        currentTime = currentTime - currentTime % 1000;
+        long oldLastFillTime = lastFilledTime.get();
+        if (currentTime <= oldLastFillTime) {
+            return;
+        }
+
+        long oldValue = storedTokens.get();
+        long newValue = addTokens(currentTime, passQps, count, maxToken);
+
+        if (storedTokens.compareAndSet(oldValue, newValue)) {
+            long currentValue = storedTokens.addAndGet(0 - passQps);
+            if (currentValue < 0) {
+                storedTokens.set(0L);
+            }
+            lastFilledTime.set(currentTime);
+        }
+
+    }
+
+    private long addTokens(long currentTime, long passQps, long count, long maxToken) {
+        long oldValue = storedTokens.get();
+        long newValue = oldValue;
+
+        if (oldValue < maxToken) {
+            if (lastFilledTime.get() == 0) {
+                newValue = count;
+            } else {
+                newValue = (long)(oldValue + (currentTime - lastFilledTime.get()) * count / 1000);
+            }
+
+        }
+
+        return Math.min(newValue, maxToken);
+    }
+
+    public static double getCurrentCpuUsage() {
+        try {
+            return statusListener.getCpuUsage();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+}

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/controller/TokenBucketController.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/adaptive/controller/TokenBucketController.java
@@ -135,7 +135,6 @@ public class TokenBucketController implements TrafficShapingController {
 
             }
 
-            // Todo
             long newMaxToken = Math.max(newCount, (long)(previousTotalQps * targetRatio));
             long oldMaxToken = maxTokens.get();
             if (newMaxToken > oldMaxToken) {

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/data/MetricBucket.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/data/MetricBucket.java
@@ -30,6 +30,7 @@ public class MetricBucket {
     private final LongAdder[] counters;
 
     private volatile long minRt;
+    private volatile long maxRt;
 
     public MetricBucket() {
         MetricEvent[] events = MetricEvent.values();
@@ -38,6 +39,7 @@ public class MetricBucket {
             counters[event.ordinal()] = new LongAdder();
         }
         initMinRt();
+        initMaxRt();
     }
 
     public MetricBucket reset(MetricBucket bucket) {
@@ -46,13 +48,14 @@ public class MetricBucket {
             counters[event.ordinal()].add(bucket.get(event));
         }
         initMinRt();
+        initMaxRt();
         return this;
     }
 
     private void initMinRt() {
         this.minRt = Constants.TIME_DROP_VALVE;
     }
-
+    private void initMaxRt() { this.maxRt = 0; }
     /**
      * Reset the adders.
      *
@@ -63,6 +66,7 @@ public class MetricBucket {
             counters[event.ordinal()].reset();
         }
         initMinRt();
+        initMaxRt();
         return this;
     }
 
@@ -99,6 +103,10 @@ public class MetricBucket {
         return minRt;
     }
 
+    public long maxRt() {
+        return maxRt;
+    }
+
     public long success() {
         return get(MetricEvent.SUCCESS);
     }
@@ -129,6 +137,9 @@ public class MetricBucket {
         // Not thread-safe, but it's okay.
         if (rt < minRt) {
             minRt = rt;
+        }
+        if (rt > maxRt) {
+            maxRt = rt;
         }
     }
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/metric/ArrayMetric.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/metric/ArrayMetric.java
@@ -152,6 +152,20 @@ public class ArrayMetric implements Metric {
     }
 
     @Override
+    public long maxRt() {
+        data.currentWindow();
+        long rt = 0;
+        List<MetricBucket> list = data.values();
+        for (MetricBucket window : list) {
+            if (window.maxRt() > rt) {
+                rt = window.maxRt();
+            }
+        }
+
+        return Math.min(Constants.TIME_DROP_VALVE, rt);
+    }
+
+    @Override
     public List<MetricNode> details() {
         List<MetricNode> details = new ArrayList<MetricNode>();
         data.currentWindow();

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/metric/Metric.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/metric/Metric.java
@@ -78,6 +78,13 @@ public interface Metric extends DebugSupport {
     long minRt();
 
     /**
+     * Get the maximal RT.
+     *
+     * @return maximal RT
+     */
+    long maxRt();
+
+    /**
      * Get aggregated metric nodes of all resources.
      *
      * @return metric node list of all resources

--- a/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/adaptive/AdaptiveDemo.java
+++ b/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/adaptive/AdaptiveDemo.java
@@ -72,8 +72,9 @@ public class AdaptiveDemo {
         List<AdaptiveRule> rules = new ArrayList<AdaptiveRule>();
         AdaptiveRule rule = new AdaptiveRule();
         rule.setResource(KEY);
-        rule.setCount(200);
-        rule.setMaxToken(2000);
+        //rule.setCount(40000);
+        rule.setMaxToken(80000);
+        rule.setTargetRadio(0.5);
         rules.add(rule);
         AdaptiveRuleManager.loadRules(rules);
     }
@@ -127,7 +128,7 @@ public class AdaptiveDemo {
                 }
                 Random random2 = new Random();
                 try {
-                    TimeUnit.MILLISECONDS.sleep(random2.nextInt(50));
+                    TimeUnit.MILLISECONDS.sleep(random2.nextInt(1));
                 } catch (InterruptedException e) {
                     // ignore
                 }
@@ -155,7 +156,7 @@ public class AdaptiveDemo {
                 }
                 Random random2 = new Random();
                 try {
-                    TimeUnit.MILLISECONDS.sleep(random2.nextInt(50));
+                    TimeUnit.MILLISECONDS.sleep(random2.nextInt(2));
                 } catch (InterruptedException e) {
                     // ignore
                 }

--- a/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/adaptive/AdaptiveDemo.java
+++ b/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/adaptive/AdaptiveDemo.java
@@ -1,0 +1,223 @@
+package com.alibaba.csp.sentinel.demo.adaptive;
+
+import com.alibaba.csp.sentinel.Entry;
+import com.alibaba.csp.sentinel.SphU;
+import com.alibaba.csp.sentinel.slots.block.BlockException;
+import com.alibaba.csp.sentinel.slots.block.adaptive.AdaptiveRule;
+import com.alibaba.csp.sentinel.slots.block.adaptive.AdaptiveRuleManager;
+import com.alibaba.csp.sentinel.util.TimeUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author Liu Yiming
+ * @date 2019-07-17 14:31
+ */
+public class AdaptiveDemo {
+
+    private static final String KEY = "abc";
+
+    private static AtomicInteger pass = new AtomicInteger();
+    private static AtomicInteger block = new AtomicInteger();
+    private static AtomicInteger total = new AtomicInteger();
+
+    private static volatile boolean stop = false;
+    private static volatile boolean stop1 = false;
+    private static volatile boolean stop2 = false;
+    private static volatile boolean start2 = false;
+    private static volatile boolean flag = false;
+    private static final int threadCount = 100;
+    private static int seconds = 60 + 40;
+
+    public static void main(String[] args) throws Exception {
+
+        initAdaptiveRule();
+
+        Entry entry = null;
+        try {
+            entry = SphU.entry(KEY);
+        } catch (Exception e) {
+        } finally {
+            if (entry != null) {
+                entry.exit();
+            }
+        }
+
+        tick();
+        for(int i = 0; i < 3; i++) {
+                Thread t = new Thread(new StableTask());
+                t.setName("sentinel-stable-task");
+                t.start();
+        }
+        Thread.sleep(20000);
+
+        for (int i = 0; i < threadCount; i++) {
+            Thread t = new Thread(new RunTask1());
+            t.setName("sentinel-run-task1");
+            t.start();
+        }
+        Thread.sleep(40000);
+        for (int i = 0; i < threadCount; i++) {
+            Thread t = new Thread(new RunTask2());
+            t.setName("sentinel-run-task2");
+            t.start();
+        }
+    }
+
+    private static void initAdaptiveRule() {
+        List<AdaptiveRule> rules = new ArrayList<AdaptiveRule>();
+        AdaptiveRule rule = new AdaptiveRule();
+        rule.setResource(KEY);
+        rule.setCount(200);
+        rule.setMaxToken(2000);
+        rules.add(rule);
+        AdaptiveRuleManager.loadRules(rules);
+    }
+
+    static class StableTask implements Runnable {
+        @Override
+        public void run() {
+            while (!stop) {
+                Entry entry = null;
+                try {
+                    entry = SphU.entry(KEY);
+                    // token acquired, means pass
+                    pass.addAndGet(1);
+                } catch (BlockException e1) {
+                    block.incrementAndGet();
+                } catch (Exception e2) {
+                    // biz exception
+                } finally {
+                    total.incrementAndGet();
+                    if (entry != null) {
+                        entry.exit();
+                    }
+                }
+                Random random2 = new Random();
+                try {
+                    TimeUnit.MILLISECONDS.sleep(random2.nextInt(2000));
+                } catch (InterruptedException e) {
+                    // ignore
+                }
+            }
+        }
+    }
+
+    static class RunTask1 implements Runnable {
+        @Override
+        public void run() {
+            while (!stop1) {
+                Entry entry = null;
+                try {
+                    entry = SphU.entry(KEY);
+                    pass.addAndGet(1);
+                } catch (BlockException e1) {
+                    block.incrementAndGet();
+                } catch (Exception e2) {
+                    // biz exception
+                } finally {
+                    total.incrementAndGet();
+                    if (entry != null) {
+                        entry.exit();
+                    }
+                }
+                Random random2 = new Random();
+                try {
+                    TimeUnit.MILLISECONDS.sleep(random2.nextInt(50));
+                } catch (InterruptedException e) {
+                    // ignore
+                }
+            }
+        }
+    }
+
+    static class RunTask2 implements Runnable {
+        @Override
+        public void run() {
+            while (!stop2) {
+                Entry entry = null;
+                try {
+                    entry = SphU.entry(KEY);
+                    pass.addAndGet(1);
+                } catch (BlockException e1) {
+                    block.incrementAndGet();
+                } catch (Exception e2) {
+                    // biz exception
+                } finally {
+                    total.incrementAndGet();
+                    if (entry != null) {
+                        entry.exit();
+                    }
+                }
+                Random random2 = new Random();
+                try {
+                    TimeUnit.MILLISECONDS.sleep(random2.nextInt(50));
+                } catch (InterruptedException e) {
+                    // ignore
+                }
+            }
+        }
+    }
+
+    private static void tick() {
+        Thread timer = new Thread(new TimerTask());
+        timer.setName("sentinel-timer-task");
+        timer.start();
+    }
+
+    static class TimerTask implements Runnable {
+
+        @Override
+        public void run() {
+            long start = System.currentTimeMillis();
+            System.out.println("begin to statistic!!!");
+
+            long oldTotal = 0;
+            long oldPass = 0;
+            long oldBlock = 0;
+            while (!stop) {
+                try {
+                    TimeUnit.SECONDS.sleep(1);
+                } catch (InterruptedException e) {
+                }
+                long globalTotal = total.get();
+                long oneSecondTotal = globalTotal - oldTotal;
+                oldTotal = globalTotal;
+
+                long globalPass = pass.get();
+                long oneSecondPass = globalPass - oldPass;
+                oldPass = globalPass;
+
+                long globalBlock = block.get();
+                long oneSecondBlock = globalBlock - oldBlock;
+                oldBlock = globalBlock;
+
+                System.out.println(seconds + " send qps is: " + oneSecondTotal);
+                System.out.println(TimeUtil.currentTimeMillis() + ", total:" + oneSecondTotal
+                        + ", pass:" + oneSecondPass
+                        + ", block:" + oneSecondBlock);
+
+                if(seconds <= 70) {
+                    stop1 = true;
+                }
+                if(seconds <= 20) {
+                    stop2 = true;
+                }
+
+                if (seconds-- <= 0) {
+                    stop = true;
+                }
+            }
+
+            long cost = System.currentTimeMillis() - start;
+            System.out.println("time cost: " + cost + " ms");
+            System.out.println("total:" + total.get() + ", pass:" + pass.get()
+                    + ", block:" + block.get());
+            System.exit(0);
+        }
+    }
+}

--- a/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/adaptive/AdaptiveDemo.java
+++ b/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/adaptive/AdaptiveDemo.java
@@ -73,8 +73,9 @@ public class AdaptiveDemo {
         AdaptiveRule rule = new AdaptiveRule();
         rule.setResource(KEY);
         //rule.setCount(40000);
-        rule.setMaxToken(80000);
-        rule.setTargetRadio(0.5);
+        //rule.setMaxToken(80000);
+        rule.setTargetRatio(0.5);
+        rule.setExpectRt(0.5);
         rules.add(rule);
         AdaptiveRuleManager.loadRules(rules);
     }
@@ -128,7 +129,7 @@ public class AdaptiveDemo {
                 }
                 Random random2 = new Random();
                 try {
-                    TimeUnit.MILLISECONDS.sleep(random2.nextInt(1));
+                    TimeUnit.MILLISECONDS.sleep(random2.nextInt(2));
                 } catch (InterruptedException e) {
                     // ignore
                 }

--- a/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/adaptive/AdaptiveRateDemo.java
+++ b/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/adaptive/AdaptiveRateDemo.java
@@ -66,7 +66,7 @@ public class AdaptiveRateDemo {
          * CONTROL_BEHAVIOR_RATE_LIMITER means requests more than threshold will be queueing in the queue,
          * until the queueing time is more than {@link FlowRule#maxQueueingTimeMs}, the requests will be rejected.
          */
-        rule1.setExpectRt(20 * 1000);
+        rule1.setExpectRt(5 * 1000);
 
         rules.add(rule1);
         AdaptiveRuleManager.loadRules(rules);

--- a/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/adaptive/AdaptiveRateDemo.java
+++ b/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/adaptive/AdaptiveRateDemo.java
@@ -1,0 +1,126 @@
+package com.alibaba.csp.sentinel.demo.adaptive;
+
+import com.alibaba.csp.sentinel.Entry;
+import com.alibaba.csp.sentinel.SphU;
+import com.alibaba.csp.sentinel.slots.block.BlockException;
+import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+import com.alibaba.csp.sentinel.slots.block.adaptive.AdaptiveRule;
+import com.alibaba.csp.sentinel.slots.block.adaptive.AdaptiveRuleManager;
+import com.alibaba.csp.sentinel.slots.block.flow.FlowRule;
+import com.alibaba.csp.sentinel.slots.block.flow.FlowRuleManager;
+import com.alibaba.csp.sentinel.util.TimeUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author Liu Yiming
+ * @date 2019-07-28 20:34
+ */
+public class AdaptiveRateDemo {
+    private static final String KEY1 = "abc";
+    private static final String KEY2 = "def";
+
+    private static volatile CountDownLatch countDown;
+
+    private static final Integer requestQps = 100;
+    private static final Integer count = 10;
+    private static final AtomicInteger done = new AtomicInteger();
+    private static final AtomicInteger pass = new AtomicInteger();
+    private static final AtomicInteger block = new AtomicInteger();
+
+    public static void main(String[] args) throws InterruptedException {
+        System.out.println("pace behavior");
+        countDown = new CountDownLatch(1);
+        initAdaptiveRateRule();
+        simulatePulseFlow(KEY1);
+        countDown.await();
+
+        System.out.println("done");
+        System.out.println("total pass:" + pass.get() + ", total block:" + block.get());
+
+        System.out.println();
+        System.out.println("default behavior");
+        TimeUnit.SECONDS.sleep(5);
+        done.set(0);
+        pass.set(0);
+        block.set(0);
+        countDown = new CountDownLatch(1);
+        initDefaultFlowRule();
+        simulatePulseFlow(KEY2);
+        countDown.await();
+        System.out.println("done");
+        System.out.println("total pass:" + pass.get() + ", total block:" + block.get());
+        System.exit(0);
+    }
+
+    private static void initAdaptiveRateRule() {
+        List<AdaptiveRule> rules = new ArrayList<AdaptiveRule>();
+        AdaptiveRule rule1 = new AdaptiveRule();
+        rule1.setResource(KEY1);
+        //rule1.setCount(count);
+        /*
+         * CONTROL_BEHAVIOR_RATE_LIMITER means requests more than threshold will be queueing in the queue,
+         * until the queueing time is more than {@link FlowRule#maxQueueingTimeMs}, the requests will be rejected.
+         */
+        rule1.setExpectRt(20 * 1000);
+
+        rules.add(rule1);
+        AdaptiveRuleManager.loadRules(rules);
+    }
+
+    private static void initDefaultFlowRule() {
+        List<FlowRule> rules = new ArrayList<FlowRule>();
+        FlowRule rule1 = new FlowRule();
+        rule1.setResource(KEY2);
+        rule1.setCount(count);
+        rule1.setGrade(RuleConstant.FLOW_GRADE_QPS);
+        rule1.setLimitApp("default");
+        // CONTROL_BEHAVIOR_DEFAULT means requests more than threshold will be rejected immediately.
+        rule1.setControlBehavior(RuleConstant.CONTROL_BEHAVIOR_DEFAULT);
+
+        rules.add(rule1);
+        FlowRuleManager.loadRules(rules);
+    }
+
+    private static void simulatePulseFlow(String key) {
+        for (int i = 0; i < requestQps; i++) {
+            Thread thread = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    long startTime = TimeUtil.currentTimeMillis();
+                    Entry entry = null;
+                    try {
+                        entry = SphU.entry(key);
+                    } catch (BlockException e1) {
+                        block.incrementAndGet();
+                    } catch (Exception e2) {
+                        // biz exception
+                    } finally {
+                        if (entry != null) {
+                            entry.exit();
+                            pass.incrementAndGet();
+                            long cost = TimeUtil.currentTimeMillis() - startTime;
+                            System.out.println(
+                                    TimeUtil.currentTimeMillis() + " one request pass, cost " + cost + " ms");
+                        }
+                    }
+
+                    try {
+                        TimeUnit.MILLISECONDS.sleep(5);
+                    } catch (InterruptedException e1) {
+                        // ignore
+                    }
+
+                    if (done.incrementAndGet() >= requestQps) {
+                        countDown.countDown();
+                    }
+                }
+            }, "Thread " + i);
+            thread.start();
+        }
+    }
+}

--- a/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/adaptive/TokenBucketDemo.java
+++ b/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/adaptive/TokenBucketDemo.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @author Liu Yiming
  * @date 2019-07-17 14:31
  */
-public class AdaptiveDemo {
+public class TokenBucketDemo {
 
     private static final String KEY = "abc";
 

--- a/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/adaptive/TokenBucketDemo.java
+++ b/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/adaptive/TokenBucketDemo.java
@@ -3,6 +3,7 @@ package com.alibaba.csp.sentinel.demo.adaptive;
 import com.alibaba.csp.sentinel.Entry;
 import com.alibaba.csp.sentinel.SphU;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
+import com.alibaba.csp.sentinel.slots.block.RuleConstant;
 import com.alibaba.csp.sentinel.slots.block.adaptive.AdaptiveRule;
 import com.alibaba.csp.sentinel.slots.block.adaptive.AdaptiveRuleManager;
 import com.alibaba.csp.sentinel.util.TimeUtil;
@@ -28,8 +29,6 @@ public class TokenBucketDemo {
     private static volatile boolean stop = false;
     private static volatile boolean stop1 = false;
     private static volatile boolean stop2 = false;
-    private static volatile boolean start2 = false;
-    private static volatile boolean flag = false;
     private static final int threadCount = 100;
     private static int seconds = 60 + 40;
 
@@ -72,10 +71,9 @@ public class TokenBucketDemo {
         List<AdaptiveRule> rules = new ArrayList<AdaptiveRule>();
         AdaptiveRule rule = new AdaptiveRule();
         rule.setResource(KEY);
-        //rule.setCount(40000);
-        //rule.setMaxToken(80000);
         rule.setTargetRatio(0.5);
         rule.setExpectRt(0.5);
+        //rule.setGrade(RuleConstant.FLOW_ADAPTIVE_PID);
         rules.add(rule);
         AdaptiveRuleManager.loadRules(rules);
     }


### PR DESCRIPTION

### Describe what this PR does / why we need it
Nowadays users have to manually set the complex flow control rules for flow control. It is required for users to have a better understanding of Sentinel's flow control rules. It would be better if we can introduce intelligent mechanisms to do adaptive flow control automatically based on real-time metrics. Not only can the new mechanisms simplify users operations, but it can also make flow control smarter and adjust more quickly.

### Does this pull request fix one issue?
Fixes #748 

### Describe how you did it
#### User peak
The scene of user peak should not have long delay. Therefore the algorithm for user peak is based on the method of token bucket. 

The adjustion of the token issuance speed refers to:
* The pass ratio which user expect to achieve;
* The RT which user expect to less than(`expectRt`);
* The CPU utilization.

The capacity of token bucket  is adjusted according to the maximum requests and the token issuance rate.

#### Callback peak
The scene of callback peak can have the delay longer. The algorithm is based on the rate limiter which implemented by Sentinel's `RateLimiterController`.

The adjustion of the flow rate refers to:
* The number of timeout requests;
* The CPU utilization.

#### PID control
This method is more suitable for user peak. And the adjustion of PID controller is also based on the token bucket. Users can try this algorithm by `rule.setGrade(RuleConstant.FLOW_ADAPTIVE_PID);`.

We use incremental PID controller to calculate the change of CPU utilization. Our goal is to keep the CPU utilization at a certain value. 

### Describe how to verify it
When it comes to the scene of user peak , see `TokenBucketDemo`;
When it comes to the scene of callback peak, see `AdaptiveRateDemo`.

### Special notes for reviews
