### PR TITLE
Fix NPE in Tracer when context size exceeds the limit (#1184)

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Tracer.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Tracer.java
@@ -17,6 +17,7 @@ package com.alibaba.csp.sentinel;
 
 import com.alibaba.csp.sentinel.context.Context;
 import com.alibaba.csp.sentinel.context.ContextUtil;
+import com.alibaba.csp.sentinel.context.NullContext;
 import com.alibaba.csp.sentinel.metric.extension.MetricExtensionProvider;
 import com.alibaba.csp.sentinel.node.ClusterNode;
 import com.alibaba.csp.sentinel.node.DefaultNode;
@@ -53,17 +54,7 @@ public class Tracer {
      * @param count exception count to add
      */
     public static void trace(Throwable e, int count) {
-        if (!shouldTrace(e)) {
-            return;
-        }
-
-        Context context = ContextUtil.getContext();
-        if (context == null) {
-            return;
-        }
-
-        DefaultNode curNode = (DefaultNode)context.getCurNode();
-        traceExceptionToNode(e, count, context.getCurEntry(), curNode);
+        traceContext(e, count, ContextUtil.getContext());
     }
 
     /**
@@ -77,7 +68,8 @@ public class Tracer {
         if (!shouldTrace(e)) {
             return;
         }
-        if (context == null) {
+
+        if (context == null || context instanceof NullContext) {
             return;
         }
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/context/Context.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/context/Context.java
@@ -109,7 +109,7 @@ public class Context {
     }
 
     public Node getCurNode() {
-        return curEntry.getCurNode();
+        return curEntry == null ? null : curEntry.getCurNode();
     }
 
     public Context setCurNode(Node node) {

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/TracerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/TracerTest.java
@@ -1,5 +1,6 @@
 package com.alibaba.csp.sentinel;
 
+import com.alibaba.csp.sentinel.context.ContextUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -7,6 +8,24 @@ import org.junit.Test;
  * @author Carpenter Lee
  */
 public class TracerTest extends Tracer {
+
+    @Test
+    public void testTraceWhenContextSizeExceedsThreshold() {
+        int i = 0;
+        for (; i < Constants.MAX_CONTEXT_NAME_SIZE; i++) {
+            ContextUtil.enter("test-context-" + i);
+            ContextUtil.exit();
+        }
+
+        try {
+            ContextUtil.enter("test-context-" + i);
+            throw new RuntimeException("test");
+        } catch (Exception e) {
+            Tracer.trace(e);
+        } finally {
+            ContextUtil.exit();
+        }
+    }
 
     @Test
     public void setExceptionsToTrace() {

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/TracerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/TracerTest.java
@@ -1,13 +1,28 @@
 package com.alibaba.csp.sentinel;
 
+import com.alibaba.csp.sentinel.context.ContextTestUtil;
 import com.alibaba.csp.sentinel.context.ContextUtil;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
  * @author Carpenter Lee
  */
 public class TracerTest extends Tracer {
+
+    @Before
+    public void setUp() {
+        ContextTestUtil.cleanUpContext();
+        ContextTestUtil.resetContextMap();
+    }
+
+    @After
+    public void tearDown() {
+        ContextTestUtil.cleanUpContext();
+        ContextTestUtil.resetContextMap();
+    }
 
     @Test
     public void testTraceWhenContextSizeExceedsThreshold() {


### PR DESCRIPTION
### Describe what this PR does / why we need it

When context size exceeds the limit, `Tracer#trace` throws NPE.

### Does this pull request fix one issue?

Fixes #1184

### Describe how you did it

Add checking logic in `Tracer#traceContext` and `Context#getCurNode`.

### Describe how to verify it

Add a test case `TracerTest#testTraceWhenContextSizeExceedsThreshold`.

### Special notes for reviews

`Tracer#trace(Throwable, int)` do a small improvements, 
call `Tracer#traceContext(Throwable, int, Context)` to avoid duplicate code.

