### PR TITLE
Add "web-context-unify" configuration to support "chain" relation flow strategy in Spring webmvc adapter

### DIFF
--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/README.md
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/README.md
@@ -97,6 +97,7 @@ config.setBlockExceptionHandler((request, response, e) -> {
 | urlCleaner | The `UrlCleaner` interface is designed for clean and unify the URL resource. | `UrlCleaner` | - |
 | requestAttributeName | Attribute key in request used by Sentinel (internal) | `String` | `$$sentinel_spring_web_entry_attr` |
 | httpMethodSpecify | Specify whether the URL resource name should contain the HTTP method prefix (e.g. `POST:`). | `boolean` | `false` |
+| webContextUnify | Specify whether unify web context(i.e. use the default context name). | `boolean` | `true` |
 
 - `SentinelWebMvcTotalConfig` configuration:
 

--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/AbstractSentinelInterceptor.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/AbstractSentinelInterceptor.java
@@ -59,7 +59,8 @@ public abstract class AbstractSentinelInterceptor implements HandlerInterceptor 
             if (StringUtil.isNotEmpty(resourceName)) {
                 // Parse the request origin using registered origin parser.
                 String origin = parseOrigin(request);
-                ContextUtil.enter(SENTINEL_SPRING_WEB_CONTEXT_NAME, origin);
+                String contextName = getContextName(request);
+                ContextUtil.enter(contextName, origin);
                 Entry entry = SphU.entry(resourceName, ResourceTypeConstants.COMMON_WEB, EntryType.IN);
 
                 setEntryInRequest(request, baseWebMvcConfig.getRequestAttributeName(), entry);
@@ -78,6 +79,16 @@ public abstract class AbstractSentinelInterceptor implements HandlerInterceptor 
      * @return the resource name of the target web resource.
      */
     protected abstract String getResourceName(HttpServletRequest request);
+
+    /**
+     * Return the context name of the target web resource.
+     *
+     * @param request web request
+     * @return the context name of the target web resource.
+     */
+    protected String getContextName(HttpServletRequest request) {
+        return SENTINEL_SPRING_WEB_CONTEXT_NAME;
+    }
 
     @Override
     public void afterCompletion(HttpServletRequest request, HttpServletResponse response,

--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/SentinelWebInterceptor.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/SentinelWebInterceptor.java
@@ -66,4 +66,12 @@ public class SentinelWebInterceptor extends AbstractSentinelInterceptor {
         return resourceName;
     }
 
+    @Override
+    protected String getContextName(HttpServletRequest request) {
+        if (config.isWebContextUnify()) {
+            return super.getContextName(request);
+        }
+
+        return getResourceName(request);
+    }
 }

--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/config/SentinelWebMvcConfig.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/config/SentinelWebMvcConfig.java
@@ -34,6 +34,11 @@ public class SentinelWebMvcConfig extends BaseWebMvcConfig {
      */
     private boolean httpMethodSpecify;
 
+    /**
+     * Specify whether unify web context(i.e. use the default context name), and is true by default.
+     */
+    private boolean webContextUnify = true;
+
     public SentinelWebMvcConfig() {
         super();
         setRequestAttributeName(DEFAULT_REQUEST_ATTRIBUTE_NAME);
@@ -57,11 +62,21 @@ public class SentinelWebMvcConfig extends BaseWebMvcConfig {
         return this;
     }
 
+    public boolean isWebContextUnify() {
+        return webContextUnify;
+    }
+
+    public SentinelWebMvcConfig setWebContextUnify(boolean webContextUnify) {
+        this.webContextUnify = webContextUnify;
+        return this;
+    }
+
     @Override
     public String toString() {
         return "SentinelWebMvcConfig{" +
             "urlCleaner=" + urlCleaner +
             ", httpMethodSpecify=" + httpMethodSpecify +
+            ", webContextUnify=" + webContextUnify +
             ", requestAttributeName='" + requestAttributeName + '\'' +
             ", blockExceptionHandler=" + blockExceptionHandler +
             ", originParser=" + originParser +

--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/config/SentinelWebMvcConfig.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/config/SentinelWebMvcConfig.java
@@ -29,6 +29,7 @@ public class SentinelWebMvcConfig extends BaseWebMvcConfig {
      * Specify the URL cleaner that unifies the URL resources.
      */
     private UrlCleaner urlCleaner;
+
     /**
      * Specify whether the URL resource name should contain the HTTP method prefix (e.g. {@code POST:}).
      */
@@ -36,6 +37,8 @@ public class SentinelWebMvcConfig extends BaseWebMvcConfig {
 
     /**
      * Specify whether unify web context(i.e. use the default context name), and is true by default.
+     *
+     * @since 1.7.2
      */
     private boolean webContextUnify = true;
 

--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/config/InterceptorConfig.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/config/InterceptorConfig.java
@@ -66,6 +66,7 @@ public class InterceptorConfig implements WebMvcConfigurer {
 
         //Custom configuration if necessary
         config.setHttpMethodSpecify(false);
+        config.setWebContextUnify(true);
         config.setOriginParser(new RequestOriginParser() {
             @Override
             public String parseOrigin(HttpServletRequest request) {

--- a/sentinel-adapter/sentinel-web-servlet/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/CommonFilter.java
+++ b/sentinel-adapter/sentinel-web-servlet/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/CommonFilter.java
@@ -54,7 +54,7 @@ public class CommonFilter implements Filter {
      */
     public static final String HTTP_METHOD_SPECIFY = "HTTP_METHOD_SPECIFY";
     /**
-     * If enabled, use the URL path as the context name, or else use the default
+     * If enabled, use the default context name, or else use the URL path as the context name,
      * {@link WebServletConfig#WEB_SERVLET_CONTEXT_NAME}. Please pay attention to the number of context (EntranceNode),
      * which may affect the memory footprint.
      *

--- a/sentinel-demo/sentinel-demo-spring-webmvc/src/main/java/com/alibaba/csp/sentinel/demo/spring/webmvc/config/InterceptorConfig.java
+++ b/sentinel-demo/sentinel-demo-spring-webmvc/src/main/java/com/alibaba/csp/sentinel/demo/spring/webmvc/config/InterceptorConfig.java
@@ -53,9 +53,12 @@ public class InterceptorConfig implements WebMvcConfigurer {
 
         // Custom configuration if necessary
         config.setHttpMethodSpecify(true);
-        // If set false, entrance contexts will be separated by different URLs,
+        // By default web context is true, means that unify web context(i.e. use the default context name),
+        // in most scenarios that's enough, and it could reduce the memory footprint.
+        // If set it to false, entrance contexts will be separated by different URLs,
         // which is useful to support "chain" relation flow strategy.
-        config.setWebContextUnify(false);
+        // We can change it and view different result in `Resource Chain` menu of dashboard.
+        config.setWebContextUnify(true);
         config.setOriginParser(request -> request.getHeader("S-user"));
 
         // Add sentinel interceptor

--- a/sentinel-demo/sentinel-demo-spring-webmvc/src/main/java/com/alibaba/csp/sentinel/demo/spring/webmvc/config/InterceptorConfig.java
+++ b/sentinel-demo/sentinel-demo-spring-webmvc/src/main/java/com/alibaba/csp/sentinel/demo/spring/webmvc/config/InterceptorConfig.java
@@ -53,6 +53,9 @@ public class InterceptorConfig implements WebMvcConfigurer {
 
         // Custom configuration if necessary
         config.setHttpMethodSpecify(true);
+        // If set false, entrance contexts will be separated by different URLs,
+        // which is useful to support "chain" relation flow strategy.
+        config.setWebContextUnify(false);
         config.setOriginParser(request -> request.getHeader("S-user"));
 
         // Add sentinel interceptor


### PR DESCRIPTION
### Describe what this PR does / why we need it

Add "web-context-unify" configuration in spring webmvc adaptor, the same as web servlet 
adaptor, to support "chain" relation flow strategy.

### Does this pull request fix one issue?

Fixes #1314 

### Describe how you did it

Add a configuration `webContextUnify` in `SentinelWebMvcConfig`, default is true.

Add `getContextName` method in `AbstractSentinelInterceptor`, which use `SENTINEL_SPRING_WEB_CONTEXT_NAME` by default, and subclass can implement their own logic by overriding it.

### Describe how to verify it

Change `config.setWebContextUnify(true);` in demo to false and start the `WebMvcDemoApplication` and dashboard, visit different url and view in `Resource Chain`menu.

Besides, in local test, I add `sentinel-annotation-aspectj` in demo, add a service method marked with `SentienlResource`, the same method called by different url of controller, add "chain" relation flow rule to verify if it works.

### Special notes for reviews

I found that the comment of`WEB_CONTEXT_UNIFY` in `CommonFilter` seems inconsistent,
and fix it.

In `CommonFilter`,  when `webContextUnify` is set to false, the context name is target, which is not with HTTP method prefix if httpMethodSpecify is true. In `SentinelWebInterceptor`, since we have a ancapsulated `getResourceName` method, so to reuse it, the context name is the same as resource name. Maybe it's better than `CommonFilter`. I'm not very sure and didn't modify `CommonFilter`, please review it.