### PR TITLE
Fix hookOnCancel handing logic in SentinelReactorSubscriber

### DIFF
--- a/sentinel-adapter/sentinel-reactor-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/reactor/SentinelReactorSubscriber.java
+++ b/sentinel-adapter/sentinel-reactor-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/reactor/SentinelReactorSubscriber.java
@@ -155,7 +155,7 @@ public class SentinelReactorSubscriber<T> extends InheritableBaseSubscriber<T> {
 
     @Override
     protected void hookOnCancel() {
-
+        tryCompleteEntry();
     }
 
     private boolean tryCompleteEntry() {


### PR DESCRIPTION
### Describe what this PR does / why we need it

Fix the `hookOnCancel` handing logic in `SentinelReactorSubscriber` to avoid Entry-exit leaking.

### Does this pull request fix one issue?

Fixes #1084 

### Describe how you did it

Add `tryCompleteEntry()` in `hookOnCancel` hook of SentinelReactorSubscriber.

Note that this is only a temporary solution. We might need to improve or refactor the SentinelReactorSubscriber later to handle all events more appropriately according to the reactive stream specification.

### Describe how to verify it

Run the test cases.

### Special notes for reviews

NONE