### PR TITLE
[sentinal-1039] the multidimensional statistics should based on same …

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/ClusterNode.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/ClusterNode.java
@@ -99,7 +99,7 @@ public class ClusterNode extends StatisticNode {
             return;
         }
         if (!BlockException.isBlockException(throwable)) {
-            this.increaseExceptionQps(count);
+            this.increaseExceptionQps(0,count);
         }
     }
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/DefaultNode.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/DefaultNode.java
@@ -107,15 +107,15 @@ public class DefaultNode extends StatisticNode {
     }
 
     @Override
-    public void increaseBlockQps(int count) {
-        super.increaseBlockQps(count);
-        this.clusterNode.increaseBlockQps(count);
+    public void increaseBlockQps(long rt, int count) {
+        super.increaseBlockQps(rt,count);
+        this.clusterNode.increaseBlockQps(rt,count);
     }
 
     @Override
-    public void increaseExceptionQps(int count) {
-        super.increaseExceptionQps(count);
-        this.clusterNode.increaseExceptionQps(count);
+    public void increaseExceptionQps(long rt, int count) {
+        super.increaseExceptionQps(rt,count);
+        this.clusterNode.increaseExceptionQps(rt,count);
     }
 
     @Override

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/DefaultNode.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/DefaultNode.java
@@ -15,15 +15,15 @@
  */
 package com.alibaba.csp.sentinel.node;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import com.alibaba.csp.sentinel.log.RecordLog;
 import com.alibaba.csp.sentinel.SphO;
 import com.alibaba.csp.sentinel.SphU;
 import com.alibaba.csp.sentinel.context.Context;
+import com.alibaba.csp.sentinel.log.RecordLog;
 import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
 import com.alibaba.csp.sentinel.slots.nodeselector.NodeSelectorSlot;
+
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * <p>
@@ -119,9 +119,15 @@ public class DefaultNode extends StatisticNode {
     }
 
     @Override
-    public void addRtAndSuccess(long rt, int successCount) {
-        super.addRtAndSuccess(rt, successCount);
-        this.clusterNode.addRtAndSuccess(rt, successCount);
+    public void addRtAndSuccessInSecond(long rt, int successCount) {
+        super.addRtAndSuccessInSecond(rt, successCount);
+        this.clusterNode.addRtAndSuccessInSecond(rt, successCount);
+    }
+
+    @Override
+    public void addRtAndSuccessInMinute(long rt, int success) {
+        super.addRtAndSuccessInSecond(rt, success);
+        this.clusterNode.addRtAndSuccessInSecond(rt, success);
     }
 
     @Override

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/Node.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/Node.java
@@ -164,16 +164,18 @@ public interface Node extends OccupySupport, DebugSupport {
     /**
      * Increase the block count.
      *
+     * @param rt Current timestamp, calculated based on this
      * @param count count to add
      */
-    void increaseBlockQps(int count);
+    void increaseBlockQps(long rt, int count);
 
     /**
      * Add the biz exception count.
      *
+     * @param rt Current timestamp, calculated based on this
      * @param count count to add
      */
-    void increaseExceptionQps(int count);
+    void increaseExceptionQps(long rt, int count);
 
     /**
      * Increase current thread count.

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/Node.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/Node.java
@@ -15,11 +15,11 @@
  */
 package com.alibaba.csp.sentinel.node;
 
-import java.util.Map;
-
 import com.alibaba.csp.sentinel.Entry;
 import com.alibaba.csp.sentinel.node.metric.MetricNode;
 import com.alibaba.csp.sentinel.slots.statistic.metric.DebugSupport;
+
+import java.util.Map;
 
 /**
  * Holds real-time statistics for resources.
@@ -154,12 +154,20 @@ public interface Node extends OccupySupport, DebugSupport {
     void addPassRequest(int count);
 
     /**
-     * Add rt and success count.
+     * Add rt and success count. (counting in second)
      *
      * @param rt      response time
      * @param success success count to add
      */
-    void addRtAndSuccess(long rt, int success);
+    void addRtAndSuccessInSecond(long rt, int success);
+
+    /**
+     * Add rt and success count. (counting in second)
+     *
+     * @param rt      response time
+     * @param success success count to add
+     */
+    void addRtAndSuccessInMinute(long rt,int success);
 
     /**
      * Increase the block count.

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/StatisticNode.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/StatisticNode.java
@@ -251,13 +251,13 @@ public class StatisticNode implements Node {
     }
 
     @Override
-    public void increaseBlockQps(int count) {
+    public void increaseBlockQps(long rt, int count) {
         rollingCounterInSecond.addBlock(count);
         rollingCounterInMinute.addBlock(count);
     }
 
     @Override
-    public void increaseExceptionQps(int count) {
+    public void increaseExceptionQps(long rt, int count) {
         rollingCounterInSecond.addException(count);
         rollingCounterInMinute.addException(count);
     }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/StatisticNode.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/StatisticNode.java
@@ -242,11 +242,14 @@ public class StatisticNode implements Node {
     }
 
     @Override
-    public void addRtAndSuccess(long rt, int successCount) {
+    public void addRtAndSuccessInSecond(long rt, int successCount) {
         rollingCounterInSecond.addSuccess(successCount);
         rollingCounterInSecond.addRT(rt);
+    }
 
-        rollingCounterInMinute.addSuccess(successCount);
+    @Override
+    public void addRtAndSuccessInMinute(long rt, int success) {
+        rollingCounterInMinute.addSuccess(success);
         rollingCounterInMinute.addRT(rt);
     }
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/StatisticSlot.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/StatisticSlot.java
@@ -51,6 +51,7 @@ public class StatisticSlot extends AbstractLinkedProcessorSlot<DefaultNode> {
     @Override
     public void entry(Context context, ResourceWrapper resourceWrapper, DefaultNode node, int count,
                       boolean prioritized, Object... args) throws Throwable {
+        long rt = TimeUtil.currentTimeMillis() - context.getCurEntry().getCreateTime();
         try {
             // Do some checking.
             fireEntry(context, resourceWrapper, node, count, prioritized, args);
@@ -97,12 +98,12 @@ public class StatisticSlot extends AbstractLinkedProcessorSlot<DefaultNode> {
             // Add block count.
             node.increaseBlockQps(count);
             if (context.getCurEntry().getOriginNode() != null) {
-                context.getCurEntry().getOriginNode().increaseBlockQps(count);
+                context.getCurEntry().getOriginNode().increaseBlockQps(rt,count);
             }
 
             if (resourceWrapper.getType() == EntryType.IN) {
                 // Add count for global inbound entry node for global statistics.
-                Constants.ENTRY_NODE.increaseBlockQps(count);
+                Constants.ENTRY_NODE.increaseBlockQps(rt,count);
             }
 
             // Handle block event with registered entry callback handlers.
@@ -118,11 +119,11 @@ public class StatisticSlot extends AbstractLinkedProcessorSlot<DefaultNode> {
             // This should not happen.
             node.increaseExceptionQps(count);
             if (context.getCurEntry().getOriginNode() != null) {
-                context.getCurEntry().getOriginNode().increaseExceptionQps(count);
+                context.getCurEntry().getOriginNode().increaseExceptionQps(rt,count);
             }
 
             if (resourceWrapper.getType() == EntryType.IN) {
-                Constants.ENTRY_NODE.increaseExceptionQps(count);
+                Constants.ENTRY_NODE.increaseExceptionQps(rt,count);
             }
             throw e;
         }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/StatisticSlot.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/StatisticSlot.java
@@ -15,20 +15,20 @@
  */
 package com.alibaba.csp.sentinel.slots.statistic;
 
-import java.util.Collection;
-
-import com.alibaba.csp.sentinel.slotchain.ProcessorSlotEntryCallback;
-import com.alibaba.csp.sentinel.slotchain.ProcessorSlotExitCallback;
-import com.alibaba.csp.sentinel.slots.block.flow.PriorityWaitException;
-import com.alibaba.csp.sentinel.util.TimeUtil;
 import com.alibaba.csp.sentinel.Constants;
 import com.alibaba.csp.sentinel.EntryType;
 import com.alibaba.csp.sentinel.context.Context;
 import com.alibaba.csp.sentinel.node.ClusterNode;
 import com.alibaba.csp.sentinel.node.DefaultNode;
 import com.alibaba.csp.sentinel.slotchain.AbstractLinkedProcessorSlot;
+import com.alibaba.csp.sentinel.slotchain.ProcessorSlotEntryCallback;
+import com.alibaba.csp.sentinel.slotchain.ProcessorSlotExitCallback;
 import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
+import com.alibaba.csp.sentinel.slots.block.flow.PriorityWaitException;
+import com.alibaba.csp.sentinel.util.TimeUtil;
+
+import java.util.Collection;
 
 /**
  * <p>
@@ -141,9 +141,9 @@ public class StatisticSlot extends AbstractLinkedProcessorSlot<DefaultNode> {
             }
 
             // Record response time and success count.
-            node.addRtAndSuccess(rt, count);
+            node.addRtAndSuccessInSecond(rt, count);
             if (context.getCurEntry().getOriginNode() != null) {
-                context.getCurEntry().getOriginNode().addRtAndSuccess(rt, count);
+                context.getCurEntry().getOriginNode().addRtAndSuccessInMinute(rt, count);
             }
 
             node.decreaseThreadNum();
@@ -153,7 +153,7 @@ public class StatisticSlot extends AbstractLinkedProcessorSlot<DefaultNode> {
             }
 
             if (resourceWrapper.getType() == EntryType.IN) {
-                Constants.ENTRY_NODE.addRtAndSuccess(rt, count);
+                Constants.ENTRY_NODE.addRtAndSuccessInMinute(rt, count);
                 Constants.ENTRY_NODE.decreaseThreadNum();
             }
         } else {

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/StatisticSlot.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/StatisticSlot.java
@@ -96,7 +96,7 @@ public class StatisticSlot extends AbstractLinkedProcessorSlot<DefaultNode> {
             context.getCurEntry().setError(e);
 
             // Add block count.
-            node.increaseBlockQps(count);
+            node.increaseBlockQps(rt,count);
             if (context.getCurEntry().getOriginNode() != null) {
                 context.getCurEntry().getOriginNode().increaseBlockQps(rt,count);
             }
@@ -117,7 +117,7 @@ public class StatisticSlot extends AbstractLinkedProcessorSlot<DefaultNode> {
             context.getCurEntry().setError(e);
 
             // This should not happen.
-            node.increaseExceptionQps(count);
+            node.increaseExceptionQps(rt,count);
             if (context.getCurEntry().getOriginNode() != null) {
                 context.getCurEntry().getOriginNode().increaseExceptionQps(rt,count);
             }

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/node/StatisticNodeTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/node/StatisticNodeTest.java
@@ -15,10 +15,11 @@
  */
 package com.alibaba.csp.sentinel.node;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.alibaba.csp.sentinel.Constants;
 import com.alibaba.csp.sentinel.util.TimeUtil;
-import org.junit.Assert;
-import org.junit.Test;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -35,8 +36,8 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Test cases for {@link StatisticNode}.
@@ -143,7 +144,7 @@ public class StatisticNodeTest {
                 assertTrue(node.curThreadNum() < THREAD_COUNT);
 
                 long rt = TimeUtil.currentTimeMillis() - startTime;
-                node.addRtAndSuccess(rt, 1);
+                //node.addRtAndSuccess(rt, 1);
 
                 // wait random 0.5 second for simulate method call interval,
                 // otherwise the curThreadNum will always be THREAD_COUNT at the beginning


### PR DESCRIPTION
the multidimensional statistics should based on same time stamp

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
The request mentioned in #1040  is very close to the next second or high in the last second. I think rt should be monitored for each request when the status is changed.

### Describe how to verify it


### Special notes for reviews

the multidimensional statistics should based on same time stamp,the issue is #1039 
