### PR TITLE
support dubbo to register fallback and defining rules through annotat…

### DIFF
--- a/sentinel-adapter/pom.xml
+++ b/sentinel-adapter/pom.xml
@@ -25,6 +25,7 @@
         <module>sentinel-api-gateway-adapter-common</module>
         <module>sentinel-spring-cloud-gateway-adapter</module>
         <module>sentinel-spring-webmvc-adapter</module>
+        <module>sentinel-apache-dubbo-springboot</module>
     </modules>
 
     <dependencyManagement>

--- a/sentinel-adapter/sentinel-apache-dubbo-springboot/pom.xml
+++ b/sentinel-adapter/sentinel-apache-dubbo-springboot/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sentinel-adapter</artifactId>
+        <groupId>com.alibaba.csp</groupId>
+        <version>1.7.2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>sentinel-apache-dubbo-springboot</artifactId>
+    <packaging>pom</packaging>
+
+    <properties>
+        <springboot.starter.version>2.1.1.RELEASE</springboot.starter.version>
+        <dubbo.springboot.starter>2.7.3</dubbo.springboot.starter>
+        <java.source.version>1.8</java.source.version>
+        <java.target.version>1.8</java.target.version>
+    </properties>
+
+    <modules>
+        <module>sentinel-apache-dubbo-spring-boot-autoconfigure</module>
+        <module>sentinel-apache-dubbo-spring-boot-starter</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.dubbo</groupId>
+                <artifactId>dubbo-spring-boot-autoconfigure</artifactId>
+                <version>${dubbo.springboot.starter}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter</artifactId>
+                <version>${springboot.starter.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.alibaba.csp</groupId>
+                <artifactId>sentinel-apache-dubbo-spring-boot-autoconfigure</artifactId>
+                <version>${project.parent.version}</version>
+            </dependency>
+
+            <!-- Sentinel -->
+            <dependency>
+                <groupId>com.alibaba.csp</groupId>
+                <artifactId>sentinel-apache-dubbo-adapter</artifactId>
+                <version>${project.parent.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.alibaba.csp</groupId>
+                <artifactId>sentinel-core</artifactId>
+                <version>${project.parent.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/pom.xml
+++ b/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sentinel-apache-dubbo-springboot</artifactId>
+        <groupId>com.alibaba.csp</groupId>
+        <version>1.7.2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>sentinel-apache-dubbo-spring-boot-autoconfigure</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-spring-boot-autoconfigure</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-context</artifactId>
+                </exclusion>
+            </exclusions>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-apache-dubbo-adapter</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>${springboot.starter.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/csp/sentinel/dubbo/springboot/annotation/DegradeRuleDefine.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/csp/sentinel/dubbo/springboot/annotation/DegradeRuleDefine.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dubbo.springboot.annotation;
+
+import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD,ElementType.TYPE})
+@Inherited
+@Documented
+@Rule
+public @interface DegradeRuleDefine {
+    String timeWindow() default "10"; // seconds
+    String count() default "500";
+    String app() default "default";
+    int grade() default RuleConstant.DEGRADE_GRADE_RT;
+}

--- a/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/csp/sentinel/dubbo/springboot/annotation/FallbackHandler.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/csp/sentinel/dubbo/springboot/annotation/FallbackHandler.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dubbo.springboot.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD,ElementType.TYPE})
+@Inherited
+@Documented
+public @interface FallbackHandler {
+    Class<?> fallbackClass() default void.class;
+}

--- a/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/csp/sentinel/dubbo/springboot/annotation/FlowRuleDefine.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/csp/sentinel/dubbo/springboot/annotation/FlowRuleDefine.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dubbo.springboot.annotation;
+
+import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD,ElementType.TYPE,ElementType.FIELD})
+@Inherited
+@Documented
+@Rule
+public @interface FlowRuleDefine {
+    String count() default "4000";
+    String app() default "default";
+    int grade() default RuleConstant.FLOW_GRADE_QPS;
+    int behavior() default RuleConstant.CONTROL_BEHAVIOR_DEFAULT;
+}

--- a/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/csp/sentinel/dubbo/springboot/annotation/RateLimitFlowRuleDefine.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/csp/sentinel/dubbo/springboot/annotation/RateLimitFlowRuleDefine.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dubbo.springboot.annotation;
+
+import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD,ElementType.TYPE})
+@Inherited
+@Documented
+@Rule
+public @interface RateLimitFlowRuleDefine {
+    String count() default "4000";
+    String app() default "default";
+    String rateLimit() default "500";
+    int grade() default RuleConstant.FLOW_GRADE_QPS;
+}

--- a/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/csp/sentinel/dubbo/springboot/annotation/Rule.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/csp/sentinel/dubbo/springboot/annotation/Rule.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dubbo.springboot.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Target({ElementType.METHOD,ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+public @interface Rule {
+}

--- a/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/csp/sentinel/dubbo/springboot/annotation/WarmUpFlowRuleDefine.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/csp/sentinel/dubbo/springboot/annotation/WarmUpFlowRuleDefine.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dubbo.springboot.annotation;
+
+import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD,ElementType.TYPE})
+@Inherited
+@Documented
+@Rule
+public @interface WarmUpFlowRuleDefine {
+    String count() default "4000";
+    String app() default "default";
+    String warmUpPeriodSec() default "10";
+    String rateLimit() default "";
+    int grade() default RuleConstant.FLOW_GRADE_QPS;
+}

--- a/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/csp/sentinel/dubbo/springboot/configuration/FallbackManager.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/csp/sentinel/dubbo/springboot/configuration/FallbackManager.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dubbo.springboot.configuration;
+
+import com.alibaba.csp.sentinel.adapter.dubbo.DubboUtils;
+import com.alibaba.csp.sentinel.adapter.dubbo.config.DubboConfig;
+import com.alibaba.csp.sentinel.adapter.dubbo.fallback.DubboFallback;
+import com.alibaba.csp.sentinel.dubbo.springboot.utils.ResourceUtils;
+import com.alibaba.csp.sentinel.slots.block.BlockException;
+import org.apache.dubbo.rpc.AsyncRpcResult;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.Result;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+/**
+ * @author zhengzechao
+ * @date 2020-02-15
+ */
+
+public class FallbackManager implements DubboFallback {
+
+    /**
+     * methodResourceName -> fallback method
+     */
+    private Map<String, Method> fallbackMethod = new ConcurrentHashMap<>();
+    /**
+     * Cached data for fallback impl supplier, keyed by interface resourcenames.
+     */
+    private Map<String, FallbackImplSupplier> fallbackImplMap = new ConcurrentHashMap<>();
+
+    @Override
+    public Result handle(Invoker<?> invoker, Invocation invocation, BlockException ex) {
+        String methodResourceName = DubboUtils.getResourceName(invoker, invocation, DubboConfig.getDubboProviderPrefix());
+        String interfaceResourceName = ResourceUtils.getInterfaceResourceName(invoker.getUrl());
+        FallbackImplSupplier fallbackImplSupplier = fallbackImplMap.get(interfaceResourceName);
+        Method method = fallbackMethod.get(methodResourceName);
+        try {
+            return AsyncRpcResult.newDefaultAsyncResult(method.invoke(fallbackImplSupplier.get(), invocation.getArguments()), invocation);
+        } catch (Exception e) {
+            return AsyncRpcResult.newDefaultAsyncResult(new IllegalStateException("Failed to trigger fallback method!", e), invocation);
+        }
+    }
+
+    void setFallbackMethod(String resource, Method method) {
+        fallbackMethod.put(resource, method);
+    }
+
+    void setFallbackImpl(String key, FallbackImplSupplier fallbackImplSupplier) {
+        fallbackImplMap.put(key, fallbackImplSupplier);
+    }
+
+    public Map<String, Method> getFallbackMethod() {
+        return fallbackMethod;
+    }
+
+    public Map<String, FallbackImplSupplier> getFallbackImplMap() {
+        return fallbackImplMap;
+    }
+
+    static class FallbackImplSupplier implements Supplier<Object> {
+
+        /**
+         * the actual fallback implementation
+         */
+        private volatile Object actual;
+
+        /**
+         * the delegated supplier to get the actual fallback implementation
+         */
+        private Supplier delegate;
+
+        FallbackImplSupplier(Supplier delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Object get() {
+            if (actual == null) {
+                synchronized (this) {
+                    if (actual == null) {
+                        actual = delegate.get();
+                    }
+                }
+            }
+            return actual;
+        }
+    }
+}

--- a/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/csp/sentinel/dubbo/springboot/configuration/SentinelAutoConfiguration.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/csp/sentinel/dubbo/springboot/configuration/SentinelAutoConfiguration.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dubbo.springboot.configuration;
+
+import com.alibaba.csp.sentinel.adapter.dubbo.BaseSentinelDubboFilter;
+import com.alibaba.csp.sentinel.config.SentinelConfig;
+import org.apache.dubbo.spring.boot.autoconfigure.DubboAutoConfiguration;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author zhengzechao
+ * @date 2020-02-15
+ */
+
+@Configuration
+@ConditionalOnClass(value = {BaseSentinelDubboFilter.class, SentinelConfig.class})
+@AutoConfigureAfter(value = DubboAutoConfiguration.class)
+public class SentinelAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(name = "providerFallbackManager")
+    public FallbackManager providerFallbackManager() {
+        return new FallbackManager();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(name = "consumerFallbackManager")
+    public FallbackManager consumerFallbackManager() {
+        return new FallbackManager();
+    }
+
+    @Bean
+    public SentinelServiceBeanPostProcessor sentinelServiceBeanPostProcessor(@Qualifier("providerFallbackManager") FallbackManager providerFallbackManager
+            , @Qualifier("consumerFallbackManager") FallbackManager consumerFallbackManager) {
+        return new SentinelServiceBeanPostProcessor(providerFallbackManager, consumerFallbackManager);
+    }
+
+}

--- a/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/csp/sentinel/dubbo/springboot/configuration/SentinelServiceBeanPostProcessor.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/csp/sentinel/dubbo/springboot/configuration/SentinelServiceBeanPostProcessor.java
@@ -1,0 +1,442 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dubbo.springboot.configuration;
+
+import com.alibaba.csp.sentinel.adapter.dubbo.config.DubboConfig;
+import com.alibaba.csp.sentinel.adapter.dubbo.fallback.DubboFallbackRegistry;
+import com.alibaba.csp.sentinel.dubbo.springboot.annotation.DegradeRuleDefine;
+import com.alibaba.csp.sentinel.dubbo.springboot.annotation.FallbackHandler;
+import com.alibaba.csp.sentinel.dubbo.springboot.annotation.FlowRuleDefine;
+import com.alibaba.csp.sentinel.dubbo.springboot.annotation.RateLimitFlowRuleDefine;
+import com.alibaba.csp.sentinel.dubbo.springboot.annotation.WarmUpFlowRuleDefine;
+import com.alibaba.csp.sentinel.dubbo.springboot.utils.ConstStrings;
+import com.alibaba.csp.sentinel.dubbo.springboot.utils.ResourceUtils;
+import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRule;
+import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRuleManager;
+import com.alibaba.csp.sentinel.slots.block.flow.FlowRule;
+import com.alibaba.csp.sentinel.slots.block.flow.FlowRuleManager;
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.config.annotation.Reference;
+import org.apache.dubbo.config.annotation.Service;
+import org.apache.dubbo.config.spring.ServiceBean;
+import org.apache.dubbo.rpc.service.GenericService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.MutablePropertyValues;
+import org.springframework.beans.PropertyValue;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.config.RuntimeBeanReference;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.annotation.ScannedGenericBeanDefinition;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.env.Environment;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.INTERFACE_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.VERSION_KEY;
+
+
+/**
+ * @author zhengzechao
+ * @date 2020-02-15
+ *
+ * {@link BeanDefinitionRegistryPostProcessor Bean Definition Registry Post Processor}
+ * The role of this SentinelServiceBeanPostProcessor is to process all Class annotated with
+ * {@link com.alibaba.csp.sentinel.dubbo.springboot.annotation.Rule @Rule}
+ * (i.e., a class annotated with
+ * {@link com.alibaba.csp.sentinel.dubbo.springboot.annotation.DegradeRuleDefine @DegradeRuleDefine},
+ * {@link com.alibaba.csp.sentinel.dubbo.springboot.annotation.FlowRuleDefine @FlowRuleDefine},
+ * {@link com.alibaba.csp.sentinel.dubbo.springboot.annotation.RateLimitFlowRuleDefine @RateLimitFlowRuleDefine}
+ * {@link com.alibaba.csp.sentinel.dubbo.springboot.annotation.WarmUpFlowRuleDefine @WarmUpFlowRuleDefine}, etc.)
+ * and convert them to the corresponding rules of Sentinel Rule API. And also handle the annotation
+ * {@link com.alibaba.csp.sentinel.dubbo.springboot.annotation.FallbackHandler @FallbackHandler} and register to
+ * {@link FallbackManager}
+ *
+ */
+
+public class SentinelServiceBeanPostProcessor implements BeanDefinitionRegistryPostProcessor, ApplicationContextAware {
+
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SentinelServiceBeanPostProcessor.class);
+
+
+    // @VisibleForTesting
+    FallbackManager providerFallbackManager;
+    // @VisibleForTesting
+    FallbackManager consumerFallbackManager;
+    // @VisibleForTesting
+    List<FlowRule> flowRules = new ArrayList<FlowRule>();
+    // @VisibleForTesting
+    List<DegradeRule> degradeRules = new ArrayList<DegradeRule>();
+
+    private Environment environment;
+    private EvaluationContext context;
+    private SpelExpressionParser parser = new SpelExpressionParser();
+
+
+    public SentinelServiceBeanPostProcessor(FallbackManager providerFallbackManager, FallbackManager consumerFallbackManager) {
+        this.providerFallbackManager = providerFallbackManager;
+        this.consumerFallbackManager = consumerFallbackManager;
+    }
+
+    @Override
+    public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
+        // NO OP
+    }
+
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+        processService(beanFactory);
+        processReference(beanFactory);
+        // register rules and set fallback factory
+        finishSentinelInitialize();
+    }
+
+
+    /**
+     * process all @Service class
+     *
+     * @param beanFactory
+     */
+    public void processService(ConfigurableListableBeanFactory beanFactory) {
+        String[] beanNamesForType = beanFactory.getBeanNamesForType(ServiceBean.class);
+        for (String beanName : beanNamesForType) {
+            BeanDefinition beanDefinition = beanFactory.getBeanDefinition(beanName);
+            MutablePropertyValues propertyValues = beanDefinition.getPropertyValues();
+
+            PropertyValue ref = propertyValues.getPropertyValue("ref");
+
+            // "ref" beanName is linking to the acutual Service bean in BeanFactory,
+            // and the "interface" PropertyValue is linking to the Service Interface class name
+            String serviceImplBdName = ((RuntimeBeanReference) ref.getValue()).getBeanName();
+            BeanDefinition serviceImplBd = beanFactory.getBeanDefinition(serviceImplBdName);
+            PropertyValue interfacePv = propertyValues.getPropertyValue("interface");
+            String interfaceClassName = (String) interfacePv.getValue();
+            Class interfaceClazz = null;
+
+            try {
+                // resolve interface class by BeanClassLoader
+                ((ScannedGenericBeanDefinition) serviceImplBd).resolveBeanClass(beanFactory.getBeanClassLoader());
+                interfaceClazz = ClassUtils.resolveClassName(interfaceClassName, beanFactory.getBeanClassLoader());
+            } catch (ClassNotFoundException e) {
+                throw new IllegalStateException("PostProcessBeanFactory failed because can't resolve class by ClassLoader: "
+                        + beanFactory.getBeanClassLoader(), e);
+            }
+
+            Class<?> serviceImplBeanClass = ((ScannedGenericBeanDefinition) serviceImplBd).getBeanClass();
+
+            Service serviceAnno = AnnotationUtils.findAnnotation(serviceImplBeanClass, Service.class);
+            beanDefinition.getPropertyValues().getPropertyValue("interface");
+
+            if (serviceAnno != null) {
+                String group = serviceAnno.group();
+                String version = serviceAnno.version();
+                FallbackHandler fallbackHandler = serviceImplBeanClass.getAnnotation(FallbackHandler.class);
+                processFallback(beanFactory, fallbackHandler, interfaceClazz, group, version, providerFallbackManager);
+                assembleRules(serviceImplBeanClass, interfaceClazz, group, version);
+            }
+
+        }
+    }
+
+    /**
+     * Initially, we will support only Rule in interface level. In the future, we may add support for Rule in method level.
+     */
+    void assembleRules(Object obj, Class interfaceClass, String group, String version) {
+        URL url = new URL(null, null, 0).addParameters(INTERFACE_KEY, interfaceClass.getName(), GROUP_KEY, group, VERSION_KEY, version);
+        String serviceInterface = url.getServiceInterface();
+        boolean foundFlowRule = false;
+        FlowRuleDefine flowDef = getAnnotation(obj, FlowRuleDefine.class);
+        if (flowDef != null) {
+            loadFlowRule(flowDef, ResourceUtils.getInterfaceResourceName(url), serviceInterface, "");
+            foundFlowRule = true;
+        }
+
+        WarmUpFlowRuleDefine warmDef = getAnnotation(obj, WarmUpFlowRuleDefine.class);
+        if (warmDef != null) {
+            loadWarmupFlowRule(warmDef, ResourceUtils.getInterfaceResourceName(url), serviceInterface, "");
+            foundFlowRule = true;
+        }
+
+        RateLimitFlowRuleDefine rateDef = getAnnotation(obj, RateLimitFlowRuleDefine.class);
+        if (rateDef != null) {
+            loadRateLimitFlowRule(rateDef, ResourceUtils.getInterfaceResourceName(url), serviceInterface, "");
+            foundFlowRule = true;
+        }
+
+        if (!foundFlowRule) {
+            LOGGER.warn("SENTINEL   FLOW  ==> not found @FlowRuleDefine at [{}.{}], remove `blockHandler` or add @FlowRuleDefine", serviceInterface, "");
+        }
+
+        DegradeRuleDefine degradeDef = getAnnotation(obj, DegradeRuleDefine.class);
+        if (degradeDef != null) {
+            loadDegradeRule(degradeDef, ResourceUtils.getInterfaceResourceName(url), url.getServiceInterface(), "");
+        } else {
+            LOGGER.warn("SENTINEL DEGRADE ==> not found @DegradeRuleDefine at [{}.{}], remove `fallback` or add @DegradeRuleDefine", serviceInterface, "");
+        }
+    }
+
+
+    <T extends Annotation> T getAnnotation(Object obj, Class<T> annotationClass) {
+        if (obj instanceof Field) {
+            Annotation declaredAnnotation = ((Field) obj).getDeclaredAnnotation(annotationClass);
+            return (T) declaredAnnotation;
+        }
+        return (T) ((Class) obj).getDeclaredAnnotation(annotationClass);
+
+    }
+
+    void processReference(ConfigurableListableBeanFactory beanFactory) {
+
+        for (String beanDefinitionName : beanFactory.getBeanDefinitionNames()) {
+            BeanDefinition beanDefinition = beanFactory.getBeanDefinition(beanDefinitionName);
+            String beanClassName = beanDefinition.getBeanClassName();
+            Class targetClass = null;
+
+            // The target class has not been resolved, try to resolve it
+            if (!((AbstractBeanDefinition) beanDefinition).hasBeanClass()) {
+                // Maybe it's a factory bean with @Bean annotation
+                if (beanClassName == null) {
+                    if (beanDefinition instanceof AnnotatedBeanDefinition) {
+                        beanClassName = ((AnnotatedBeanDefinition) beanDefinition).getFactoryMethodMetadata().getReturnTypeName();
+                    }
+                }
+                if (beanClassName != null) {
+                    try {
+                        targetClass = ClassUtils.resolveClassName(beanClassName, beanFactory.getBeanClassLoader());
+                    } catch (Throwable e) {
+                        LOGGER.info("Can't resolve class by ClassLoader: " + beanFactory.getBeanClassLoader(), e);
+                    }
+                }
+            } else {
+                targetClass = ((AbstractBeanDefinition) beanDefinition).getBeanClass();
+            }
+
+            // If there is still no way to resolve, discard it
+            if (targetClass == null) {
+                continue;
+            }
+
+            ReflectionUtils.doWithFields(targetClass
+                    , field -> processReferenceField(beanFactory, field)
+                    , field -> field.getDeclaredAnnotation(Reference.class) != null);
+        }
+
+    }
+
+    public void processReferenceField(ConfigurableListableBeanFactory beanFactory, Field field) {
+        Class<?> referenceInterfaceClass = field.getType();
+        FallbackHandler fallbackHandler = field.getDeclaredAnnotation(FallbackHandler.class);
+        Reference reference = field.getDeclaredAnnotation(Reference.class);
+        // generic reference should be ignored
+        if (reference.generic() && GenericService.class.equals(referenceInterfaceClass)) {
+            return;
+        }
+        processFallback(beanFactory, fallbackHandler, referenceInterfaceClass, reference.group(), reference.version(), consumerFallbackManager);
+        assembleRules(field, field.getType(), reference.group(), reference.version());
+    }
+
+
+    public void processFallback(BeanFactory beanFactory,
+                                FallbackHandler fallbackHandler,
+                                Class interfaceClazz, String group,
+                                String version, FallbackManager consumerFallbackManager) {
+        if (fallbackHandler != null) {
+            Class<?> clazz = fallbackHandler.fallbackClass();
+
+            // the fallback class must inherit the interfaceClass
+            if (!clazz.isAssignableFrom(interfaceClazz)) {
+            }
+            URL url = new URL(null, null, 0).addParameters(INTERFACE_KEY, interfaceClazz.getName(), GROUP_KEY, group, VERSION_KEY, version);
+
+            String key = ResourceUtils.getInterfaceResourceName(url);
+            // fallback bean should be lazy-init by Supplier after all BeanPostProcessors have initialized
+            consumerFallbackManager.setFallbackImpl(key, new FallbackManager.FallbackImplSupplier(() -> beanFactory.getBean(clazz)));
+
+            // ignore superclass's methods and non-public methods
+            Arrays.stream(clazz.getDeclaredMethods())
+                    .filter(method -> Modifier.isPublic(method.getModifiers()))
+                    .forEach(method -> {
+                        String resourceName = ResourceUtils.getResourceName(url, method.getName(), method.getParameterTypes(),
+                                DubboConfig.getDubboInterfaceGroupAndVersionEnabled(), DubboConfig.getDubboProviderPrefix());
+                        consumerFallbackManager.setFallbackMethod(resourceName, method);
+                    });
+        }
+    }
+
+
+    private void loadRateLimitFlowRule(RateLimitFlowRuleDefine flowDef, String resource, String className, String
+            methodName) {
+        FlowRule rule = new FlowRule();
+        rule.setResource(resource);
+        rule.setCount(getDouble(flowDef.count()));
+        rule.setGrade(flowDef.grade());
+        rule.setLimitApp(flowDef.app());
+        rule.setControlBehavior(RuleConstant.CONTROL_BEHAVIOR_RATE_LIMITER);
+        rule.setMaxQueueingTimeMs(getInt(flowDef.rateLimit()));
+
+        flowRules.add(rule);
+
+        LOGGER.info("SENTINEL RateLimit FLOW  ==> resource \"{}\" on METHOD: ({}.{}), rule: <grade:{}, count:{}, maxQueueTimeMS:{}, behavior:{}>",
+                resource, className, methodName,
+                ConstStrings.flowGradeString(rule.getGrade()), rule.getCount(), rule.getMaxQueueingTimeMs(),
+                ConstStrings.behaviorGradeString(rule.getControlBehavior()));
+    }
+
+    private void loadWarmupFlowRule(WarmUpFlowRuleDefine flowDef, String resource, String className, String
+            methodName) {
+        FlowRule rule = new FlowRule();
+        rule.setResource(resource);
+        rule.setCount(getDouble(flowDef.count()));
+        rule.setGrade(flowDef.grade());
+        rule.setWarmUpPeriodSec(getInt(flowDef.warmUpPeriodSec()));
+        rule.setLimitApp(flowDef.app());
+        if (!flowDef.rateLimit().isEmpty()) {
+            rule.setControlBehavior(RuleConstant.CONTROL_BEHAVIOR_WARM_UP_RATE_LIMITER);
+            rule.setMaxQueueingTimeMs(getInt(flowDef.rateLimit()));
+            LOGGER.info("SENTINEL WarmUp FLOW  ==> resource \"{}\" on METHOD: ({}.{}), rule: <grade:{}, count:{}, WarmUpPeriodSec:{}, maxQueueTimeMS:{} behavior:{}>",
+                    resource, className, methodName,
+                    ConstStrings.flowGradeString(flowDef.grade()), rule.getCount(), rule.getWarmUpPeriodSec(), rule.getMaxQueueingTimeMs(),
+                    ConstStrings.behaviorGradeString(rule.getControlBehavior()));
+
+        } else {
+            rule.setControlBehavior(RuleConstant.CONTROL_BEHAVIOR_WARM_UP);
+            LOGGER.info("SENTINEL WarmUp FLOW  ==> resource \"{}\" on METHOD: ({}.{}), rule: <grade:{}, count:{}, WarmUpPeriodSec:{}, behavior:{}>",
+                    resource, className, methodName,
+                    ConstStrings.flowGradeString(flowDef.grade()), rule.getCount(), rule.getWarmUpPeriodSec(),
+                    ConstStrings.behaviorGradeString(rule.getControlBehavior()));
+        }
+
+        flowRules.add(rule);
+
+    }
+
+    private void loadFlowRule(FlowRuleDefine flowDef, String resource, String className, String methodName) {
+        FlowRule rule = new FlowRule();
+        rule.setResource(resource);
+        rule.setCount(getDouble(flowDef.count()));
+        rule.setGrade(flowDef.grade());
+        rule.setControlBehavior(flowDef.behavior());
+        rule.setLimitApp(flowDef.app());
+        flowRules.add(rule);
+        LOGGER.info("SENTINEL   FLOW  ==> resource \"{}\" on METHOD: ({}.{}), rule: <grade:{}, count:{}, behavior:{}>",
+                resource, className, methodName,
+                ConstStrings.flowGradeString(flowDef.grade()), rule.getCount(),
+                ConstStrings.behaviorGradeString(flowDef.behavior()));
+    }
+
+    private void loadDegradeRule(DegradeRuleDefine degradeDef, String resource, String className, String methodName) {
+        DegradeRule rule = new DegradeRule();
+        rule.setResource(resource);
+        rule.setCount(getDouble(degradeDef.count()));
+        rule.setGrade(degradeDef.grade());
+        rule.setTimeWindow(getInt(degradeDef.timeWindow()));
+        rule.setLimitApp(degradeDef.app());
+        degradeRules.add(rule);
+        LOGGER.info("SENTINEL DEGRADE ==> resource \"{}\" on METHOD: ({}.{}), rule: <grade:{}, count:{}, timeWindow:{}(s)>",
+                resource, className, methodName,
+                ConstStrings.degradeGradeString(degradeDef.grade()),
+                rule.getCount(), rule.getTimeWindow());
+    }
+
+    public void finishSentinelInitialize() {
+        LOGGER.info("SENTINEL         ==> load {} flow rules", flowRules.size());
+        FlowRuleManager.loadRules(flowRules);
+        LOGGER.info("SENTINEL         ==> load {} degrade rules", degradeRules.size());
+        DegradeRuleManager.loadRules(degradeRules);
+
+        DubboFallbackRegistry.setProviderFallback(providerFallbackManager);
+        DubboFallbackRegistry.setConsumerFallback(consumerFallbackManager);
+
+    }
+
+    public String parserSPEL(String expr) {
+        String key;
+        if (expr.charAt(1) == '{') {
+            // ${xxx} format
+            key = expr.substring(2, expr.length() - 1);
+        } else {
+            // $xxx format
+            key = expr.substring(1);
+        }
+
+        return parser.parseExpression(key).getValue(context, String.class);
+    }
+
+    public String readProperty(String expr) {
+        String key;
+        if (expr.charAt(1) == '{') {
+            // ${xxx} format
+            key = expr.substring(2, expr.length() - 1);
+        } else {
+            // $xxx format
+            key = expr.substring(1);
+        }
+
+        return environment.getProperty(key);
+    }
+
+    String getProperty(String expr) {
+        expr = expr.trim();
+        if (expr.isEmpty()) {
+            return expr;
+        }
+
+        switch (expr.charAt(0)) {
+            case '#':
+                return parserSPEL(expr);
+            case '$':
+                return readProperty(expr);
+            default:
+                return expr;
+        }
+    }
+
+    double getDouble(String expr) {
+        return Double.parseDouble(getProperty(expr));
+    }
+
+    int getInt(String expr) {
+        return Integer.parseInt(getProperty(expr));
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        environment = applicationContext.getEnvironment();
+        context = new StandardEvaluationContext(environment);
+    }
+}

--- a/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/csp/sentinel/dubbo/springboot/utils/ConstStrings.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/csp/sentinel/dubbo/springboot/utils/ConstStrings.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dubbo.springboot.utils;
+
+public class ConstStrings {
+    public static String flowGradeString(int grade) {
+        switch (grade) {
+            case 0: return "FLOW_GRADE_THREAD";
+            case 1: return "FLOW_GRADE_QPS";
+            default: return "unknown flow grade";
+        }
+    }
+
+    public static String degradeGradeString(int grade) {
+        switch (grade) {
+            case 0: return "DEGRADE_GRADE_RT";
+            case 1: return "DEGRADE_GRADE_EXCEPTION_RATIO";
+            case 2: return "DEGRADE_GRADE_EXCEPTION_COUNT";
+            default: return "unknown degrade grade";
+        }
+    }
+
+    public static String behaviorGradeString(int behavior) {
+        switch (behavior) {
+            case 0: return "CONTROL_BEHAVIOR_DEFAULT";
+            case 1: return "CONTROL_BEHAVIOR_WARM_UP";
+            case 2: return "CONTROL_BEHAVIOR_RATE_LIMITER";
+            case 3: return "CONTROL_BEHAVIOR_WARM_UP_RATE_LIMITER";
+            default: return "unknown behavior grade";
+        }
+    }
+}

--- a/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/csp/sentinel/dubbo/springboot/utils/ResourceUtils.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/csp/sentinel/dubbo/springboot/utils/ResourceUtils.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dubbo.springboot.utils;
+
+import com.alibaba.csp.sentinel.adapter.dubbo.config.DubboConfig;
+import com.alibaba.csp.sentinel.util.StringUtil;
+import org.apache.dubbo.common.URL;
+
+
+public class ResourceUtils {
+    private static String getResourceName(URL url, String methodName, Class<?>[] parameterTypes, Boolean useGroupAndVersion) {
+        StringBuilder buf = new StringBuilder(64);
+        String interfaceResource = useGroupAndVersion ? url.getColonSeparatedKey() : url.getServiceInterface();
+        buf.append(interfaceResource)
+                .append(":")
+                .append(methodName)
+                .append("(");
+        boolean isFirst = true;
+        for (Class<?> clazz : parameterTypes) {
+            if (!isFirst) {
+                buf.append(",");
+            }
+            buf.append(clazz.getName());
+            isFirst = false;
+        }
+        buf.append(")");
+        return buf.toString();
+    }
+
+    public static String getResourceName(URL url, String methodName, Class<?>[] parameterTypes, Boolean useGroupAndVersion, String prefix) {
+        if (StringUtil.isNotBlank(prefix)) {
+            return new StringBuilder(64)
+                    .append(prefix)
+                    .append(getResourceName(url, methodName, parameterTypes, useGroupAndVersion))
+                    .toString();
+        } else {
+            return getResourceName(url, methodName, parameterTypes, useGroupAndVersion);
+        }
+    }
+
+
+    public static String getInterfaceResourceName(URL url) {
+        return DubboConfig.getDubboInterfaceGroupAndVersionEnabled() ? url.getColonSeparatedKey()
+                : url.getServiceInterface();
+    }
+}

--- a/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+com.alibaba.csp.sentinel.dubbo.springboot.configuration.SentinelAutoConfiguration

--- a/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/test/java/com/alibaba/csp/sentinel/dubbo/springboot/api/DemoService.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/test/java/com/alibaba/csp/sentinel/dubbo/springboot/api/DemoService.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dubbo.springboot.api;
+
+
+public interface DemoService {
+    String test();
+}

--- a/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/test/java/com/alibaba/csp/sentinel/dubbo/springboot/api/impl/DemoServiceFallback.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/test/java/com/alibaba/csp/sentinel/dubbo/springboot/api/impl/DemoServiceFallback.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dubbo.springboot.api.impl;
+
+import com.alibaba.csp.sentinel.dubbo.springboot.api.DemoService;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class DemoServiceFallback implements DemoService {
+    @Override
+    public String test() {
+        return "fallback";
+    }
+}

--- a/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/test/java/com/alibaba/csp/sentinel/dubbo/springboot/api/impl/DemoServiceImpl.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/test/java/com/alibaba/csp/sentinel/dubbo/springboot/api/impl/DemoServiceImpl.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dubbo.springboot.api.impl;
+
+import com.alibaba.csp.sentinel.dubbo.springboot.annotation.DegradeRuleDefine;
+import com.alibaba.csp.sentinel.dubbo.springboot.annotation.FallbackHandler;
+import com.alibaba.csp.sentinel.dubbo.springboot.annotation.FlowRuleDefine;
+import com.alibaba.csp.sentinel.dubbo.springboot.api.DemoService;
+import org.apache.dubbo.config.annotation.Service;
+
+
+@Service
+@FallbackHandler(fallbackClass = DemoServiceFallback.class)
+@FlowRuleDefine(count = "${flow.count}")
+@DegradeRuleDefine
+public class DemoServiceImpl implements DemoService {
+    @Override
+    public String test() {
+        return "test";
+    }
+}

--- a/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/test/java/com/alibaba/csp/sentinel/dubbo/springboot/api/impl/TestClient.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/test/java/com/alibaba/csp/sentinel/dubbo/springboot/api/impl/TestClient.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dubbo.springboot.api.impl;
+
+import com.alibaba.csp.sentinel.dubbo.springboot.annotation.FallbackHandler;
+import com.alibaba.csp.sentinel.dubbo.springboot.annotation.FlowRuleDefine;
+import com.alibaba.csp.sentinel.dubbo.springboot.api.DemoService;
+import org.apache.dubbo.config.annotation.Reference;
+
+
+public class TestClient {
+    @Reference
+    @FlowRuleDefine
+    @FallbackHandler(fallbackClass = DemoServiceFallback.class)
+    private DemoService demoService;
+}

--- a/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/test/java/com/alibaba/csp/sentinel/dubbo/springboot/configuration/FallbackManagerTest.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/test/java/com/alibaba/csp/sentinel/dubbo/springboot/configuration/FallbackManagerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dubbo.springboot.configuration;
+
+import com.alibaba.csp.sentinel.dubbo.springboot.api.DemoService;
+import com.alibaba.csp.sentinel.dubbo.springboot.api.impl.DemoServiceFallback;
+import com.alibaba.csp.sentinel.dubbo.springboot.utils.ResourceUtils;
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.Result;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class FallbackManagerTest {
+
+    private FallbackManager fallbackManager = new FallbackManager();
+    private URL url = mock(URL.class);
+    private Invoker invoker = mock(Invoker.class);
+    private Invocation invocation = mock(Invocation.class);
+    private Method method;
+
+
+    @Before
+    public void setUp() throws NoSuchMethodException {
+        fallbackManager.getFallbackImplMap().clear();
+        fallbackManager.getFallbackMethod().clear();
+        when(url.getServiceInterface()).thenReturn(DemoService.class.getName());
+        when(invoker.getUrl()).thenReturn(url);
+        when(invoker.getInterface()).thenReturn(DemoService.class);
+        method = DemoServiceFallback.class.getDeclaredMethod("test");
+        when(invocation.getMethodName()).thenReturn(method.getName());
+        when(invocation.getParameterTypes()).thenReturn(method.getParameterTypes());
+    }
+
+
+    @Test
+    public void testHandle() {
+        Result result1 = fallbackManager.handle(invoker, invocation, null);
+        assertTrue(result1.hasException());
+        testSetFallbackMethod();
+        testSetFallbackImpl();
+        Result result2 = fallbackManager.handle(invoker, invocation, null);
+        assertFalse(result2.hasException());
+        assertEquals("fallback", result2.getValue());
+    }
+
+    @Test
+    public void testSetFallbackMethod() {
+        String resourceName = ResourceUtils.getResourceName(url, method.getName(), method.getParameterTypes(), false, "");
+        fallbackManager.setFallbackMethod(resourceName, method);
+        assertEquals(1, fallbackManager.getFallbackMethod().size());
+    }
+
+    @Test
+    public void testSetFallbackImpl() {
+        fallbackManager.setFallbackImpl(ResourceUtils.getInterfaceResourceName(url), new FallbackManager.FallbackImplSupplier(DemoServiceFallback::new));
+        assertEquals(1, fallbackManager.getFallbackImplMap().size());
+    }
+}

--- a/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/test/java/com/alibaba/csp/sentinel/dubbo/springboot/configuration/SentinelAutoConfigurationTest.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/test/java/com/alibaba/csp/sentinel/dubbo/springboot/configuration/SentinelAutoConfigurationTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dubbo.springboot.configuration;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = SentinelAutoConfigurationTest.class)
+@EnableAutoConfiguration
+public class SentinelAutoConfigurationTest {
+    @Autowired
+    private SentinelServiceBeanPostProcessor beanPostProcessor;
+
+    @Test
+    public void test() {
+        assertNotNull(beanPostProcessor);
+    }
+}

--- a/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/test/java/com/alibaba/csp/sentinel/dubbo/springboot/configuration/SentinelServiceBeanPostProcessorTest.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/test/java/com/alibaba/csp/sentinel/dubbo/springboot/configuration/SentinelServiceBeanPostProcessorTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dubbo.springboot.configuration;
+
+import com.alibaba.csp.sentinel.dubbo.springboot.api.impl.TestClient;
+import com.alibaba.csp.sentinel.slots.block.flow.FlowRule;
+import org.apache.dubbo.spring.boot.autoconfigure.DubboAutoConfiguration;
+import org.apache.dubbo.spring.boot.autoconfigure.DubboRelaxedBinding2AutoConfiguration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = {DubboRelaxedBinding2AutoConfiguration.class
+        , SentinelServiceBeanPostProcessorTest.class
+        , DubboAutoConfiguration.class
+        , SentinelAutoConfiguration.class},
+        properties = {"dubbo.scan.base-packages=com.alibaba.csp.sentinel.dubbo.springboot.api.impl", "flow.count=10"})
+@PropertySource(value = "classpath:/dubbo.properties")
+@Configuration
+public class SentinelServiceBeanPostProcessorTest {
+
+
+    @Autowired
+    private ConfigurableListableBeanFactory beanFactory;
+
+    @Bean
+    public TestClient testClient() {
+        return new TestClient();
+    }
+
+
+    @Test
+    public void test() {
+        assertNotNull(beanFactory);
+        SentinelServiceBeanPostProcessor sentinelServiceBeanPostProcessor = beanFactory.getBean(SentinelServiceBeanPostProcessor.class);
+        assertNotNull(sentinelServiceBeanPostProcessor);
+        assertEquals(2, sentinelServiceBeanPostProcessor.flowRules.size());
+        assertEquals(1, sentinelServiceBeanPostProcessor.degradeRules.size());
+
+        FlowRule flowRule = sentinelServiceBeanPostProcessor.flowRules.get(0);
+        assertEquals(10, flowRule.getCount(), 0);
+        assertEquals(1, sentinelServiceBeanPostProcessor.providerFallbackManager.getFallbackMethod().size());
+        assertEquals(1, sentinelServiceBeanPostProcessor.consumerFallbackManager.getFallbackMethod().size());
+    }
+}

--- a/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/test/java/com/alibaba/csp/sentinel/dubbo/springboot/utils/ConstStringsTest.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/test/java/com/alibaba/csp/sentinel/dubbo/springboot/utils/ConstStringsTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dubbo.springboot.utils;
+
+import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class ConstStringsTest {
+
+    @Test
+    public void flowGradeString() {
+        String s = ConstStrings.flowGradeString(RuleConstant.FLOW_GRADE_QPS);
+        assertEquals("FLOW_GRADE_QPS", s);
+    }
+
+    @Test
+    public void degradeGradeString() {
+        String s = ConstStrings.degradeGradeString(RuleConstant.DEGRADE_GRADE_EXCEPTION_RATIO);
+        assertEquals("DEGRADE_GRADE_EXCEPTION_RATIO", s);
+    }
+
+    @Test
+    public void behaviorGradeString() {
+        String s = ConstStrings.behaviorGradeString(RuleConstant.CONTROL_BEHAVIOR_RATE_LIMITER);
+        assertEquals("CONTROL_BEHAVIOR_RATE_LIMITER", s);
+    }
+}

--- a/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/test/java/com/alibaba/csp/sentinel/dubbo/springboot/utils/ResourceUtilsTest.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/test/java/com/alibaba/csp/sentinel/dubbo/springboot/utils/ResourceUtilsTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dubbo.springboot.utils;
+
+import com.alibaba.csp.sentinel.adapter.dubbo.config.DubboConfig;
+import com.alibaba.csp.sentinel.config.SentinelConfig;
+import org.apache.dubbo.common.URL;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class ResourceUtilsTest {
+
+    @Test
+    public void getResourceName() {
+        URL url = mock(URL.class);
+        String interfaceName = "com.alibaba.dubbo.DemoService";
+        String colonSeparatedKey = "com.alibaba.dubbo.DemoService:1.0.0:grp1";
+        when(url.getColonSeparatedKey()).thenReturn(colonSeparatedKey);
+        when(url.getServiceInterface()).thenReturn(interfaceName);
+        String methodName = "test";
+        Class[] classes = new Class[]{Object.class, Integer[].class};
+        String resourceName = ResourceUtils.getResourceName(url, methodName, classes, true, "prefix");
+        assertNotNull(resourceName);
+
+    }
+
+    @Test
+    public void getInterfaceResourceName() {
+        URL url = mock(URL.class);
+        String interfaceName = "com.alibaba.dubbo.DemoService";
+        String colonSeparatedKey = "com.alibaba.dubbo.DemoService:1.0.0:grp1";
+        when(url.getColonSeparatedKey()).thenReturn(colonSeparatedKey);
+        when(url.getServiceInterface()).thenReturn(interfaceName);
+        assertEquals(interfaceName, ResourceUtils.getInterfaceResourceName(url));
+        SentinelConfig.setConfig(DubboConfig.DUBBO_INTERFACE_GROUP_VERSION_ENABLED, "true");
+        assertEquals(colonSeparatedKey, ResourceUtils.getInterfaceResourceName(url));
+    }
+
+}

--- a/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/test/resources/dubbo.properties
+++ b/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-autoconfigure/src/test/resources/dubbo.properties
@@ -1,0 +1,2 @@
+dubbo.application.name=hello
+dubbo.registry.address=N/A

--- a/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-starter/pom.xml
+++ b/sentinel-adapter/sentinel-apache-dubbo-springboot/sentinel-apache-dubbo-spring-boot-starter/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sentinel-apache-dubbo-springboot</artifactId>
+        <groupId>com.alibaba.csp</groupId>
+        <version>1.7.2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>sentinel-apache-dubbo-spring-boot-starter</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-apache-dubbo-spring-boot-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-apache-dubbo-adapter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-spring-boot-autoconfigure</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>


### PR DESCRIPTION


### 背景和目的

1. Sentinel的限流降级配置需要手动编码实现，特别对于Dubbo这种resourceName比较复杂的字符串，配置麻烦并且容易出错。
2. sentinel dubbo adapter目前提供的`FallbackFactory`全局熔断降级使用不够灵活。

### 如何激活使用

通过springboot自动装配的技术，如果当前classpath存在`SentinelConfig`和`BaseSentinelFilter`类存在便会激活。因此需要导入`sentinel-core`与`sentinel-apache-dubbo-adapter`两个jar包。

### 实现方法

通过`BeanRegistryPostProcessor`在Spring容器启动前扫描所有@Service注解的类与@Reference的Field，并对其上的注解进行解析和装配成对应的sentinel rule。

### 提供的注解

提供了多种流控配置注解和降级控制注解,如下

| 注解类                     | 功能          |
| ----------------------- | ----------- |
| FlowRuleDefine          | 默认直接拒绝行为的流控 |
| RateLimitFlowRuleDefine | 限速流控        |
| WarmUpFlowRuleDefine    | 预热和预热限速流控   |
| DegradeRuleDefine       | 降级规则        |
| FallbackHandler         | 降级处理注册      |

### 使用例子

以消费端使用为例：

```java
@Reference(version = "1.0.0")
@FallbackHandler(fallbackClass = DemoServiceFallback.class)
@FlowRuleDefine(count = "5")
private DemoService demoService;
```

FallbackHandler注解指定对应的降级类，其中fallbackClass的类需要托管到Spring容器中，如下

```java
@Component
public class DemoServiceFallback implements DemoService {
    @Override
    public String sayHello(String name) {
        return "fallback";
    }
}

```



### 支持占位符注入

注解中的关键配置数值可以支持占位符注入.例如application.properties包含如下内容

```
my.flow.count=500
```

`@FlowRuleDefine(count = "${my.flow.count}")`