### PR TITLE
treat it as root node when parentId is empty string

### DIFF
--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/domain/ResourceTreeNode.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/domain/ResourceTreeNode.java
@@ -56,7 +56,7 @@ public class ResourceTreeNode {
             ResourceTreeNode node = fromNodeVo(vo);
             map.put(node.id, node);
             // real root
-            if (node.parentId == null) {
+            if (node.parentId == null || node.parentId.isEmpty()) {
                 root = node;
             } else if (map.containsKey(node.parentId)) {
                 map.get(node.parentId).children.add(node);


### PR DESCRIPTION
One node should also be treated as root node when its parentId is an empty string. because FetchJsonTreeCommandHandler.java use fastjson to serialize tree node data, if WriteNullStringAsEmpty option in fastjson is set then null string value will be output as empty string, which will convert parentId of root node  to empty string, so this real root node can not be treated as root node.

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
