### PR TITLE
Set default log level to INFO of JDK logging and improve log info and comment in SpiLoader

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/BaseJulLogger.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/BaseJulLogger.java
@@ -90,7 +90,9 @@ public class BaseJulLogger {
         if (handler != null) {
             disableOtherHandlers(heliumRecordLog, handler);
         }
-        heliumRecordLog.setLevel(Level.ALL);
+
+        // Set log level to INFO by default
+        heliumRecordLog.setLevel(Level.INFO);
         return handler;
     }
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/DefaultSlotChainBuilder.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/DefaultSlotChainBuilder.java
@@ -21,7 +21,6 @@ import com.alibaba.csp.sentinel.slotchain.DefaultProcessorSlotChain;
 import com.alibaba.csp.sentinel.slotchain.ProcessorSlot;
 import com.alibaba.csp.sentinel.slotchain.ProcessorSlotChain;
 import com.alibaba.csp.sentinel.slotchain.SlotChainBuilder;
-import com.alibaba.csp.sentinel.spi.SpiOrder;
 import com.alibaba.csp.sentinel.util.SpiLoader;
 
 import java.util.List;
@@ -33,21 +32,6 @@ import java.util.List;
  * @author leyou
  */
 public class DefaultSlotChainBuilder implements SlotChainBuilder {
-
-    static {
-        List<ProcessorSlot> sortedSlotList = SpiLoader.loadPrototypeInstanceListSorted(ProcessorSlot.class);
-        for (ProcessorSlot slot : sortedSlotList) {
-            String slotClassCanonicalName = slot.getClass().getCanonicalName();
-            int order;
-            if (slot.getClass().isAnnotationPresent(SpiOrder.class)) {
-                SpiOrder spiOrder = slot.getClass().getAnnotation(SpiOrder.class);
-                order = spiOrder.value();
-            } else {
-                order = SpiOrder.LOWEST_PRECEDENCE;
-            }
-            RecordLog.info("[DefaultSlotChainBuilder]Found ProcessorSlot {} with order {}", slotClassCanonicalName, order);
-        }
-    }
 
     @Override
     public ProcessorSlotChain build() {

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/SpiLoader.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/SpiLoader.java
@@ -60,7 +60,7 @@ public final class SpiLoader {
                 return null;
             }
         } catch (Throwable t) {
-            RecordLog.warn("[SpiLoader] ERROR: loadFirstInstance failed", t);
+            RecordLog.error("[SpiLoader] ERROR: loadFirstInstance failed", t);
             t.printStackTrace();
             return null;
         }
@@ -95,7 +95,7 @@ public final class SpiLoader {
             }
             return defaultClass.newInstance();
         } catch (Throwable t) {
-            RecordLog.warn("[SpiLoader] ERROR: loadFirstInstanceOrDefault failed", t);
+            RecordLog.error("[SpiLoader] ERROR: loadFirstInstanceOrDefault failed", t);
             t.printStackTrace();
             return null;
         }
@@ -124,15 +124,15 @@ public final class SpiLoader {
             SpiOrderWrapper<T> w = null;
             for (T spi : serviceLoader) {
                 int order = SpiOrderResolver.resolveOrder(spi);
-                RecordLog.info("[SpiLoader] Found {} SPI: {} with order " + order, clazz.getSimpleName(),
-                    spi.getClass().getCanonicalName());
+                RecordLog.info("[SpiLoader] Found {} SPI: {} with order {}", clazz.getSimpleName(),
+                    spi.getClass().getCanonicalName(), order);
                 if (w == null || order < w.order) {
                     w = new SpiOrderWrapper<>(order, spi);
                 }
             }
             return w == null ? null : w.spi;
         } catch (Throwable t) {
-            RecordLog.warn("[SpiLoader] ERROR: loadHighestPriorityInstance failed", t);
+            RecordLog.error("[SpiLoader] ERROR: loadHighestPriorityInstance failed", t);
             t.printStackTrace();
             return null;
         }
@@ -167,7 +167,7 @@ public final class SpiLoader {
             }
             return list;
         } catch (Throwable t) {
-            RecordLog.warn("[SpiLoader] ERROR: loadInstanceList failed", t);
+            RecordLog.error("[SpiLoader] ERROR: loadInstanceList failed", t);
             t.printStackTrace();
             return new ArrayList<>();
         }
@@ -201,13 +201,13 @@ public final class SpiLoader {
                 RecordLog.info("[SpiLoader] Found {} SPI: {} with order {}", clazz.getSimpleName(),
                     spi.getClass().getCanonicalName(), order);
             }
-            List<T> list = new ArrayList<>();
+            List<T> list = new ArrayList<>(orderWrappers.size());
             for (int i = 0; i < orderWrappers.size(); i++) {
-                list.add(i, orderWrappers.get(i).spi);
+                list.add(orderWrappers.get(i).spi);
             }
             return list;
         } catch (Throwable t) {
-            RecordLog.warn("[SpiLoader] ERROR: loadInstanceListSorted failed", t);
+            RecordLog.error("[SpiLoader] ERROR: loadInstanceListSorted failed", t);
             t.printStackTrace();
             return new ArrayList<>();
         }
@@ -236,13 +236,13 @@ public final class SpiLoader {
                 RecordLog.debug("[SpiLoader] Found {} SPI: {} with order {}", clazz.getSimpleName(),
                         spi.getClass().getCanonicalName(), order);
             }
-            List<T> list = new ArrayList<>();
+            List<T> list = new ArrayList<>(orderWrappers.size());
             for (int i = 0; i < orderWrappers.size(); i++) {
-                list.add(i, orderWrappers.get(i).spi);
+                list.add(orderWrappers.get(i).spi);
             }
             return list;
         } catch (Throwable t) {
-            RecordLog.warn("[SpiLoader] ERROR: loadPrototypeInstanceListSorted failed", t);
+            RecordLog.error("[SpiLoader] ERROR: loadPrototypeInstanceListSorted failed", t);
             t.printStackTrace();
             return new ArrayList<>();
         }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/SpiLoader.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/SpiLoader.java
@@ -167,7 +167,7 @@ public final class SpiLoader {
             }
             return list;
         } catch (Throwable t) {
-            RecordLog.warn("[SpiLoader] ERROR: loadInstanceListSorted failed", t);
+            RecordLog.warn("[SpiLoader] ERROR: loadInstanceList failed", t);
             t.printStackTrace();
             return new ArrayList<>();
         }

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/util/SpiLoaderTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/util/SpiLoaderTest.java
@@ -62,7 +62,7 @@ public class SpiLoaderTest {
         ProcessorSlot processorSlot = SpiLoader.loadHighestPriorityInstance(ProcessorSlot.class);
         assertNotNull(processorSlot);
 
-        // NodeSelectorSlot is highest order with @SpiOrder(-9000), among all slots
+        // NodeSelectorSlot is highest order with @SpiOrder(-10000), among all slots
         assertTrue(processorSlot instanceof NodeSelectorSlot);
 
         ProcessorSlot processorSlot2 = SpiLoader.loadHighestPriorityInstance(ProcessorSlot.class);

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/util/SpiLoaderTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/util/SpiLoaderTest.java
@@ -44,9 +44,17 @@ public class SpiLoaderTest {
         ProcessorSlot processorSlot = SpiLoader.loadFirstInstance(ProcessorSlot.class);
         assertNotNull(processorSlot);
 
+        ProcessorSlot processorSlot2 = SpiLoader.loadFirstInstance(ProcessorSlot.class);
+        // As SERVICE_LOADER_MAP in SpiLoader cached the instance, so they're same instances
+        assertSame(processorSlot, processorSlot2);
+
         SlotChainBuilder slotChainBuilder = SpiLoader.loadFirstInstance(SlotChainBuilder.class);
         assertNotNull(slotChainBuilder);
         assertTrue(slotChainBuilder instanceof DefaultSlotChainBuilder);
+
+        SlotChainBuilder slotChainBuilder2 = SpiLoader.loadFirstInstance(SlotChainBuilder.class);
+        // As SERVICE_LOADER_MAP in SpiLoader cached the instance, so they're same instances
+        assertSame(slotChainBuilder, slotChainBuilder2);
     }
 
     @Test
@@ -56,6 +64,10 @@ public class SpiLoaderTest {
 
         // NodeSelectorSlot is highest order with @SpiOrder(-9000), among all slots
         assertTrue(processorSlot instanceof NodeSelectorSlot);
+
+        ProcessorSlot processorSlot2 = SpiLoader.loadHighestPriorityInstance(ProcessorSlot.class);
+        // As SERVICE_LOADER_MAP in SpiLoader cached the instance, so they're same instances
+        assertSame(processorSlot, processorSlot2);
     }
 
     @Test
@@ -66,14 +78,15 @@ public class SpiLoaderTest {
         // Total 8 default slot in sentinel-core
         assertEquals(8, slots.size());
 
-        // Store the first slot of slots
+        // Get the first slot of slots
         ProcessorSlot firstSlot = slots.get(0);
 
         // Call loadInstanceList again
         List<ProcessorSlot> slots2 = SpiLoader.loadInstanceList(ProcessorSlot.class);
+        // Note: the return list are different, and the item instances in list are same
         assertNotSame(slots, slots2);
 
-        // Store the first slot of slots
+        // Get the first slot of slots2
         ProcessorSlot firstSlot2 = slots2.get(0);
 
         // As SERVICE_LOADER_MAP in SpiLoader cached the instance, so they're same instances
@@ -100,6 +113,7 @@ public class SpiLoaderTest {
         assertTrue(sortedSlots.get(index++) instanceof DegradeSlot);
 
         // Verify each call return different instances
+        // Note: the return list are different, and the item instances in list are same
         List<ProcessorSlot> sortedSlots2 = SpiLoader.loadInstanceListSorted(ProcessorSlot.class);
         assertNotSame(sortedSlots, sortedSlots2);
         assertEquals(sortedSlots.size(), sortedSlots2.size());
@@ -107,11 +121,14 @@ public class SpiLoaderTest {
             ProcessorSlot slot = sortedSlots.get(i);
             ProcessorSlot slot2 = sortedSlots2.get(i);
             assertEquals(slot.getClass(), slot2.getClass());
+
+            // As SERVICE_LOADER_MAP in SpiLoader cached the instance, so they're same instances
+            assertSame(slot, slot2);
         }
     }
 
     @Test
-    public void testLoadDifferentInstanceListSorted() {
+    public void testLoadPrototypeInstanceListSorted() {
         List<ProcessorSlot> sortedSlots = SpiLoader.loadInstanceListSorted(ProcessorSlot.class);
         assertNotNull(sortedSlots);
 
@@ -129,8 +146,8 @@ public class SpiLoaderTest {
         assertTrue(sortedSlots.get(index++) instanceof FlowSlot);
         assertTrue(sortedSlots.get(index++) instanceof DegradeSlot);
 
-        // Verify each call return different instances
-        List<ProcessorSlot> sortedSlots2 = SpiLoader.loadDifferentInstanceListSorted(ProcessorSlot.class);
+        // Verify each call return new instances
+        List<ProcessorSlot> sortedSlots2 = SpiLoader.loadPrototypeInstanceListSorted(ProcessorSlot.class);
         assertNotSame(sortedSlots, sortedSlots2);
         assertEquals(sortedSlots.size(), sortedSlots2.size());
         for (int i = 0; i < sortedSlots.size(); i++) {


### PR DESCRIPTION
### Describe what this PR does / why we need it

Relate to #411 
Improve the log, comment and test case of `SpiLoader`.

### Does this pull request fix one issue?

NONE

### Describe how you did it

Rename the method `loadDifferentInstanceListSorted` to `loadPrototypeInstanceListSorted` in `SpiLoader`, using `RecordLog.debug` in it instead of `RecordLog.info`, and use `{}` to print log.

Use a static block to log the ProcessorSlot info loaded by `SpiLoader` in `DefaultSlotChainBuilder`, which is in order to facilitate log troubleshooting.

### Describe how to verify it

Run test case; Start dashboard, view log file to check.

### Special notes for reviews

When using `RecordLog.debug` in `SpiLoader#loadPrototypeInstanceListSorted`, I found that the debug log messages are also printed in `sentinel-record.log` file. Feeling surprised, debug and check finally find one line in `BaseJulLogger#makeLoggingHandler`, which seems to be the reason.
`heliumRecordLog.setLevel(Level.ALL);`

As default log level is usually INFO, so I changed it to `heliumRecordLog.setLevel(Level.INFO);` and it works as expected.

PTAL.
