### PR TITLE
Improve the SPI ClassLoader mechanism to handle more complex scenarios

### DIFF
--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/processor/RequestProcessorProvider.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/processor/RequestProcessorProvider.java
@@ -20,6 +20,7 @@ import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.alibaba.csp.sentinel.cluster.annotation.RequestType;
+import com.alibaba.csp.sentinel.spi.ServiceLoaderUtil;
 import com.alibaba.csp.sentinel.util.AssertUtil;
 
 /**
@@ -30,7 +31,8 @@ public final class RequestProcessorProvider {
 
     private static final Map<Integer, RequestProcessor> PROCESSOR_MAP = new ConcurrentHashMap<>();
 
-    private static final ServiceLoader<RequestProcessor> SERVICE_LOADER = ServiceLoader.load(RequestProcessor.class);
+    private static final ServiceLoader<RequestProcessor> SERVICE_LOADER = ServiceLoaderUtil.getServiceLoader(
+        RequestProcessor.class);
 
     static {
         loadAndInit();
@@ -70,7 +72,6 @@ public final class RequestProcessorProvider {
         AssertUtil.notNull(processor, "processor cannot be null");
         PROCESSOR_MAP.put(type, processor);
     }
-
 
     private RequestProcessorProvider() {}
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/config/SentinelConfig.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/config/SentinelConfig.java
@@ -48,6 +48,7 @@ public class SentinelConfig {
     public static final String TOTAL_METRIC_FILE_COUNT = "csp.sentinel.metric.file.total.count";
     public static final String COLD_FACTOR = "csp.sentinel.flow.cold.factor";
     public static final String STATISTIC_MAX_RT = "csp.sentinel.statistic.max.rt";
+    public static final String SPI_CLASSLOADER = "csp.sentinel.spi.classloader";
 
     static final String DEFAULT_CHARSET = "UTF-8";
     static final long DEFAULT_SINGLE_METRIC_FILE_SIZE = 1024 * 1024 * 50;

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/init/InitExecutor.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/init/InitExecutor.java
@@ -21,6 +21,7 @@ import java.util.ServiceLoader;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.alibaba.csp.sentinel.log.RecordLog;
+import com.alibaba.csp.sentinel.spi.ServiceLoaderUtil;
 
 /**
  * Load registered init functions and execute in order.
@@ -42,7 +43,7 @@ public final class InitExecutor {
             return;
         }
         try {
-            ServiceLoader<InitFunc> loader = ServiceLoader.load(InitFunc.class);
+            ServiceLoader<InitFunc> loader = ServiceLoaderUtil.getServiceLoader(InitFunc.class);
             List<OrderWrapper> initList = new ArrayList<OrderWrapper>();
             for (InitFunc initFunc : loader) {
                 RecordLog.info("[InitExecutor] Found init func: " + initFunc.getClass().getCanonicalName());

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/spi/ServiceLoaderUtil.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/spi/ServiceLoaderUtil.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.spi;
+
+import java.util.ServiceLoader;
+
+import com.alibaba.csp.sentinel.config.SentinelConfig;
+
+/**
+ * @author Eric Zhao
+ * @since 1.7.0
+ */
+public final class ServiceLoaderUtil {
+
+    private static final String CLASSLOADER_DEFAULT = "default";
+    private static final String CLASSLOADER_CONTEXT = "context";
+
+    public static <S> ServiceLoader<S> getServiceLoader(Class<S> clazz) {
+        if (shouldUseContextClassloader()) {
+            return ServiceLoader.load(clazz);
+        } else {
+            return ServiceLoader.load(clazz, clazz.getClassLoader());
+        }
+    }
+
+    public static boolean shouldUseContextClassloader() {
+        String classloaderConf = SentinelConfig.getConfig(SentinelConfig.SPI_CLASSLOADER);
+        return CLASSLOADER_CONTEXT.equalsIgnoreCase(classloaderConf);
+    }
+
+    private ServiceLoaderUtil() {}
+}

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/command/CommandHandlerProvider.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/command/CommandHandlerProvider.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.ServiceLoader;
 
 import com.alibaba.csp.sentinel.command.annotation.CommandMapping;
+import com.alibaba.csp.sentinel.spi.ServiceLoaderUtil;
 import com.alibaba.csp.sentinel.util.StringUtil;
 
 /**
@@ -30,7 +31,8 @@ import com.alibaba.csp.sentinel.util.StringUtil;
  */
 public class CommandHandlerProvider implements Iterable<CommandHandler> {
 
-    private final ServiceLoader<CommandHandler> serviceLoader = ServiceLoader.load(CommandHandler.class);
+    private final ServiceLoader<CommandHandler> serviceLoader = ServiceLoaderUtil.getServiceLoader(
+        CommandHandler.class);
 
     /**
      * Get all command handlers annotated with {@link CommandMapping} with command name.


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Improve the SPI ClassLoader mechanism to handle more complex scenarios.

### Does this pull request fix one issue?

Resolves #1087

### Describe how you did it

- Add a property `csp.sentinel.spi.classloader` to indicate which ClassLoader should be used when loading SPI implementations. By default Sentinel will use the default ClassLoader (i.e. `clazz.getClassLoader()`). Only if the property is set to `context`, Sentinel will try to load SPI implementations with the thread context ClassLoader.
- Add a `ServiceLoaderUtil` class as the universal `ServiceLoader` wrapper, and improve the `SpiLoader`.
- Change all SPI providers to use `ServiceLoaderUtil` instead.

### Describe how to verify it

Run all test cases and demo.

### Special notes for reviews

This PR contains *internal breaking change*. Please verify it in scenarios with *advanced ClassLoader mechanism*.