### PR TITLE
Bug fixed for rule.getStrategy() in FlowRuleUtil.checkClusterField()

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleUtil.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleUtil.java
@@ -195,7 +195,7 @@ public final class FlowRuleUtil {
         if (!isWindowConfigValid(clusterConfig.getSampleCount(), clusterConfig.getWindowIntervalMs())) {
             return false;
         }
-        switch (rule.getStrategy()) {
+        switch (clusterConfig.getStrategy()) {
             case ClusterRuleConstant.FLOW_CLUSTER_STRATEGY_NORMAL:
                 return true;
             default:


### PR DESCRIPTION
There is a bug in FlowRuleUtil.checkClusterField(),I privide a PR to fix it.
Fixes #1103 
### How to deal with?
Replacing the rule.getStrategy() with clusterConfig.getStrategy().