### PR TITLE
Supplement missing javax.annotation-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 
         <!-- Test libs -->
         <junit.version>4.12</junit.version>
-        <mockito.version>2.21.0</mockito.version>
+        <mockito.version>2.28.2</mockito.version>
         <assertj.version>3.12.1</assertj.version>
         <awaitility.version>3.1.5</awaitility.version>
         <powermock.version>2.0.0</powermock.version>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
     <properties>
         <!-- Compile libs -->
         <fastjson.version>1.2.62</fastjson.version>
+        <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
 
         <!-- Test libs -->
         <junit.version>4.12</junit.version>

--- a/sentinel-adapter/sentinel-grpc-adapter/pom.xml
+++ b/sentinel-adapter/sentinel-grpc-adapter/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
-            <version>1.2</version>
+            <version>${javax.annotation-api.version}</version>
         </dependency>
 
 

--- a/sentinel-cluster/sentinel-cluster-server-envoy-rls/pom.xml
+++ b/sentinel-cluster/sentinel-cluster-server-envoy-rls/pom.xml
@@ -35,6 +35,11 @@
             <groupId>com.alibaba.csp</groupId>
             <artifactId>sentinel-transport-simple-http</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>${javax.annotation-api.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>io.grpc</groupId>

--- a/sentinel-demo/sentinel-demo-zuul2-gateway/pom.xml
+++ b/sentinel-demo/sentinel-demo-zuul2-gateway/pom.xml
@@ -26,6 +26,11 @@
             <artifactId>zuul-core</artifactId>
             <version>2.1.5</version>
         </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>${javax.annotation-api.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Supplement missing javax.annotation-api to sentinel-cluster-server-envoy-rls, sentinel-demo-zuul2-gateway.

### Describe what this PR does / why we need it
Coming to the details please refer to #1359 

### Special notes for reviews
Because several(three) packages have same dependency so the version definition is put in sentinel-parent.