### PR TITLE
Fix the bug that resource name displayed in ClusterNode-related command APIs for SphU.entry(method) is incorrect

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slotchain/MethodResourceWrapper.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slotchain/MethodResourceWrapper.java
@@ -47,7 +47,7 @@ public class MethodResourceWrapper extends ResourceWrapper {
 
     @Override
     public String getShowName() {
-        return IdUtil.truncate(this.name);
+        return name;
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: Eric Zhao <sczyh16@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Fix the bug that resource name displayed in `ClusterNode`-related command APIs for `SphU.entry(method)` is incorrect.

### Does this pull request fix one issue?

Fixes #1077 

### Describe how you did it

Return the original method name directly in `getShowName()` of `MethodResourceWrapper`, since the truncated name seems useless.

### Describe how to verify it

Try `SphU.entry(method)` and see the display name via `tree` command API.

### Special notes for reviews

NONE.