### PR TITLE
Polish placeholders in logging content to slf4j convention

### DIFF
--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/api/GatewayApiDefinitionManager.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/api/GatewayApiDefinitionManager.java
@@ -62,8 +62,8 @@ public final class GatewayApiDefinitionManager {
         List<ApiDefinitionChangeObserver> listeners = SpiLoader.loadInstanceList(ApiDefinitionChangeObserver.class);
         for (ApiDefinitionChangeObserver e : listeners) {
             API_CHANGE_OBSERVERS.put(e.getClass().getCanonicalName(), e);
-            RecordLog.info("[GatewayApiDefinitionManager] ApiDefinitionChangeObserver added: {0}",
-                e.getClass().getCanonicalName());
+            RecordLog.info("[GatewayApiDefinitionManager] ApiDefinitionChangeObserver added: "
+                + e.getClass().getCanonicalName());
         }
     }
 

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/command/UpdateGatewayApiDefinitionGroupCommandHandler.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/command/UpdateGatewayApiDefinitionGroupCommandHandler.java
@@ -56,7 +56,7 @@ public class UpdateGatewayApiDefinitionGroupCommandHandler implements CommandHan
             return CommandResponse.ofFailure(e, "decode gateway API definition data error");
         }
 
-        RecordLog.info("[API Server] Receiving data change (type: gateway API definition): {0}", data);
+        RecordLog.info("[API Server] Receiving data change (type: gateway API definition): {}", data);
 
         String result = SUCCESS_MSG;
 

--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/AbstractSentinelInterceptor.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/AbstractSentinelInterceptor.java
@@ -109,7 +109,7 @@ public abstract class AbstractSentinelInterceptor implements HandlerInterceptor 
     protected void setEntryInRequest(HttpServletRequest request, String name, Entry entry) {
         Object attrVal = request.getAttribute(name);
         if (attrVal != null) {
-            RecordLog.warn("[{}] The attribute key '{0}' already exists in request, please set `requestAttributeName`",
+            RecordLog.warn("[{}] The attribute key '{}' already exists in request, please set `requestAttributeName`",
                 getClass().getSimpleName(), name);
         } else {
             request.setAttribute(name, entry);

--- a/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/codec/DefaultRequestEntityWriter.java
+++ b/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/codec/DefaultRequestEntityWriter.java
@@ -36,7 +36,7 @@ public class DefaultRequestEntityWriter implements RequestEntityWriter<ClusterRe
         EntityWriter<Object, ByteBuf> requestDataWriter = RequestDataWriterRegistry.getWriter(type);
 
         if (requestDataWriter == null) {
-            RecordLog.warn("[DefaultRequestEntityWriter] Cannot find matching request writer for type <{0}>,"
+            RecordLog.warn("[DefaultRequestEntityWriter] Cannot find matching request writer for type <{}>,"
                 + " dropping the request", type);
             return;
         }

--- a/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/codec/DefaultResponseEntityDecoder.java
+++ b/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/codec/DefaultResponseEntityDecoder.java
@@ -47,7 +47,7 @@ public class DefaultResponseEntityDecoder implements ResponseEntityDecoder<ByteB
 
             EntityDecoder<ByteBuf, ?> decoder = ResponseDataDecodeRegistry.getDecoder(type);
             if (decoder == null) {
-                RecordLog.warn("Unknown type of response data decoder: {0}", type);
+                RecordLog.warn("Unknown type of response data decoder: {}", type);
                 return null;
             }
 

--- a/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/handler/TokenClientHandler.java
+++ b/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/handler/TokenClientHandler.java
@@ -76,10 +76,10 @@ public class TokenClientHandler extends ChannelInboundHandlerAdapter {
     private void handlePingResponse(ChannelHandlerContext ctx, ClusterResponse response) {
         if (response.getStatus() == ClusterConstants.RESPONSE_STATUS_OK) {
             int count = (int) response.getData();
-            RecordLog.info("[TokenClientHandler] Client ping OK (target server: {0}, connected count: {1})",
+            RecordLog.info("[TokenClientHandler] Client ping OK (target server: {}, connected count: {})",
                 getRemoteAddress(ctx), count);
         } else {
-            RecordLog.warn("[TokenClientHandler] Client ping failed (target server: {0})", getRemoteAddress(ctx));
+            RecordLog.warn("[TokenClientHandler] Client ping failed (target server: {})", getRemoteAddress(ctx));
         }
     }
 

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/rule/ClusterFlowRuleManager.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/rule/ClusterFlowRuleManager.java
@@ -129,7 +129,7 @@ public final class ClusterFlowRuleManager {
         }
         synchronized (UPDATE_LOCK) {
             RecordLog.info("[ClusterFlowRuleManager] Registering new property to cluster flow rule manager"
-                + " for namespace <{0}>", namespace);
+                + " for namespace <{}>", namespace);
             registerPropertyInternal(namespace, property);
         }
     }
@@ -180,7 +180,7 @@ public final class ClusterFlowRuleManager {
                 PROPERTY_MAP.remove(namespace);
             }
             RecordLog.info("[ClusterFlowRuleManager] Removing property from cluster flow rule manager"
-                + " for namespace <{0}>", namespace);
+                + " for namespace <{}>", namespace);
         }
     }
 
@@ -380,14 +380,14 @@ public final class ClusterFlowRuleManager {
         @Override
         public synchronized void configUpdate(List<FlowRule> conf) {
             applyClusterFlowRule(conf, namespace);
-            RecordLog.info("[ClusterFlowRuleManager] Cluster flow rules received for namespace <{0}>: {1}",
+            RecordLog.info("[ClusterFlowRuleManager] Cluster flow rules received for namespace <{}>: {}",
                 namespace, FLOW_RULES);
         }
 
         @Override
         public synchronized void configLoad(List<FlowRule> conf) {
             applyClusterFlowRule(conf, namespace);
-            RecordLog.info("[ClusterFlowRuleManager] Cluster flow rules loaded for namespace <{0}>: {1}",
+            RecordLog.info("[ClusterFlowRuleManager] Cluster flow rules loaded for namespace <{}>: {}",
                 namespace, FLOW_RULES);
         }
     }

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/rule/ClusterParamFlowRuleManager.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/rule/ClusterParamFlowRuleManager.java
@@ -127,7 +127,7 @@ public final class ClusterParamFlowRuleManager {
         }
         synchronized (UPDATE_LOCK) {
             RecordLog.info("[ClusterParamFlowRuleManager] Registering new property to cluster param rule manager"
-                + " for namespace <{0}>", namespace);
+                + " for namespace <{}>", namespace);
             registerPropertyInternal(namespace, property);
         }
     }
@@ -167,7 +167,7 @@ public final class ClusterParamFlowRuleManager {
                 PROPERTY_MAP.remove(namespace);
             }
             RecordLog.info("[ClusterParamFlowRuleManager] Removing property from cluster flow rule manager"
-                + " for namespace <{0}>", namespace);
+                + " for namespace <{}>", namespace);
         }
     }
 
@@ -303,14 +303,14 @@ public final class ClusterParamFlowRuleManager {
         @Override
         public void configLoad(List<ParamFlowRule> conf) {
             applyClusterParamRules(conf, namespace);
-            RecordLog.info("[ClusterParamFlowRuleManager] Cluster parameter rules loaded for namespace <{0}>: {1}",
+            RecordLog.info("[ClusterParamFlowRuleManager] Cluster parameter rules loaded for namespace <{}>: {}",
                 namespace, PARAM_RULES);
         }
 
         @Override
         public void configUpdate(List<ParamFlowRule> conf) {
             applyClusterParamRules(conf, namespace);
-            RecordLog.info("[ClusterParamFlowRuleManager] Cluster parameter rules received for namespace <{0}>: {1}",
+            RecordLog.info("[ClusterParamFlowRuleManager] Cluster parameter rules received for namespace <{}>: {}",
                 namespace, PARAM_RULES);
         }
     }

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/codec/DefaultRequestEntityDecoder.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/codec/DefaultRequestEntityDecoder.java
@@ -46,7 +46,7 @@ public class DefaultRequestEntityDecoder implements RequestEntityDecoder<ByteBuf
 
             EntityDecoder<ByteBuf, ?> dataDecoder = RequestDataDecodeRegistry.getDecoder(type);
             if (dataDecoder == null) {
-                RecordLog.warn("Unknown type of request data decoder: {0}", type);
+                RecordLog.warn("Unknown type of request data decoder: {}", type);
                 return null;
             }
 

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/codec/DefaultResponseEntityWriter.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/codec/DefaultResponseEntityWriter.java
@@ -38,7 +38,7 @@ public class DefaultResponseEntityWriter implements ResponseEntityWriter<Cluster
 
         if (responseDataWriter == null) {
             writeHead(response.setStatus(ClusterConstants.RESPONSE_STATUS_BAD), out);
-            RecordLog.warn("[NettyResponseEncoder] Cannot find matching writer for type <{0}>", response.getType());
+            RecordLog.warn("[NettyResponseEncoder] Cannot find matching writer for type <{}>", response.getType());
             return;
         }
         writeHead(response, out);

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/command/handler/ModifyClusterFlowRulesCommandHandler.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/command/handler/ModifyClusterFlowRulesCommandHandler.java
@@ -47,7 +47,7 @@ public class ModifyClusterFlowRulesCommandHandler implements CommandHandler<Stri
         }
         try {
             data = URLDecoder.decode(data, "UTF-8");
-            RecordLog.info("[ModifyClusterFlowRulesCommandHandler] Receiving cluster flow rules for namespace <{0}>: {1}", namespace, data);
+            RecordLog.info("[ModifyClusterFlowRulesCommandHandler] Receiving cluster flow rules for namespace <{}>: {}", namespace, data);
 
             List<FlowRule> flowRules = JSONArray.parseArray(data, FlowRule.class);
             ClusterFlowRuleManager.loadRules(namespace, flowRules);

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/command/handler/ModifyClusterParamFlowRulesCommandHandler.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/command/handler/ModifyClusterParamFlowRulesCommandHandler.java
@@ -47,7 +47,7 @@ public class ModifyClusterParamFlowRulesCommandHandler implements CommandHandler
         }
         try {
             data = URLDecoder.decode(data, "UTF-8");
-            RecordLog.info("[ModifyClusterParamFlowRulesCommandHandler] Receiving cluster param rules for namespace <{0}>: {1}", namespace, data);
+            RecordLog.info("Receiving cluster param rules for namespace <{}> from command handler: {}", namespace, data);
 
             List<ParamFlowRule> flowRules = JSONArray.parseArray(data, ParamFlowRule.class);
             ClusterParamFlowRuleManager.loadRules(namespace, flowRules);

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/command/handler/ModifyClusterServerFlowConfigHandler.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/command/handler/ModifyClusterServerFlowConfigHandler.java
@@ -53,7 +53,7 @@ public class ModifyClusterServerFlowConfigHandler implements CommandHandler<Stri
                 }
                 ClusterServerConfigManager.loadGlobalFlowConfig(config);
             } else {
-                RecordLog.info("[ModifyClusterServerFlowConfigHandler] Receiving cluster server flow config for namespace <{0}>: {1}", namespace, data);
+                RecordLog.info("[ModifyClusterServerFlowConfigHandler] Receiving cluster server flow config for namespace <{}>: {}", namespace, data);
                 ServerFlowConfig config = JSON.parseObject(data, ServerFlowConfig.class);
                 if (!ClusterServerConfigManager.isValidFlowConfig(config)) {
                     CommandResponse.ofFailure(new IllegalArgumentException("Bad flow config"));

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/connection/ConnectionManager.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/connection/ConnectionManager.java
@@ -73,7 +73,7 @@ public final class ConnectionManager {
                 return;
             }
             group.removeConnection(address);
-            RecordLog.info("[ConnectionManager] Client <{0}> disconnected and removed from namespace <{1}>", address, namespace);
+            RecordLog.info("[ConnectionManager] Client <{}> disconnected and removed from namespace <{}>", address, namespace);
         }
         NAMESPACE_MAP.remove(address);
     }
@@ -87,7 +87,7 @@ public final class ConnectionManager {
         }
         group.removeConnection(address);
         NAMESPACE_MAP.remove(address);
-        RecordLog.info("[ConnectionManager] Client <{0}> disconnected and removed from namespace <{1}>", address, namespace);
+        RecordLog.info("[ConnectionManager] Client <{}> disconnected and removed from namespace <{}>", address, namespace);
     }
 
     public static ConnectionGroup addConnection(String namespace, String address) {
@@ -96,7 +96,7 @@ public final class ConnectionManager {
         ConnectionGroup group = getOrCreateGroup(namespace);
         group.addConnection(address);
         NAMESPACE_MAP.put(address, namespace);
-        RecordLog.info("[ConnectionManager] Client <{0}> registered with namespace <{1}>", address, namespace);
+        RecordLog.info("[ConnectionManager] Client <{}> registered with namespace <{}>", address, namespace);
         return group;
     }
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/config/SentinelConfig.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/config/SentinelConfig.java
@@ -204,7 +204,7 @@ public final class SentinelConfig {
             }
             return Integer.parseInt(v);
         } catch (Throwable throwable) {
-            RecordLog.warn("[SentinelConfig] Invalid statisticMaxRt value: {0}, using the default value instead: "
+            RecordLog.warn("[SentinelConfig] Invalid statisticMaxRt value: {}, using the default value instead: "
                     + DEFAULT_STATISTIC_MAX_RT, v, throwable);
             SentinelConfig.setConfig(STATISTIC_MAX_RT, String.valueOf(DEFAULT_STATISTIC_MAX_RT));
             return DEFAULT_STATISTIC_MAX_RT;

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/config/SentinelConfigLoader.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/config/SentinelConfigLoader.java
@@ -86,7 +86,7 @@ public final class SentinelConfigLoader {
             String oldConfigValue = properties.getProperty(configKey);
             properties.put(configKey, newConfigValue);
             if (oldConfigValue != null) {
-                RecordLog.info("[SentinelConfigLoader] JVM parameter overrides {0}: {1} -> {2}",
+                RecordLog.info("[SentinelConfigLoader] JVM parameter overrides {}: {} -> {}",
                         configKey, oldConfigValue, newConfigValue);
             }
         }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/DefaultNode.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/DefaultNode.java
@@ -79,7 +79,7 @@ public class DefaultNode extends StatisticNode {
      */
     public void addChild(Node node) {
         if (node == null) {
-            RecordLog.warn("Trying to add null child to node <{0}>, ignored", id.getName());
+            RecordLog.warn("Trying to add null child to node <{}>, ignored", id.getName());
             return;
         }
         if (!childList.contains(node)) {
@@ -91,7 +91,7 @@ public class DefaultNode extends StatisticNode {
                     childList = newSet;
                 }
             }
-            RecordLog.info("Add child <{0}> to node <{1}>", ((DefaultNode)node).id.getName(), id.getName());
+            RecordLog.info("Add child <{}> to node <{}>", ((DefaultNode)node).id.getName(), id.getName());
         }
     }
 

--- a/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/AbstractSentinelAspectSupport.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/AbstractSentinelAspectSupport.java
@@ -280,7 +280,7 @@ public abstract class AbstractSentinelAspectSupport {
                 && returnType.isAssignableFrom(method.getReturnType())
                 && Arrays.equals(parameterTypes, method.getParameterTypes())) {
 
-                RecordLog.info("Resolved method [{0}] in class [{1}]", name, clazz.getCanonicalName());
+                RecordLog.info("Resolved method [{}] in class [{}]", name, clazz.getCanonicalName());
                 return method;
             }
         }
@@ -290,7 +290,7 @@ public abstract class AbstractSentinelAspectSupport {
             return findMethod(mustStatic, superClass, name, returnType, parameterTypes);
         } else {
             String methodType = mustStatic ? " static" : "";
-            RecordLog.warn("Cannot find{0} method [{1}] in class [{2}] with parameters {3}",
+            RecordLog.warn("Cannot find{} method [{}] in class [{}] with parameters {}",
                 methodType, name, clazz.getCanonicalName(), Arrays.toString(parameterTypes));
             return null;
         }

--- a/sentinel-extension/sentinel-datasource-consul/src/main/java/com/alibaba/csp/sentinel/datasource/consul/ConsulDataSource.java
+++ b/sentinel-extension/sentinel-datasource-consul/src/main/java/com/alibaba/csp/sentinel/datasource/consul/ConsulDataSource.java
@@ -157,11 +157,11 @@ public class ConsulDataSource<T> extends AbstractDataSource<String, T> {
                     String newValue = getValue.getDecodedValue();
                     try {
                         getProperty().updateValue(parser.convert(newValue));
-                        RecordLog.info("[ConsulDataSource] New property value received for ({0}, {1}): {2}",
+                        RecordLog.info("[ConsulDataSource] New property value received for ({}, {}): {}",
                             address, ruleKey, newValue);
                     } catch (Exception ex) {
                         // In case of parsing error.
-                        RecordLog.warn("[ConsulDataSource] Failed to update value for ({0}, {1}), raw value: {2}",
+                        RecordLog.warn("[ConsulDataSource] Failed to update value for ({}, {}), raw value: {}",
                             address, ruleKey, newValue);
                     }
                 }

--- a/sentinel-extension/sentinel-datasource-etcd/src/main/java/com/alibaba/csp/sentinel/datasource/etcd/EtcdDataSource.java
+++ b/sentinel-extension/sentinel-datasource-etcd/src/main/java/com/alibaba/csp/sentinel/datasource/etcd/EtcdDataSource.java
@@ -94,7 +94,7 @@ public class EtcdDataSource<T> extends AbstractDataSource<String, T> {
                         RecordLog.warn("[EtcdDataSource] Failed to update config", e);
                     }
                 } else if (eventType == WatchEvent.EventType.DELETE) {
-                    RecordLog.info("[EtcdDataSource] Cleaning config for key <{0}>", key);
+                    RecordLog.info("[EtcdDataSource] Cleaning config for key <{}>", key);
                     getProperty().updateValue(null);
                 }
             }

--- a/sentinel-extension/sentinel-datasource-spring-cloud-config/src/main/java/com/alibaba/csp/sentinel/datasource/spring/cloud/config/SentinelRuleLocator.java
+++ b/sentinel-extension/sentinel-datasource-spring-cloud-config/src/main/java/com/alibaba/csp/sentinel/datasource/spring/cloud/config/SentinelRuleLocator.java
@@ -50,7 +50,6 @@ import static org.springframework.cloud.config.client.ConfigClientProperties.*;
 @Order(0)
 public class SentinelRuleLocator implements PropertySourceLocator {
 
-
     private RestTemplate restTemplate;
     private ConfigClientProperties defaultProperties;
     private org.springframework.core.env.Environment environment;
@@ -150,10 +149,7 @@ public class SentinelRuleLocator implements PropertySourceLocator {
                     result.getName(), result.getPropertySources().size(),
                     propertyCount));
         }
-
-
     }
-
 
     private Environment getRemoteEnvironment(RestTemplate restTemplate,
                                              ConfigClientProperties properties, String label, String state) {
@@ -163,10 +159,11 @@ public class SentinelRuleLocator implements PropertySourceLocator {
         String token = properties.getToken();
         int noOfUrls = properties.getUri().length;
         if (noOfUrls > 1) {
-            RecordLog.info("Multiple Config Server Urls found listed.");
+            RecordLog.debug("Multiple Config Server Urls found listed.");
         }
 
-        RecordLog.info("properties = {0},label={1}, state={2}", properties, label, state);
+        RecordLog.info("[SentinelRuleLocator] getRemoteEnvironment, properties = {},label={}, state={}",
+            properties, label, state);
 
         Object[] args = new String[]{name, profile};
         if (StringUtils.hasText(label)) {

--- a/sentinel-extension/sentinel-datasource-spring-cloud-config/src/main/java/com/alibaba/csp/sentinel/datasource/spring/cloud/config/SentinelRuleLocator.java
+++ b/sentinel-extension/sentinel-datasource-spring-cloud-config/src/main/java/com/alibaba/csp/sentinel/datasource/spring/cloud/config/SentinelRuleLocator.java
@@ -1,6 +1,22 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.csp.sentinel.datasource.spring.cloud.config;
 
 import com.alibaba.csp.sentinel.log.RecordLog;
+
 import org.springframework.cloud.bootstrap.config.PropertySourceLocator;
 import org.springframework.cloud.config.client.ConfigClientProperties;
 import org.springframework.cloud.config.client.ConfigClientStateHolder;
@@ -38,10 +54,11 @@ import static org.springframework.cloud.config.client.ConfigClientProperties.*;
 
 /**
  * <p>
- * {@link SentinelRuleLocator}  which pull sentinel rules from remote server.
- * It retrieve configurations of spring-cloud-config client configurations from  {@link org.springframework.core.env.Environment}
- * Such as spring.cloud.config.uri=uri, spring.cloud.config.profile=profile .... and so on.
- * When pull rules successfully, save to {@link SentinelRuleStorage} for ${@link SpringCloudConfigDataSource} retrieve.
+ * {@link SentinelRuleLocator} which pulls Sentinel rules from remote server.
+ * It retrieves configurations of spring-cloud-config client configurations from
+ * {@link org.springframework.core.env.Environment}, such as {@code spring.cloud.config.uri=uri},
+ * {@code spring.cloud.config.profile=profile}, and so on.
+ * When rules are pulled successfully, it will be stored to {@link SentinelRuleStorage}.
  * </p>
  *
  * @author lianglin
@@ -54,11 +71,11 @@ public class SentinelRuleLocator implements PropertySourceLocator {
     private ConfigClientProperties defaultProperties;
     private org.springframework.core.env.Environment environment;
 
-    public SentinelRuleLocator(ConfigClientProperties defaultProperties, org.springframework.core.env.Environment environment) {
+    public SentinelRuleLocator(ConfigClientProperties defaultProperties,
+                               org.springframework.core.env.Environment environment) {
         this.defaultProperties = defaultProperties;
         this.environment = environment;
     }
-
 
     /**
      * Responsible for pull data from remote server
@@ -69,35 +86,35 @@ public class SentinelRuleLocator implements PropertySourceLocator {
     @Override
     @Retryable(interceptor = "configServerRetryInterceptor")
     public org.springframework.core.env.PropertySource<?> locate(
-            org.springframework.core.env.Environment environment) {
+        org.springframework.core.env.Environment environment) {
         ConfigClientProperties properties = this.defaultProperties.override(environment);
         CompositePropertySource composite = new CompositePropertySource("configService");
         RestTemplate restTemplate = this.restTemplate == null
-                ? getSecureRestTemplate(properties)
-                : this.restTemplate;
+            ? getSecureRestTemplate(properties)
+            : this.restTemplate;
         Exception error = null;
         String errorBody = null;
         try {
-            String[] labels = new String[]{""};
+            String[] labels = new String[] {""};
             if (StringUtils.hasText(properties.getLabel())) {
                 labels = StringUtils
-                        .commaDelimitedListToStringArray(properties.getLabel());
+                    .commaDelimitedListToStringArray(properties.getLabel());
             }
             String state = ConfigClientStateHolder.getState();
             // Try all the labels until one works
             for (String label : labels) {
                 Environment result = getRemoteEnvironment(restTemplate, properties,
-                        label.trim(), state);
+                    label.trim(), state);
                 if (result != null) {
                     log(result);
                     // result.getPropertySources() can be null if using xml
                     if (result.getPropertySources() != null) {
                         for (PropertySource source : result.getPropertySources()) {
                             @SuppressWarnings("unchecked")
-                            Map<String, Object> map = (Map<String, Object>) source
-                                    .getSource();
+                            Map<String, Object> map = (Map<String, Object>)source
+                                .getSource();
                             composite.addPropertySource(
-                                    new MapPropertySource(source.getName(), map));
+                                new MapPropertySource(source.getName(), map));
                         }
                     }
                     SentinelRuleStorage.setRulesSource(composite);
@@ -106,8 +123,7 @@ public class SentinelRuleLocator implements PropertySourceLocator {
             }
         } catch (HttpServerErrorException e) {
             error = e;
-            if (MediaType.APPLICATION_JSON
-                    .includes(e.getResponseHeaders().getContentType())) {
+            if (MediaType.APPLICATION_JSON.includes(e.getResponseHeaders().getContentType())) {
                 errorBody = e.getResponseBodyAsString();
             }
         } catch (Exception e) {
@@ -115,12 +131,12 @@ public class SentinelRuleLocator implements PropertySourceLocator {
         }
         if (properties.isFailFast()) {
             throw new IllegalStateException(
-                    "Could not locate PropertySource and the fail fast property is set, failing",
-                    error);
+                "Could not locate PropertySource and the fail fast property is set, failing",
+                error);
         }
         RecordLog.warn("Could not locate PropertySource: " + (errorBody == null
-                ? error == null ? "label not found" : error.getMessage()
-                : errorBody));
+            ? error == null ? "label not found" : error.getMessage()
+            : errorBody));
         return null;
 
     }
@@ -132,11 +148,10 @@ public class SentinelRuleLocator implements PropertySourceLocator {
     private void log(Environment result) {
 
         RecordLog.info(String.format(
-                "Located environment: name=%s, profiles=%s, label=%s, version=%s, state=%s",
-                result.getName(),
-                result.getProfiles() == null ? ""
-                        : Arrays.asList(result.getProfiles()),
-                result.getLabel(), result.getVersion(), result.getState()));
+            "Located environment: name=%s, profiles=%s, label=%s, version=%s, state=%s",
+            result.getName(),
+            result.getProfiles() == null ? "" : Arrays.asList(result.getProfiles()),
+            result.getLabel(), result.getVersion(), result.getState()));
 
         List<PropertySource> propertySourceList = result.getPropertySources();
         if (propertySourceList != null) {
@@ -144,10 +159,8 @@ public class SentinelRuleLocator implements PropertySourceLocator {
             for (PropertySource propertySource : propertySourceList) {
                 propertyCount += propertySource.getSource().size();
             }
-            RecordLog.info(String.format(
-                    "Environment %s has %d property sources with %d properties.",
-                    result.getName(), result.getPropertySources().size(),
-                    propertyCount));
+            RecordLog.info("[SentinelRuleLocator] Environment {} has {} property sources with {} properties",
+                result.getName(), result.getPropertySources().size(), propertyCount);
         }
     }
 
@@ -159,18 +172,18 @@ public class SentinelRuleLocator implements PropertySourceLocator {
         String token = properties.getToken();
         int noOfUrls = properties.getUri().length;
         if (noOfUrls > 1) {
-            RecordLog.debug("Multiple Config Server Urls found listed.");
+            RecordLog.debug("[SentinelRuleLocator] Multiple Config Server Urls found listed.");
         }
 
-        RecordLog.info("[SentinelRuleLocator] getRemoteEnvironment, properties = {},label={}, state={}",
+        RecordLog.info("[SentinelRuleLocator] getRemoteEnvironment, properties={}, label={}, state={}",
             properties, label, state);
 
-        Object[] args = new String[]{name, profile};
+        Object[] args = new String[] {name, profile};
         if (StringUtils.hasText(label)) {
             if (label.contains("/")) {
                 label = label.replace("/", "(_)");
             }
-            args = new String[]{name, profile, label};
+            args = new String[] {name, profile, label};
             path = path + "/{label}";
         }
         ResponseEntity<Environment> response = null;
@@ -181,7 +194,7 @@ public class SentinelRuleLocator implements PropertySourceLocator {
             String username = credentials.getUsername();
             String password = credentials.getPassword();
 
-            RecordLog.info("Fetching config from server at : " + uri);
+            RecordLog.info("[SentinelRuleLocator] Fetching config from server at: " + uri);
 
             try {
                 HttpHeaders headers = new HttpHeaders();
@@ -193,16 +206,16 @@ public class SentinelRuleLocator implements PropertySourceLocator {
                     headers.add(STATE_HEADER, state);
                 }
 
-                final HttpEntity<Void> entity = new HttpEntity<>((Void) null, headers);
+                final HttpEntity<Void> entity = new HttpEntity<>((Void)null, headers);
                 response = restTemplate.exchange(uri + path, HttpMethod.GET, entity,
-                        Environment.class, args);
+                    Environment.class, args);
             } catch (HttpClientErrorException e) {
                 if (e.getStatusCode() != HttpStatus.NOT_FOUND) {
                     throw e;
                 }
             } catch (ResourceAccessException e) {
-                RecordLog.info("Connect Timeout Exception on Url - " + uri
-                        + ". Will be trying the next url if available");
+                RecordLog.warn("[SentinelRuleLocator] ConnectTimeoutException on url <{}>."
+                    + " Will be trying the next url if available", uri);
                 if (i == noOfUrls - 1) {
                     throw e;
                 } else {
@@ -221,7 +234,6 @@ public class SentinelRuleLocator implements PropertySourceLocator {
         return null;
     }
 
-
     private RestTemplate getSecureRestTemplate(ConfigClientProperties client) {
         SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
         if (client.getRequestReadTimeout() < 0) {
@@ -236,7 +248,7 @@ public class SentinelRuleLocator implements PropertySourceLocator {
         }
         if (!headers.isEmpty()) {
             template.setInterceptors(Arrays.<ClientHttpRequestInterceptor>asList(
-                    new GenericRequestHeaderInterceptor(headers)));
+                new GenericRequestHeaderInterceptor(headers)));
         }
 
         return template;
@@ -248,7 +260,7 @@ public class SentinelRuleLocator implements PropertySourceLocator {
 
         if (password != null && authorization != null) {
             throw new IllegalStateException(
-                    "You must set either 'password' or 'authorization'");
+                "You must set either 'password' or 'authorization'");
         }
 
         if (password != null) {
@@ -264,9 +276,8 @@ public class SentinelRuleLocator implements PropertySourceLocator {
         this.restTemplate = restTemplate;
     }
 
-
     public static class GenericRequestHeaderInterceptor
-            implements ClientHttpRequestInterceptor {
+        implements ClientHttpRequestInterceptor {
 
         private final Map<String, String> headers;
 


### PR DESCRIPTION
Signed-off-by: Eric Zhao <sczyh16@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Polish placeholders in logging content to `{}`, as the logging has been based on the slf4j convention since 1.7.2.

### Does this pull request fix one issue?

Related to #757

### Describe how you did it

Replace all old placeholders `{x}` to `{}`.

### Describe how to verify it

Run the demo and see the log output.

### Special notes for reviews

NONE