### PR TITLE
Improve the ACL checking mechanism of Sentinel dashboard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
     <properties>
         <!-- Compile libs -->
-        <fastjson.version>1.2.58</fastjson.version>
+        <fastjson.version>1.2.60</fastjson.version>
 
         <!-- Test libs -->
         <junit.version>4.12</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
     <properties>
         <!-- Compile libs -->
-        <fastjson.version>1.2.60</fastjson.version>
+        <fastjson.version>1.2.58</fastjson.version>
 
         <!-- Test libs -->
         <junit.version>4.12</junit.version>

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/auth/AuthAction.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/auth/AuthAction.java
@@ -1,0 +1,19 @@
+package com.alibaba.csp.sentinel.dashboard.auth;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Target({ElementType.METHOD})
+public @interface AuthAction {
+
+    AuthService.PrivilegeType value();
+
+    String targetName() default "app";
+
+    String message() default "No privilege";
+}

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/auth/AuthAction.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/auth/AuthAction.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.csp.sentinel.dashboard.auth;
 
 import java.lang.annotation.Documented;

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/auth/AuthInterceptor.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/auth/AuthInterceptor.java
@@ -1,0 +1,51 @@
+package com.alibaba.csp.sentinel.dashboard.auth;
+
+import com.alibaba.csp.sentinel.dashboard.domain.Result;
+import com.alibaba.fastjson.JSON;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.lang.reflect.Method;
+
+@Component
+public class AuthInterceptor implements HandlerInterceptor {
+
+    @Autowired
+    private AuthService<HttpServletRequest> authService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws Exception {
+        if (handler.getClass().isAssignableFrom(HandlerMethod.class)) {
+            Method method = ((HandlerMethod) handler).getMethod();
+
+            AuthAction authAction = method.getAnnotation(AuthAction.class);
+            if (authAction != null) {
+                AuthService.AuthUser authUser = authService.getAuthUser(request);
+                if (authUser == null) {
+                    responseNoPrivilegeMsg(response, authAction.message());
+                    return false;
+                }
+                String target = request.getParameter(authAction.targetName());
+
+                if (authUser.authTarget(target, authAction.value())) {
+                    responseNoPrivilegeMsg(response, authAction.message());
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private void responseNoPrivilegeMsg(HttpServletResponse response, String message) throws IOException {
+        Result result = Result.ofFail(-1, message);
+        response.addHeader("Content-Type", "application/json;charset=UTF-8");
+        response.getOutputStream().write(JSON.toJSONBytes(result));
+    }
+}

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/auth/AuthInterceptor.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/auth/AuthInterceptor.java
@@ -33,7 +33,7 @@ public class AuthInterceptor implements HandlerInterceptor {
                 }
                 String target = request.getParameter(authAction.targetName());
 
-                if (authUser.authTarget(target, authAction.value())) {
+                if (!authUser.authTarget(target, authAction.value())) {
                     responseNoPrivilegeMsg(response, authAction.message());
                     return false;
                 }

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/auth/AuthInterceptor.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/auth/AuthInterceptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.csp.sentinel.dashboard.auth;
 
 import com.alibaba.csp.sentinel.dashboard.domain.Result;

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/config/WebConfig.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/config/WebConfig.java
@@ -16,6 +16,7 @@
 package com.alibaba.csp.sentinel.dashboard.config;
 
 import com.alibaba.csp.sentinel.adapter.servlet.CommonFilter;
+import com.alibaba.csp.sentinel.dashboard.auth.AuthInterceptor;
 import com.alibaba.csp.sentinel.dashboard.filter.AuthFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -39,6 +41,14 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Autowired
     private AuthFilter authFilter;
+
+    @Autowired
+    private AuthInterceptor authInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor).addPathPatterns("/**");
+    }
 
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/AuthorityRuleController.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/AuthorityRuleController.java
@@ -69,7 +69,9 @@ public class AuthorityRuleController {
                                                                         @RequestParam String ip,
                                                                         @RequestParam Integer port) {
         AuthUser authUser = authService.getAuthUser(request);
-        authUser.authTarget(app, PrivilegeType.READ_RULE);
+        if (!authUser.authTarget(app, PrivilegeType.READ_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
         if (StringUtil.isEmpty(app)) {
             return Result.ofFail(-1, "app cannot be null or empty");
         }
@@ -122,7 +124,9 @@ public class AuthorityRuleController {
     public Result<AuthorityRuleEntity> apiAddAuthorityRule(HttpServletRequest request,
                                                            @RequestBody AuthorityRuleEntity entity) {
         AuthUser authUser = authService.getAuthUser(request);
-        authUser.authTarget(entity.getApp(), PrivilegeType.WRITE_RULE);
+        if (!authUser.authTarget(entity.getApp(), PrivilegeType.WRITE_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
         Result<AuthorityRuleEntity> checkResult = checkEntityInternal(entity);
         if (checkResult != null) {
             return checkResult;
@@ -148,7 +152,9 @@ public class AuthorityRuleController {
                                                               @PathVariable("id") Long id,
                                                               @RequestBody AuthorityRuleEntity entity) {
         AuthUser authUser = authService.getAuthUser(request);
-        authUser.authTarget(entity.getApp(), PrivilegeType.WRITE_RULE);
+        if (!authUser.authTarget(entity.getApp(), PrivilegeType.WRITE_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
         if (id == null || id <= 0) {
             return Result.ofFail(-1, "Invalid id");
         }
@@ -185,7 +191,9 @@ public class AuthorityRuleController {
         if (oldEntity == null) {
             return Result.ofSuccess(null);
         }
-        authUser.authTarget(oldEntity.getApp(), PrivilegeType.DELETE_RULE);
+        if (!authUser.authTarget(oldEntity.getApp(), PrivilegeType.DELETE_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
         try {
             repository.delete(id);
         } catch (Exception e) {

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/AuthorityRuleController.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/AuthorityRuleController.java
@@ -18,12 +18,9 @@ package com.alibaba.csp.sentinel.dashboard.controller;
 import java.util.Date;
 import java.util.List;
 
-import javax.servlet.http.HttpServletRequest;
-
+import com.alibaba.csp.sentinel.dashboard.auth.AuthAction;
 import com.alibaba.csp.sentinel.dashboard.client.SentinelApiClient;
 import com.alibaba.csp.sentinel.dashboard.discovery.MachineInfo;
-import com.alibaba.csp.sentinel.dashboard.auth.AuthService;
-import com.alibaba.csp.sentinel.dashboard.auth.AuthService.AuthUser;
 import com.alibaba.csp.sentinel.dashboard.auth.AuthService.PrivilegeType;
 import com.alibaba.csp.sentinel.slots.block.RuleConstant;
 import com.alibaba.csp.sentinel.util.StringUtil;
@@ -60,18 +57,11 @@ public class AuthorityRuleController {
     @Autowired
     private RuleRepository<AuthorityRuleEntity, Long> repository;
 
-    @Autowired
-    private AuthService<HttpServletRequest> authService;
-
     @GetMapping("/rules")
-    public Result<List<AuthorityRuleEntity>> apiQueryAllRulesForMachine(HttpServletRequest request,
-                                                                        @RequestParam String app,
+    @AuthAction(PrivilegeType.READ_RULE)
+    public Result<List<AuthorityRuleEntity>> apiQueryAllRulesForMachine(@RequestParam String app,
                                                                         @RequestParam String ip,
                                                                         @RequestParam Integer port) {
-        AuthUser authUser = authService.getAuthUser(request);
-        if (!authUser.authTarget(app, PrivilegeType.READ_RULE)) {
-            return Result.ofFail(-1, "no privilege");
-        }
         if (StringUtil.isEmpty(app)) {
             return Result.ofFail(-1, "app cannot be null or empty");
         }
@@ -121,12 +111,8 @@ public class AuthorityRuleController {
     }
 
     @PostMapping("/rule")
-    public Result<AuthorityRuleEntity> apiAddAuthorityRule(HttpServletRequest request,
-                                                           @RequestBody AuthorityRuleEntity entity) {
-        AuthUser authUser = authService.getAuthUser(request);
-        if (!authUser.authTarget(entity.getApp(), PrivilegeType.WRITE_RULE)) {
-            return Result.ofFail(-1, "no privilege");
-        }
+    @AuthAction(PrivilegeType.WRITE_RULE)
+    public Result<AuthorityRuleEntity> apiAddAuthorityRule(@RequestBody AuthorityRuleEntity entity) {
         Result<AuthorityRuleEntity> checkResult = checkEntityInternal(entity);
         if (checkResult != null) {
             return checkResult;
@@ -148,13 +134,9 @@ public class AuthorityRuleController {
     }
 
     @PutMapping("/rule/{id}")
-    public Result<AuthorityRuleEntity> apiUpdateParamFlowRule(HttpServletRequest request,
-                                                              @PathVariable("id") Long id,
+    @AuthAction(PrivilegeType.WRITE_RULE)
+    public Result<AuthorityRuleEntity> apiUpdateParamFlowRule(@PathVariable("id") Long id,
                                                               @RequestBody AuthorityRuleEntity entity) {
-        AuthUser authUser = authService.getAuthUser(request);
-        if (!authUser.authTarget(entity.getApp(), PrivilegeType.WRITE_RULE)) {
-            return Result.ofFail(-1, "no privilege");
-        }
         if (id == null || id <= 0) {
             return Result.ofFail(-1, "Invalid id");
         }
@@ -182,17 +164,14 @@ public class AuthorityRuleController {
     }
 
     @DeleteMapping("/rule/{id}")
-    public Result<Long> apiDeleteRule(HttpServletRequest request, @PathVariable("id") Long id) {
-        AuthUser authUser = authService.getAuthUser(request);
+    @AuthAction(PrivilegeType.DELETE_RULE)
+    public Result<Long> apiDeleteRule(@PathVariable("id") Long id) {
         if (id == null) {
             return Result.ofFail(-1, "id cannot be null");
         }
         AuthorityRuleEntity oldEntity = repository.findById(id);
         if (oldEntity == null) {
             return Result.ofSuccess(null);
-        }
-        if (!authUser.authTarget(oldEntity.getApp(), PrivilegeType.DELETE_RULE)) {
-            return Result.ofFail(-1, "no privilege");
         }
         try {
             repository.delete(id);

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/DegradeController.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/DegradeController.java
@@ -61,7 +61,9 @@ public class DegradeController {
     @RequestMapping("/rules.json")
     public Result<List<DegradeRuleEntity>> queryMachineRules(HttpServletRequest request, String app, String ip, Integer port) {
         AuthUser authUser = authService.getAuthUser(request);
-        authUser.authTarget(app, PrivilegeType.READ_RULE);
+        if (!authUser.authTarget(app, PrivilegeType.READ_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
 
         if (StringUtil.isEmpty(app)) {
             return Result.ofFail(-1, "app can't be null or empty");
@@ -88,7 +90,9 @@ public class DegradeController {
                                          String app, String ip, Integer port, String limitApp, String resource,
                                          Double count, Integer timeWindow, Integer grade) {
         AuthUser authUser = authService.getAuthUser(request);
-        authUser.authTarget(app, PrivilegeType.WRITE_RULE);
+        if (!authUser.authTarget(app, PrivilegeType.WRITE_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
 
         if (StringUtil.isBlank(app)) {
             return Result.ofFail(-1, "app can't be null or empty");
@@ -159,7 +163,9 @@ public class DegradeController {
         if (entity == null) {
             return Result.ofFail(-1, "id " + id + " dose not exist");
         }
-        authUser.authTarget(entity.getApp(), PrivilegeType.WRITE_RULE);
+        if (!authUser.authTarget(entity.getApp(), PrivilegeType.WRITE_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
         if (StringUtil.isNotBlank(app)) {
             entity.setApp(app.trim());
         }
@@ -205,7 +211,9 @@ public class DegradeController {
         if (oldEntity == null) {
             return Result.ofSuccess(null);
         }
-        authUser.authTarget(oldEntity.getApp(), PrivilegeType.DELETE_RULE);
+        if (!authUser.authTarget(oldEntity.getApp(), PrivilegeType.DELETE_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
         try {
             repository.delete(id);
         } catch (Throwable throwable) {

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/FlowControllerV1.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/FlowControllerV1.java
@@ -69,7 +69,9 @@ public class FlowControllerV1 {
                                                              @RequestParam String ip,
                                                              @RequestParam Integer port) {
         AuthUser authUser = authService.getAuthUser(request);
-        authUser.authTarget(app, PrivilegeType.READ_RULE);
+        if (!authUser.authTarget(app, PrivilegeType.READ_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
 
         if (StringUtil.isEmpty(app)) {
             return Result.ofFail(-1, "app can't be null or empty");
@@ -140,7 +142,9 @@ public class FlowControllerV1 {
     @PostMapping("/rule")
     public Result<FlowRuleEntity> apiAddFlowRule(HttpServletRequest request, @RequestBody FlowRuleEntity entity) {
         AuthUser authUser = authService.getAuthUser(request);
-        authUser.authTarget(entity.getApp(), PrivilegeType.WRITE_RULE);
+        if (!authUser.authTarget(entity.getApp(), PrivilegeType.WRITE_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
 
         Result<FlowRuleEntity> checkResult = checkEntityInternal(entity);
         if (checkResult != null) {
@@ -171,7 +175,9 @@ public class FlowControllerV1 {
                                                   Integer controlBehavior, Integer warmUpPeriodSec,
                                                   Integer maxQueueingTimeMs) {
         AuthUser authUser = authService.getAuthUser(request);
-        authUser.authTarget(app, PrivilegeType.WRITE_RULE);
+        if (!authUser.authTarget(app, PrivilegeType.WRITE_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
 
         if (id == null) {
             return Result.ofFail(-1, "id can't be null");
@@ -255,7 +261,9 @@ public class FlowControllerV1 {
         if (oldEntity == null) {
             return Result.ofSuccess(null);
         }
-        authUser.authTarget(oldEntity.getApp(), PrivilegeType.DELETE_RULE);
+        if (!authUser.authTarget(oldEntity.getApp(), PrivilegeType.DELETE_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
         try {
             repository.delete(id);
         } catch (Exception e) {

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/ParamFlowRuleController.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/ParamFlowRuleController.java
@@ -91,7 +91,9 @@ public class ParamFlowRuleController {
                                                                         @RequestParam String ip,
                                                                         @RequestParam Integer port) {
         AuthUser authUser = authService.getAuthUser(request);
-        authUser.authTarget(app, PrivilegeType.READ_RULE);
+        if (!authUser.authTarget(app, PrivilegeType.READ_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
         if (StringUtil.isEmpty(app)) {
             return Result.ofFail(-1, "app cannot be null or empty");
         }
@@ -130,7 +132,9 @@ public class ParamFlowRuleController {
     public Result<ParamFlowRuleEntity> apiAddParamFlowRule(HttpServletRequest request,
                                                            @RequestBody ParamFlowRuleEntity entity) {
         AuthUser authUser = authService.getAuthUser(request);
-        authUser.authTarget(entity.getApp(), PrivilegeType.WRITE_RULE);
+        if (!authUser.authTarget(entity.getApp(), PrivilegeType.WRITE_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
         Result<ParamFlowRuleEntity> checkResult = checkEntityInternal(entity);
         if (checkResult != null) {
             return checkResult;
@@ -209,7 +213,9 @@ public class ParamFlowRuleController {
         if (oldEntity == null) {
             return Result.ofFail(-1, "id " + id + " does not exist");
         }
-        authUser.authTarget(oldEntity.getApp(), PrivilegeType.WRITE_RULE);
+        if (!authUser.authTarget(oldEntity.getApp(), PrivilegeType.WRITE_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
         Result<ParamFlowRuleEntity> checkResult = checkEntityInternal(entity);
         if (checkResult != null) {
             return checkResult;
@@ -248,7 +254,9 @@ public class ParamFlowRuleController {
         if (oldEntity == null) {
             return Result.ofSuccess(null);
         }
-        authUser.authTarget(oldEntity.getApp(), PrivilegeType.DELETE_RULE);
+        if (!authUser.authTarget(oldEntity.getApp(), PrivilegeType.DELETE_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
         try {
             repository.delete(id);
             publishRules(oldEntity.getApp(), oldEntity.getIp(), oldEntity.getPort()).get();

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/ParamFlowRuleController.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/ParamFlowRuleController.java
@@ -21,18 +21,15 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
-import javax.servlet.http.HttpServletRequest;
-
+import com.alibaba.csp.sentinel.dashboard.auth.AuthAction;
 import com.alibaba.csp.sentinel.dashboard.client.CommandNotFoundException;
 import com.alibaba.csp.sentinel.dashboard.client.SentinelApiClient;
 import com.alibaba.csp.sentinel.dashboard.discovery.AppManagement;
 import com.alibaba.csp.sentinel.dashboard.discovery.MachineInfo;
 import com.alibaba.csp.sentinel.dashboard.auth.AuthService;
-import com.alibaba.csp.sentinel.dashboard.auth.AuthService.AuthUser;
 import com.alibaba.csp.sentinel.dashboard.auth.AuthService.PrivilegeType;
 import com.alibaba.csp.sentinel.slots.block.RuleConstant;
 import com.alibaba.csp.sentinel.util.StringUtil;
-
 import com.alibaba.csp.sentinel.dashboard.datasource.entity.SentinelVersion;
 import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.ParamFlowRuleEntity;
 import com.alibaba.csp.sentinel.dashboard.domain.Result;
@@ -69,9 +66,6 @@ public class ParamFlowRuleController {
     @Autowired
     private RuleRepository<ParamFlowRuleEntity, Long> repository;
 
-    @Autowired
-    private AuthService<HttpServletRequest> authService;
-
     private boolean checkIfSupported(String app, String ip, int port) {
         try {
             return Optional.ofNullable(appManagement.getDetailApp(app))
@@ -86,14 +80,10 @@ public class ParamFlowRuleController {
     }
 
     @GetMapping("/rules")
-    public Result<List<ParamFlowRuleEntity>> apiQueryAllRulesForMachine(HttpServletRequest request,
-                                                                        @RequestParam String app,
+    @AuthAction(PrivilegeType.READ_RULE)
+    public Result<List<ParamFlowRuleEntity>> apiQueryAllRulesForMachine(@RequestParam String app,
                                                                         @RequestParam String ip,
                                                                         @RequestParam Integer port) {
-        AuthUser authUser = authService.getAuthUser(request);
-        if (!authUser.authTarget(app, PrivilegeType.READ_RULE)) {
-            return Result.ofFail(-1, "no privilege");
-        }
         if (StringUtil.isEmpty(app)) {
             return Result.ofFail(-1, "app cannot be null or empty");
         }
@@ -129,12 +119,8 @@ public class ParamFlowRuleController {
     }
 
     @PostMapping("/rule")
-    public Result<ParamFlowRuleEntity> apiAddParamFlowRule(HttpServletRequest request,
-                                                           @RequestBody ParamFlowRuleEntity entity) {
-        AuthUser authUser = authService.getAuthUser(request);
-        if (!authUser.authTarget(entity.getApp(), PrivilegeType.WRITE_RULE)) {
-            return Result.ofFail(-1, "no privilege");
-        }
+    @AuthAction(AuthService.PrivilegeType.WRITE_RULE)
+    public Result<ParamFlowRuleEntity> apiAddParamFlowRule(@RequestBody ParamFlowRuleEntity entity) {
         Result<ParamFlowRuleEntity> checkResult = checkEntityInternal(entity);
         if (checkResult != null) {
             return checkResult;
@@ -202,10 +188,9 @@ public class ParamFlowRuleController {
     }
 
     @PutMapping("/rule/{id}")
-    public Result<ParamFlowRuleEntity> apiUpdateParamFlowRule(HttpServletRequest request,
-                                                              @PathVariable("id") Long id,
+    @AuthAction(AuthService.PrivilegeType.WRITE_RULE)
+    public Result<ParamFlowRuleEntity> apiUpdateParamFlowRule(@PathVariable("id") Long id,
                                                               @RequestBody ParamFlowRuleEntity entity) {
-        AuthUser authUser = authService.getAuthUser(request);
         if (id == null || id <= 0) {
             return Result.ofFail(-1, "Invalid id");
         }
@@ -213,9 +198,7 @@ public class ParamFlowRuleController {
         if (oldEntity == null) {
             return Result.ofFail(-1, "id " + id + " does not exist");
         }
-        if (!authUser.authTarget(oldEntity.getApp(), PrivilegeType.WRITE_RULE)) {
-            return Result.ofFail(-1, "no privilege");
-        }
+
         Result<ParamFlowRuleEntity> checkResult = checkEntityInternal(entity);
         if (checkResult != null) {
             return checkResult;
@@ -245,8 +228,8 @@ public class ParamFlowRuleController {
     }
 
     @DeleteMapping("/rule/{id}")
-    public Result<Long> apiDeleteRule(HttpServletRequest request, @PathVariable("id") Long id) {
-        AuthUser authUser = authService.getAuthUser(request);
+    @AuthAction(PrivilegeType.DELETE_RULE)
+    public Result<Long> apiDeleteRule(@PathVariable("id") Long id) {
         if (id == null) {
             return Result.ofFail(-1, "id cannot be null");
         }
@@ -254,9 +237,7 @@ public class ParamFlowRuleController {
         if (oldEntity == null) {
             return Result.ofSuccess(null);
         }
-        if (!authUser.authTarget(oldEntity.getApp(), PrivilegeType.DELETE_RULE)) {
-            return Result.ofFail(-1, "no privilege");
-        }
+
         try {
             repository.delete(id);
             publishRules(oldEntity.getApp(), oldEntity.getIp(), oldEntity.getPort()).get();

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/SystemController.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/SystemController.java
@@ -18,10 +18,7 @@ package com.alibaba.csp.sentinel.dashboard.controller;
 import java.util.Date;
 import java.util.List;
 
-import javax.servlet.http.HttpServletRequest;
-
-import com.alibaba.csp.sentinel.dashboard.auth.AuthService;
-import com.alibaba.csp.sentinel.dashboard.auth.AuthService.AuthUser;
+import com.alibaba.csp.sentinel.dashboard.auth.AuthAction;
 import com.alibaba.csp.sentinel.dashboard.auth.AuthService.PrivilegeType;
 import com.alibaba.csp.sentinel.dashboard.repository.rule.RuleRepository;
 import com.alibaba.csp.sentinel.util.StringUtil;
@@ -51,8 +48,6 @@ public class SystemController {
     private RuleRepository<SystemRuleEntity, Long> repository;
     @Autowired
     private SentinelApiClient sentinelApiClient;
-    @Autowired
-    private AuthService<HttpServletRequest> authService;
 
     private <R> Result<R> checkBasicParams(String app, String ip, Integer port) {
         if (StringUtil.isEmpty(app)) {
@@ -71,13 +66,9 @@ public class SystemController {
     }
 
     @GetMapping("/rules.json")
-    public Result<List<SystemRuleEntity>> apiQueryMachineRules(HttpServletRequest request, String app, String ip,
+    @AuthAction(PrivilegeType.READ_RULE)
+    public Result<List<SystemRuleEntity>> apiQueryMachineRules(String app, String ip,
                                                                Integer port) {
-        AuthUser authUser = authService.getAuthUser(request);
-        if (!authUser.authTarget(app, PrivilegeType.READ_RULE)) {
-            return Result.ofFail(-1, "no privilege");
-        }
-
         Result<List<SystemRuleEntity>> checkResult = checkBasicParams(app, ip, port);
         if (checkResult != null) {
             return checkResult;
@@ -103,13 +94,10 @@ public class SystemController {
     }
 
     @RequestMapping("/new.json")
-    public Result<SystemRuleEntity> apiAdd(HttpServletRequest request, String app, String ip, Integer port,
+    @AuthAction(PrivilegeType.WRITE_RULE)
+    public Result<SystemRuleEntity> apiAdd(String app, String ip, Integer port,
                                            Double highestSystemLoad, Double highestCpuUsage, Long avgRt,
                                            Long maxThread, Double qps) {
-        AuthUser authUser = authService.getAuthUser(request);
-        if (!authUser.authTarget(app, PrivilegeType.WRITE_RULE)) {
-            return Result.ofFail(-1, "no privilege");
-        }
 
         Result<SystemRuleEntity> checkResult = checkBasicParams(app, ip, port);
         if (checkResult != null) {
@@ -172,10 +160,9 @@ public class SystemController {
     }
 
     @GetMapping("/save.json")
-    public Result<SystemRuleEntity> apiUpdateIfNotNull(HttpServletRequest request,
-                                        Long id, String app, Double highestSystemLoad, Double highestCpuUsage,
-                                        Long avgRt, Long maxThread, Double qps) {
-        AuthUser authUser = authService.getAuthUser(request);
+    @AuthAction(PrivilegeType.WRITE_RULE)
+    public Result<SystemRuleEntity> apiUpdateIfNotNull(Long id, String app, Double highestSystemLoad,
+            Double highestCpuUsage, Long avgRt, Long maxThread, Double qps) {
         if (id == null) {
             return Result.ofFail(-1, "id can't be null");
         }
@@ -183,9 +170,7 @@ public class SystemController {
         if (entity == null) {
             return Result.ofFail(-1, "id " + id + " dose not exist");
         }
-        if (!authUser.authTarget(entity.getApp(), PrivilegeType.WRITE_RULE)) {
-            return Result.ofFail(-1, "no privilege");
-        }
+
         if (StringUtil.isNotBlank(app)) {
             entity.setApp(app.trim());
         }
@@ -237,17 +222,14 @@ public class SystemController {
     }
 
     @RequestMapping("/delete.json")
-    public Result<?> delete(HttpServletRequest request, Long id) {
-        AuthUser authUser = authService.getAuthUser(request);
+    @AuthAction(PrivilegeType.DELETE_RULE)
+    public Result<?> delete(Long id) {
         if (id == null) {
             return Result.ofFail(-1, "id can't be null");
         }
         SystemRuleEntity oldEntity = repository.findById(id);
         if (oldEntity == null) {
             return Result.ofSuccess(null);
-        }
-        if (!authUser.authTarget(oldEntity.getApp(), PrivilegeType.DELETE_RULE)) {
-            return Result.ofFail(-1, "no privilege");
         }
         try {
             repository.delete(id);

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/SystemController.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/SystemController.java
@@ -74,7 +74,9 @@ public class SystemController {
     public Result<List<SystemRuleEntity>> apiQueryMachineRules(HttpServletRequest request, String app, String ip,
                                                                Integer port) {
         AuthUser authUser = authService.getAuthUser(request);
-        authUser.authTarget(app, PrivilegeType.READ_RULE);
+        if (!authUser.authTarget(app, PrivilegeType.READ_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
 
         Result<List<SystemRuleEntity>> checkResult = checkBasicParams(app, ip, port);
         if (checkResult != null) {
@@ -105,7 +107,9 @@ public class SystemController {
                                            Double highestSystemLoad, Double highestCpuUsage, Long avgRt,
                                            Long maxThread, Double qps) {
         AuthUser authUser = authService.getAuthUser(request);
-        authUser.authTarget(app, PrivilegeType.WRITE_RULE);
+        if (!authUser.authTarget(app, PrivilegeType.WRITE_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
 
         Result<SystemRuleEntity> checkResult = checkBasicParams(app, ip, port);
         if (checkResult != null) {
@@ -179,7 +183,9 @@ public class SystemController {
         if (entity == null) {
             return Result.ofFail(-1, "id " + id + " dose not exist");
         }
-        authUser.authTarget(entity.getApp(), PrivilegeType.WRITE_RULE);
+        if (!authUser.authTarget(entity.getApp(), PrivilegeType.WRITE_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
         if (StringUtil.isNotBlank(app)) {
             entity.setApp(app.trim());
         }
@@ -240,7 +246,9 @@ public class SystemController {
         if (oldEntity == null) {
             return Result.ofSuccess(null);
         }
-        authUser.authTarget(oldEntity.getApp(), PrivilegeType.DELETE_RULE);
+        if (!authUser.authTarget(oldEntity.getApp(), PrivilegeType.DELETE_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
         try {
             repository.delete(id);
         } catch (Throwable throwable) {

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/gateway/GatewayApiController.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/gateway/GatewayApiController.java
@@ -61,7 +61,9 @@ public class GatewayApiController {
     @GetMapping("/list.json")
     public Result<List<ApiDefinitionEntity>> queryApis(HttpServletRequest request, String app, String ip, Integer port) {
         AuthService.AuthUser authUser = authService.getAuthUser(request);
-        authUser.authTarget(app, AuthService.PrivilegeType.READ_RULE);
+        if (!authUser.authTarget(app, AuthService.PrivilegeType.READ_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
 
         if (StringUtil.isEmpty(app)) {
             return Result.ofFail(-1, "app can't be null or empty");
@@ -92,7 +94,9 @@ public class GatewayApiController {
             return Result.ofFail(-1, "app can't be null or empty");
         }
 
-        authUser.authTarget(app, AuthService.PrivilegeType.WRITE_RULE);
+        if (!authUser.authTarget(app, AuthService.PrivilegeType.WRITE_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
 
         ApiDefinitionEntity entity = new ApiDefinitionEntity();
         entity.setApp(app.trim());
@@ -177,7 +181,9 @@ public class GatewayApiController {
             return Result.ofFail(-1, "app can't be null or empty");
         }
 
-        authUser.authTarget(app, AuthService.PrivilegeType.WRITE_RULE);
+        if (!authUser.authTarget(app, AuthService.PrivilegeType.WRITE_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
 
         Long id = reqVo.getId();
         if (id == null) {
@@ -247,7 +253,9 @@ public class GatewayApiController {
             return Result.ofSuccess(null);
         }
 
-        authUser.authTarget(oldEntity.getApp(), AuthService.PrivilegeType.DELETE_RULE);
+        if (!authUser.authTarget(oldEntity.getApp(), AuthService.PrivilegeType.DELETE_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
 
         try {
             repository.delete(id);

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/gateway/GatewayFlowRuleController.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/gateway/GatewayFlowRuleController.java
@@ -65,7 +65,9 @@ public class GatewayFlowRuleController {
     @GetMapping("/list.json")
     public Result<List<GatewayFlowRuleEntity>> queryFlowRules(HttpServletRequest request, String app, String ip, Integer port) {
         AuthService.AuthUser authUser = authService.getAuthUser(request);
-        authUser.authTarget(app, AuthService.PrivilegeType.READ_RULE);
+        if (!authUser.authTarget(app, AuthService.PrivilegeType.READ_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
 
         if (StringUtil.isEmpty(app)) {
             return Result.ofFail(-1, "app can't be null or empty");
@@ -96,7 +98,9 @@ public class GatewayFlowRuleController {
             return Result.ofFail(-1, "app can't be null or empty");
         }
 
-        authUser.authTarget(app, AuthService.PrivilegeType.WRITE_RULE);
+        if (!authUser.authTarget(app, AuthService.PrivilegeType.WRITE_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
 
         GatewayFlowRuleEntity entity = new GatewayFlowRuleEntity();
         entity.setApp(app.trim());
@@ -266,7 +270,9 @@ public class GatewayFlowRuleController {
             return Result.ofFail(-1, "app can't be null or empty");
         }
 
-        authUser.authTarget(app, AuthService.PrivilegeType.WRITE_RULE);
+        if (!authUser.authTarget(app, AuthService.PrivilegeType.WRITE_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
 
         Long id = reqVo.getId();
         if (id == null) {
@@ -420,7 +426,9 @@ public class GatewayFlowRuleController {
             return Result.ofSuccess(null);
         }
 
-        authUser.authTarget(oldEntity.getApp(), AuthService.PrivilegeType.DELETE_RULE);
+        if (!authUser.authTarget(oldEntity.getApp(), AuthService.PrivilegeType.DELETE_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
 
         try {
             repository.delete(id);

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/v2/FlowControllerV2.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/v2/FlowControllerV2.java
@@ -18,10 +18,8 @@ package com.alibaba.csp.sentinel.dashboard.controller.v2;
 import java.util.Date;
 import java.util.List;
 
-import javax.servlet.http.HttpServletRequest;
-
+import com.alibaba.csp.sentinel.dashboard.auth.AuthAction;
 import com.alibaba.csp.sentinel.dashboard.auth.AuthService;
-import com.alibaba.csp.sentinel.dashboard.auth.AuthService.AuthUser;
 import com.alibaba.csp.sentinel.dashboard.auth.AuthService.PrivilegeType;
 import com.alibaba.csp.sentinel.util.StringUtil;
 
@@ -67,15 +65,9 @@ public class FlowControllerV2 {
     @Qualifier("flowRuleDefaultPublisher")
     private DynamicRulePublisher<List<FlowRuleEntity>> rulePublisher;
 
-    @Autowired
-    private AuthService<HttpServletRequest> authService;
-
     @GetMapping("/rules")
-    public Result<List<FlowRuleEntity>> apiQueryMachineRules(HttpServletRequest request, @RequestParam String app) {
-        AuthUser authUser = authService.getAuthUser(request);
-        if (!authUser.authTarget(app, PrivilegeType.READ_RULE)) {
-            return Result.ofFail(-1, "no privilege");
-        }
+    @AuthAction(PrivilegeType.READ_RULE)
+    public Result<List<FlowRuleEntity>> apiQueryMachineRules(@RequestParam String app) {
 
         if (StringUtil.isEmpty(app)) {
             return Result.ofFail(-1, "app can't be null or empty");
@@ -143,11 +135,8 @@ public class FlowControllerV2 {
     }
 
     @PostMapping("/rule")
-    public Result<FlowRuleEntity> apiAddFlowRule(HttpServletRequest request, @RequestBody FlowRuleEntity entity) {
-        AuthUser authUser = authService.getAuthUser(request);
-        if (!authUser.authTarget(entity.getApp(), PrivilegeType.WRITE_RULE)) {
-            return Result.ofFail(-1, "no privilege");
-        }
+    @AuthAction(value = AuthService.PrivilegeType.WRITE_RULE)
+    public Result<FlowRuleEntity> apiAddFlowRule(@RequestBody FlowRuleEntity entity) {
 
         Result<FlowRuleEntity> checkResult = checkEntityInternal(entity);
         if (checkResult != null) {
@@ -170,10 +159,10 @@ public class FlowControllerV2 {
     }
 
     @PutMapping("/rule/{id}")
-    public Result<FlowRuleEntity> apiUpdateFlowRule(HttpServletRequest request,
-                                                    @PathVariable("id") Long id,
+    @AuthAction(AuthService.PrivilegeType.WRITE_RULE)
+
+    public Result<FlowRuleEntity> apiUpdateFlowRule(@PathVariable("id") Long id,
                                                     @RequestBody FlowRuleEntity entity) {
-        AuthUser authUser = authService.getAuthUser(request);
         if (id == null || id <= 0) {
             return Result.ofFail(-1, "Invalid id");
         }
@@ -183,9 +172,6 @@ public class FlowControllerV2 {
         }
         if (entity == null) {
             return Result.ofFail(-1, "invalid body");
-        }
-        if (!authUser.authTarget(oldEntity.getApp(), PrivilegeType.WRITE_RULE)) {
-            return Result.ofFail(-1, "no privilege");
         }
 
         entity.setApp(oldEntity.getApp());
@@ -214,8 +200,8 @@ public class FlowControllerV2 {
     }
 
     @DeleteMapping("/rule/{id}")
-    public Result<Long> apiDeleteRule(HttpServletRequest request, @PathVariable("id") Long id) {
-        AuthUser authUser = authService.getAuthUser(request);
+    @AuthAction(PrivilegeType.DELETE_RULE)
+    public Result<Long> apiDeleteRule(@PathVariable("id") Long id) {
         if (id == null || id <= 0) {
             return Result.ofFail(-1, "Invalid id");
         }
@@ -223,9 +209,7 @@ public class FlowControllerV2 {
         if (oldEntity == null) {
             return Result.ofSuccess(null);
         }
-        if (!authUser.authTarget(oldEntity.getApp(), PrivilegeType.DELETE_RULE)) {
-            return Result.ofFail(-1, "no privilege");
-        }
+
         try {
             repository.delete(id);
             publishRules(oldEntity.getApp());

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/v2/FlowControllerV2.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/v2/FlowControllerV2.java
@@ -73,7 +73,9 @@ public class FlowControllerV2 {
     @GetMapping("/rules")
     public Result<List<FlowRuleEntity>> apiQueryMachineRules(HttpServletRequest request, @RequestParam String app) {
         AuthUser authUser = authService.getAuthUser(request);
-        authUser.authTarget(app, PrivilegeType.READ_RULE);
+        if (!authUser.authTarget(app, PrivilegeType.READ_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
 
         if (StringUtil.isEmpty(app)) {
             return Result.ofFail(-1, "app can't be null or empty");
@@ -143,7 +145,9 @@ public class FlowControllerV2 {
     @PostMapping("/rule")
     public Result<FlowRuleEntity> apiAddFlowRule(HttpServletRequest request, @RequestBody FlowRuleEntity entity) {
         AuthUser authUser = authService.getAuthUser(request);
-        authUser.authTarget(entity.getApp(), PrivilegeType.WRITE_RULE);
+        if (!authUser.authTarget(entity.getApp(), PrivilegeType.WRITE_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
 
         Result<FlowRuleEntity> checkResult = checkEntityInternal(entity);
         if (checkResult != null) {
@@ -180,7 +184,9 @@ public class FlowControllerV2 {
         if (entity == null) {
             return Result.ofFail(-1, "invalid body");
         }
-        authUser.authTarget(oldEntity.getApp(), PrivilegeType.WRITE_RULE);
+        if (!authUser.authTarget(oldEntity.getApp(), PrivilegeType.WRITE_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
 
         entity.setApp(oldEntity.getApp());
         entity.setIp(oldEntity.getIp());
@@ -217,7 +223,9 @@ public class FlowControllerV2 {
         if (oldEntity == null) {
             return Result.ofSuccess(null);
         }
-        authUser.authTarget(oldEntity.getApp(), PrivilegeType.DELETE_RULE);
+        if (!authUser.authTarget(oldEntity.getApp(), PrivilegeType.DELETE_RULE)) {
+            return Result.ofFail(-1, "no privilege");
+        }
         try {
             repository.delete(id);
             publishRules(oldEntity.getApp());

--- a/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/controller/gateway/GatewayApiControllerTest.java
+++ b/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/controller/gateway/GatewayApiControllerTest.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.csp.sentinel.dashboard.controller.gateway;
 
+import com.alibaba.csp.sentinel.dashboard.auth.AuthInterceptor;
 import com.alibaba.csp.sentinel.dashboard.auth.FakeAuthServiceImpl;
 import com.alibaba.csp.sentinel.dashboard.client.SentinelApiClient;
 import com.alibaba.csp.sentinel.dashboard.datasource.entity.gateway.ApiDefinitionEntity;
@@ -60,7 +61,7 @@ import static org.mockito.BDDMockito.*;
  */
 @RunWith(SpringRunner.class)
 @WebMvcTest(GatewayApiController.class)
-@Import({FakeAuthServiceImpl.class, InMemApiDefinitionStore.class, AppManagement.class, SimpleMachineDiscovery.class})
+@Import({FakeAuthServiceImpl.class, InMemApiDefinitionStore.class, AppManagement.class, SimpleMachineDiscovery.class, AuthInterceptor.class})
 public class GatewayApiControllerTest {
 
     private static final String TEST_APP = "test_app";

--- a/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/controller/gateway/GatewayFlowRuleControllerTest.java
+++ b/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/controller/gateway/GatewayFlowRuleControllerTest.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.csp.sentinel.dashboard.controller.gateway;
 
+import com.alibaba.csp.sentinel.dashboard.auth.AuthInterceptor;
 import com.alibaba.csp.sentinel.dashboard.auth.FakeAuthServiceImpl;
 import com.alibaba.csp.sentinel.dashboard.client.SentinelApiClient;
 import com.alibaba.csp.sentinel.dashboard.datasource.entity.gateway.GatewayFlowRuleEntity;
@@ -63,7 +64,8 @@ import static org.mockito.BDDMockito.*;
  */
 @RunWith(SpringRunner.class)
 @WebMvcTest(GatewayFlowRuleController.class)
-@Import({FakeAuthServiceImpl.class, InMemGatewayFlowRuleStore.class, AppManagement.class, SimpleMachineDiscovery.class})
+@Import({FakeAuthServiceImpl.class, InMemGatewayFlowRuleStore.class, AppManagement.class, SimpleMachineDiscovery.class,
+        AuthInterceptor.class })
 public class GatewayFlowRuleControllerTest {
 
     private static final String TEST_APP = "test_app";


### PR DESCRIPTION
### Describe what this PR does / why we need it
Fix the dashboard privileges check bug, from the interface AuthService, there is a comment on the authTarget function 

> @return if current user has the specific privileges to the target, return true, otherwise return false.

but in the dashboard controllers, there is not check on the authTarget's return value to verify privileges.

and update the fastjson version because of the security, see https://github.com/alibaba/fastjson/releases

### Does this pull request fix one issue?

NONE

### Describe how you did it
Add checks for every authTarget's return.


### refer #1035