### PR TITLE
make rule properties more readable, more extensible and higher cohesive

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/enums/AuthorityStrategy.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/enums/AuthorityStrategy.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.enums;
+
+/**
+ * Define the Authority Strategy as enum instead of just two int values,
+ * and move the judgement logic as its own behavior.
+ * @author Weihua
+ * @since 1.7.0
+ */
+public enum AuthorityStrategy {
+
+    White(0, "White List"), Black(1, "Black List");
+
+    private int value;
+    private String desc;
+
+    AuthorityStrategy(int value, String desc){
+        this.value = value;
+        this.desc = desc;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public String getDesc() {
+        return desc;
+    }
+
+    /**
+     * It's kind of strategy pattern behavior.
+     * It behaves just according to <code>contains</code> and <code>value</code>.
+     * @param contains whether limitApp contains origin or not
+     * @return whether pass or not
+     */
+    public boolean pass(boolean contains){
+        return (this.value == 0 && contains) || (this.value == 1 && !contains);
+    }
+
+    public String toString(){
+        return name();
+    }
+
+}

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/RuleConstant.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/RuleConstant.java
@@ -39,7 +39,13 @@ public final class RuleConstant {
     public static final int DEGRADE_DEFAULT_SLOW_REQUEST_AMOUNT = 5;
     public static final int DEGRADE_DEFAULT_MIN_REQUEST_AMOUNT = 5;
 
+    /**
+     * Since this refactor, these two constants should never be used again,
+     * Use <code>AuthorityStrategy</code> instead.
+     */
+    @Deprecated
     public static final int AUTHORITY_WHITE = 0;
+    @Deprecated
     public static final int AUTHORITY_BLACK = 1;
 
     public static final int STRATEGY_DIRECT = 0;

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/authority/AuthorityRule.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/authority/AuthorityRule.java
@@ -16,9 +16,9 @@
 package com.alibaba.csp.sentinel.slots.block.authority;
 
 import com.alibaba.csp.sentinel.context.Context;
+import com.alibaba.csp.sentinel.enums.AuthorityStrategy;
 import com.alibaba.csp.sentinel.node.DefaultNode;
 import com.alibaba.csp.sentinel.slots.block.AbstractRule;
-import com.alibaba.csp.sentinel.slots.block.RuleConstant;
 
 /**
  * Authority rule is designed for limiting by request origins.
@@ -27,16 +27,13 @@ import com.alibaba.csp.sentinel.slots.block.RuleConstant;
  */
 public class AuthorityRule extends AbstractRule {
 
-    /**
-     * Mode: 0 for whitelist; 1 for blacklist.
-     */
-    private int strategy = RuleConstant.AUTHORITY_WHITE;
+    private AuthorityStrategy strategy = AuthorityStrategy.White;
 
-    public int getStrategy() {
+    public AuthorityStrategy getStrategy() {
         return strategy;
     }
 
-    public AuthorityRule setStrategy(int strategy) {
+    public AuthorityRule setStrategy(AuthorityStrategy strategy) {
         this.strategy = strategy;
         return this;
     }
@@ -55,7 +52,7 @@ public class AuthorityRule extends AbstractRule {
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + strategy;
+        result = 31 * result + strategy.getValue();
         return result;
     }
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/authority/AuthorityRuleChecker.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/authority/AuthorityRuleChecker.java
@@ -51,17 +51,8 @@ final class AuthorityRuleChecker {
 
             contain = exactlyMatch;
         }
-
-        int strategy = rule.getStrategy();
-        if (strategy == RuleConstant.AUTHORITY_BLACK && contain) {
-            return false;
-        }
-
-        if (strategy == RuleConstant.AUTHORITY_WHITE && !contain) {
-            return false;
-        }
-
-        return true;
+        //move the logic into AuthorityStrategy
+        return rule.getStrategy().pass(contain);
     }
 
     private AuthorityRuleChecker() {}

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/authority/AuthorityRuleManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/authority/AuthorityRuleManager.java
@@ -153,6 +153,6 @@ public final class AuthorityRuleManager {
 
     public static boolean isValidRule(AuthorityRule rule) {
         return rule != null && !StringUtil.isBlank(rule.getResource())
-            && rule.getStrategy() >= 0 && StringUtil.isNotBlank(rule.getLimitApp());
+            && rule.getStrategy() != null && StringUtil.isNotBlank(rule.getLimitApp());
     }
 }

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/authority/AuthorityRuleCheckerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/authority/AuthorityRuleCheckerTest.java
@@ -2,7 +2,7 @@ package com.alibaba.csp.sentinel.slots.block.authority;
 
 import com.alibaba.csp.sentinel.context.ContextTestUtil;
 import com.alibaba.csp.sentinel.context.ContextUtil;
-import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+import com.alibaba.csp.sentinel.enums.AuthorityStrategy;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -31,22 +31,22 @@ public class AuthorityRuleCheckerTest {
                 .setResource(resourceName)
                 .setLimitApp(origin + ",appB")
                 .as(AuthorityRule.class)
-                .setStrategy(RuleConstant.AUTHORITY_WHITE);
+                .setStrategy(AuthorityStrategy.White);
             AuthorityRule ruleB = new AuthorityRule()
                 .setResource(resourceName)
                 .setLimitApp("appB")
                 .as(AuthorityRule.class)
-                .setStrategy(RuleConstant.AUTHORITY_WHITE);
+                .setStrategy(AuthorityStrategy.White);
             AuthorityRule ruleC = new AuthorityRule()
                 .setResource(resourceName)
                 .setLimitApp(origin)
                 .as(AuthorityRule.class)
-                .setStrategy(RuleConstant.AUTHORITY_BLACK);
+                .setStrategy(AuthorityStrategy.Black);
             AuthorityRule ruleD = new AuthorityRule()
                 .setResource(resourceName)
                 .setLimitApp("appC")
                 .as(AuthorityRule.class)
-                .setStrategy(RuleConstant.AUTHORITY_BLACK);
+                .setStrategy(AuthorityStrategy.Black);
 
             assertTrue(AuthorityRuleChecker.passCheck(ruleA, ContextUtil.getContext()));
             assertFalse(AuthorityRuleChecker.passCheck(ruleB, ContextUtil.getContext()));

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/authority/AuthorityRuleManagerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/authority/AuthorityRuleManagerTest.java
@@ -3,7 +3,7 @@ package com.alibaba.csp.sentinel.slots.block.authority;
 import java.util.Collections;
 import java.util.List;
 
-import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+import com.alibaba.csp.sentinel.enums.AuthorityStrategy;
 
 import org.junit.After;
 import org.junit.Test;
@@ -29,7 +29,7 @@ public class AuthorityRuleManagerTest {
         AuthorityRule rule = new AuthorityRule();
         rule.setResource(resourceName);
         rule.setLimitApp("a,b");
-        rule.setStrategy(RuleConstant.AUTHORITY_WHITE);
+        rule.setStrategy(AuthorityStrategy.White);
         AuthorityRuleManager.loadRules(Collections.singletonList(rule));
 
         List<AuthorityRule> rules = AuthorityRuleManager.getRules();

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/authority/AuthoritySlotTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/authority/AuthoritySlotTest.java
@@ -5,9 +5,9 @@ import java.util.Collections;
 import com.alibaba.csp.sentinel.EntryType;
 import com.alibaba.csp.sentinel.context.ContextTestUtil;
 import com.alibaba.csp.sentinel.context.ContextUtil;
+import com.alibaba.csp.sentinel.enums.AuthorityStrategy;
 import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
 import com.alibaba.csp.sentinel.slotchain.StringResourceWrapper;
-import com.alibaba.csp.sentinel.slots.block.RuleConstant;
 
 import org.junit.After;
 import org.junit.Before;
@@ -33,7 +33,7 @@ public class AuthoritySlotTest {
                 .setResource(resourceName)
                 .setLimitApp(origin + ",appB")
                 .as(AuthorityRule.class)
-                .setStrategy(RuleConstant.AUTHORITY_WHITE);
+                .setStrategy(AuthorityStrategy.White);
 
             AuthorityRuleManager.loadRules(Collections.singletonList(ruleA));
             authoritySlot.checkBlackWhiteAuthority(resourceWrapper, ContextUtil.getContext());
@@ -42,7 +42,7 @@ public class AuthoritySlotTest {
                 .setResource(resourceName)
                 .setLimitApp("appD")
                 .as(AuthorityRule.class)
-                .setStrategy(RuleConstant.AUTHORITY_BLACK);
+                .setStrategy(AuthorityStrategy.Black);
 
             AuthorityRuleManager.loadRules(Collections.singletonList(ruleB));
             authoritySlot.checkBlackWhiteAuthority(resourceWrapper, ContextUtil.getContext());
@@ -62,7 +62,7 @@ public class AuthoritySlotTest {
                 .setResource(resourceName)
                 .setLimitApp(origin + ",appC")
                 .as(AuthorityRule.class)
-                .setStrategy(RuleConstant.AUTHORITY_BLACK);
+                .setStrategy(AuthorityStrategy.Black);
 
             AuthorityRuleManager.loadRules(Collections.singletonList(ruleA));
             authoritySlot.checkBlackWhiteAuthority(resourceWrapper, ContextUtil.getContext());
@@ -82,7 +82,7 @@ public class AuthoritySlotTest {
                 .setResource(resourceName)
                 .setLimitApp("appB, appE")
                 .as(AuthorityRule.class)
-                .setStrategy(RuleConstant.AUTHORITY_WHITE);
+                .setStrategy(AuthorityStrategy.White);
 
             AuthorityRuleManager.loadRules(Collections.singletonList(ruleB));
             authoritySlot.checkBlackWhiteAuthority(resourceWrapper, ContextUtil.getContext());

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/AuthorityRuleController.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/AuthorityRuleController.java
@@ -25,7 +25,6 @@ import com.alibaba.csp.sentinel.dashboard.discovery.MachineInfo;
 import com.alibaba.csp.sentinel.dashboard.auth.AuthService;
 import com.alibaba.csp.sentinel.dashboard.auth.AuthService.AuthUser;
 import com.alibaba.csp.sentinel.dashboard.auth.AuthService.PrivilegeType;
-import com.alibaba.csp.sentinel.slots.block.RuleConstant;
 import com.alibaba.csp.sentinel.util.StringUtil;
 
 import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.AuthorityRuleEntity;
@@ -111,8 +110,7 @@ public class AuthorityRuleController {
         if (StringUtil.isBlank(entity.getLimitApp())) {
             return Result.ofFail(-1, "limitApp should be valid");
         }
-        if (entity.getStrategy() != RuleConstant.AUTHORITY_WHITE
-            && entity.getStrategy() != RuleConstant.AUTHORITY_BLACK) {
+        if (entity.getStrategy() == null) {
             return Result.ofFail(-1, "Unknown strategy (must be blacklist or whitelist)");
         }
         return null;

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/datasource/entity/rule/AuthorityRuleEntity.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/datasource/entity/rule/AuthorityRuleEntity.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.csp.sentinel.dashboard.datasource.entity.rule;
 
+import com.alibaba.csp.sentinel.enums.AuthorityStrategy;
 import com.alibaba.csp.sentinel.slots.block.authority.AuthorityRule;
 import com.alibaba.csp.sentinel.util.AssertUtil;
 import com.alibaba.fastjson.annotation.JSONField;
@@ -56,7 +57,7 @@ public class AuthorityRuleEntity extends AbstractRuleEntity<AuthorityRule> {
 
     @JsonIgnore
     @JSONField(serialize = false)
-    public int getStrategy() {
+    public AuthorityStrategy getStrategy() {
         return rule.getStrategy();
     }
 }

--- a/sentinel-dashboard/src/main/webapp/resources/app/views/authority.html
+++ b/sentinel-dashboard/src/main/webapp/resources/app/views/authority.html
@@ -49,8 +49,8 @@
                             <td style="word-wrap:break-word;word-break:break-all;">{{ruleEntity.rule.resource}}</td>
                             <td style="word-wrap:break-word;word-break:break-all;">{{ruleEntity.rule.limitApp }}</td>
                             <td>
-                                <span ng-if="ruleEntity.rule.strategy == 0">白名单</span>
-                                <span ng-if="ruleEntity.rule.strategy == 1">黑名单</span>
+                                <span ng-if="ruleEntity.rule.strategy == 'White'">白名单</span>
+                                <span ng-if="ruleEntity.rule.strategy == 'Black'">黑名单</span>
                             </td>
                             <td>
                                 <button class="btn btn-xs btn-default" type="button" ng-click="editRule(ruleEntity)" style="font-size: 12px; height:25px;">编辑</button>

--- a/sentinel-dashboard/src/main/webapp/resources/app/views/dialog/authority-rule-dialog.html
+++ b/sentinel-dashboard/src/main/webapp/resources/app/views/dialog/authority-rule-dialog.html
@@ -26,8 +26,8 @@
                         <label class="col-sm-2 control-label">授权类型</label>
                         <div class="col-sm-4">
                             <div class="form-control highlight-border" align="center">
-                                <input type="radio" name="strategy" value="0" checked ng-model='currentRule.rule.strategy' />&nbsp;白名单&nbsp;&nbsp;
-                                <input type="radio" name="strategy" value="1" ng-model='currentRule.rule.strategy' />&nbsp;黑名单
+                                <input type="radio" name="strategy" value="White" checked ng-model='currentRule.rule.strategy' />&nbsp;白名单&nbsp;&nbsp;
+                                <input type="radio" name="strategy" value="Black" ng-model='currentRule.rule.strategy' />&nbsp;黑名单
                             </div>
                         </div>
                     </div>

--- a/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/datasource/entity/JsonSerializeTest.java
+++ b/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/datasource/entity/JsonSerializeTest.java
@@ -17,6 +17,7 @@ package com.alibaba.csp.sentinel.dashboard.datasource.entity;
 
 import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.AuthorityRuleEntity;
 import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.ParamFlowRuleEntity;
+import com.alibaba.csp.sentinel.enums.AuthorityStrategy;
 import com.alibaba.csp.sentinel.slots.block.authority.AuthorityRule;
 import com.alibaba.csp.sentinel.slots.block.flow.param.ParamFlowClusterConfig;
 import com.alibaba.csp.sentinel.slots.block.flow.param.ParamFlowRule;
@@ -37,9 +38,9 @@ public class JsonSerializeTest {
 
         AuthorityRuleEntity authorityRule = new AuthorityRuleEntity();
         AuthorityRule rule = new AuthorityRule();
-        rule.setStrategy(0).setLimitApp("default").setResource("rs");
+        rule.setStrategy(AuthorityStrategy.White).setLimitApp("default").setResource("rs");
         authorityRule.setRule(rule);
-        Assert.assertTrue("{\"rule\":{\"limitApp\":\"default\",\"resource\":\"rs\",\"strategy\":0}}".equals(JSON.toJSONString(authorityRule)));
+        Assert.assertTrue("{\"rule\":{\"limitApp\":\"default\",\"resource\":\"rs\",\"strategy\":\"White\"}}".equals(JSON.toJSONString(authorityRule)));
     }
 
     @Test

--- a/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/authority/AuthorityDemo.java
+++ b/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/authority/AuthorityDemo.java
@@ -20,8 +20,8 @@ import java.util.Collections;
 import com.alibaba.csp.sentinel.Entry;
 import com.alibaba.csp.sentinel.SphU;
 import com.alibaba.csp.sentinel.context.ContextUtil;
+import com.alibaba.csp.sentinel.enums.AuthorityStrategy;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
-import com.alibaba.csp.sentinel.slots.block.RuleConstant;
 import com.alibaba.csp.sentinel.slots.block.authority.AuthorityRule;
 import com.alibaba.csp.sentinel.slots.block.authority.AuthorityRuleManager;
 
@@ -71,7 +71,7 @@ public class AuthorityDemo {
     private static void initWhiteRules() {
         AuthorityRule rule = new AuthorityRule();
         rule.setResource(RESOURCE_NAME);
-        rule.setStrategy(RuleConstant.AUTHORITY_WHITE);
+        rule.setStrategy(AuthorityStrategy.White);
         rule.setLimitApp("appA,appE");
         AuthorityRuleManager.loadRules(Collections.singletonList(rule));
     }
@@ -79,7 +79,7 @@ public class AuthorityDemo {
     private static void initBlackRules() {
         AuthorityRule rule = new AuthorityRule();
         rule.setResource(RESOURCE_NAME);
-        rule.setStrategy(RuleConstant.AUTHORITY_BLACK);
+        rule.setStrategy(AuthorityStrategy.Black);
         rule.setLimitApp("appA,appB");
         AuthorityRuleManager.loadRules(Collections.singletonList(rule));
     }

--- a/sentinel-demo/sentinel-demo-dynamic-file-rule/src/main/java/com/alibaba/csp/sentinel/demo/file/rule/JsonConverterDemo.java
+++ b/sentinel-demo/sentinel-demo-dynamic-file-rule/src/main/java/com/alibaba/csp/sentinel/demo/file/rule/JsonConverterDemo.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.demo.file.rule;
+
+import com.alibaba.csp.sentinel.datasource.Converter;
+import com.alibaba.csp.sentinel.datasource.FileRefreshableDataSource;
+import com.alibaba.csp.sentinel.slots.block.authority.AuthorityRule;
+import com.alibaba.csp.sentinel.slots.block.authority.AuthorityRuleManager;
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.TypeReference;
+
+import java.net.URLDecoder;
+import java.util.List;
+
+/**
+ * This demo is used to check if fastjson supports parsing both int value and string value to enum
+ * @author Weihua
+ * @since 1.7.0
+ */
+public class JsonConverterDemo {
+
+    public static void main(String[] args) throws Exception {
+        new JsonConverterDemo().parse();
+    }
+
+    private void parse() throws Exception {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String authorityPath = URLDecoder.decode(classLoader.getResource("AuthorityRule.json").getFile(), "UTF-8");
+
+        // Data source for SystemRule
+        FileRefreshableDataSource<List<AuthorityRule>> authorityRuleDataSource
+            = new FileRefreshableDataSource<>(
+            authorityPath, authorityRuleListParser);
+        AuthorityRuleManager.register2Property(authorityRuleDataSource.getProperty());
+        System.out.println(AuthorityRuleManager.getRules());
+    }
+
+    private Converter<String, List<AuthorityRule>> authorityRuleListParser = source -> JSON.parseObject(source,
+        new TypeReference<List<AuthorityRule>>() {});
+}

--- a/sentinel-demo/sentinel-demo-dynamic-file-rule/src/main/resources/AuthorityRule.json
+++ b/sentinel-demo/sentinel-demo-dynamic-file-rule/src/main/resources/AuthorityRule.json
@@ -1,0 +1,12 @@
+[
+  {
+    "resource": "abc",
+    "limitApp": "app1,app2",
+    "strategy": 0
+  },
+  {
+    "resource": "bcd",
+    "limitApp": "app1,app2",
+    "strategy": "White"
+  }
+]


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
There're so many groups of int constants among in RuleConstant class, each group can be replaced with enum type. Benefits are obvious: 
1. Users now can put 'White/Black' string on strategy property instead of legacy 0/1 which is much more readable to them. 
2. Though there couldn't be another XXX list in the future, like red list or blue list, it's still needed to make it extensible. Just put a new enum type in AuthorityStrategy class. Without this refactor, we need to change many classes to achieve this. 
3. Provided "contains" is specified, the enum type can judge if it's pass or not. This is the business of enum type itself. So it's very reasonable to move the piece of logic from AuthorityRuleChecker to AuthorityStrategy.

If this pr is useful and acceptable, I'll do similar refactor for RuleConstant. AuthorityStrategy is the simplest and just the start. Hope it helps.

### Does this pull request fix one issue?
No, just code refactor. 

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it
Unit test runs and passed. Additional unit test class was added.

### Special notes for reviews
If needed, just leave me a message or send me email, I'll reply on it in the first time.