### PR TITLE
[1191] Support configuring project.name via the properties file

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/config/SentinelConfigLoader.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/config/SentinelConfigLoader.java
@@ -38,9 +38,6 @@ public final class SentinelConfigLoader {
     public static final String SENTINEL_CONFIG_ENV_KEY = "CSP_SENTINEL_CONFIG_FILE";
     public static final String SENTINEL_CONFIG_PROPERTY_KEY = "csp.sentinel.config.file";
 
-    private static final String DIR_NAME = "logs" + File.separator + "csp";
-    private static final String USER_HOME = "user.home";
-
     private static final String DEFAULT_SENTINEL_CONFIG_FILE = "classpath:sentinel.properties";
 
     private static Properties properties = new Properties();
@@ -64,17 +61,6 @@ public final class SentinelConfigLoader {
         }
 
         Properties p = ConfigUtil.loadProperties(fileName);
-
-        // Compatible with legacy config file path.
-        if (p == null) {
-            String path = addSeparator(System.getProperty(USER_HOME)) + DIR_NAME + File.separator;
-            fileName = path + AppNameUtil.getAppName() + ".properties";
-            File file = new File(fileName);
-            if (file.exists()) {
-                p = ConfigUtil.loadProperties(fileName);
-            }
-        }
-
         if (p != null && !p.isEmpty()) {
             RecordLog.info("[SentinelConfigLoader] Loading Sentinel config from " + fileName);
             properties.putAll(p);

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/AppNameUtil.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/AppNameUtil.java
@@ -15,86 +15,21 @@
  */
 package com.alibaba.csp.sentinel.util;
 
-import com.alibaba.csp.sentinel.log.RecordLog;
-
-import java.io.File;
+import com.alibaba.csp.sentinel.config.SentinelConfig;
 
 /**
- * Util class for getting application name. This class uses the flowing order to get app's name:
- *
- * <ol>
- * <li>get {@code project.name} from System Properties, if not null, use the value as app name;</li>
- * <li>get {@code sun.java.command} from System properties, remove path, arguments and ".jar" or ".JAR"
- * suffix, use the result as app name. Note that whitespace in file name or path is not allowed, or a
- * wrong app name may be gotten, For example:
- * <p>
- * <code>
- * "test.Main" -> test.Main<br/>
- * "/target/test.Main" -> test.Main<br/>
- * "/target/test.Main args1" -> test.Main<br/>
- * "Main.jar" -> Main<br/>
- * "/target/Main.JAR args1" -> Main<br/>
- * "Mai n.jar" -> Mai // whitespace in file name is not allowed<br/>
- * </code>
- * </p>
- * </li>
- * </ol>
- *
  * @author Eric Zhao
  * @author leyou
  */
+
 public final class AppNameUtil {
 
-    public static final String APP_NAME = "project.name";
-    public static final String SUN_JAVA_COMMAND = "sun.java.command";
-    private static final String JAR_SUFFIX_LOWER = ".jar";
-    private static final String JAR_SUFFIX_UPPER = ".JAR";
-
-    private static String appName;
 
     private AppNameUtil() {
     }
 
-    static {
-        resolveAppName();
-        RecordLog.info("App name resolved: " + appName);
-    }
-
-    public static void resolveAppName() {
-        String app = System.getProperty(APP_NAME);
-        // use -Dproject.name first
-        if (!isEmpty(app)) {
-            appName = app;
-            return;
-        }
-
-        // parse sun.java.command property
-        String command = System.getProperty(SUN_JAVA_COMMAND);
-        if (isEmpty(command)) {
-            return;
-        }
-        command = command.split("\\s")[0];
-        String separator = File.separator;
-        if (command.contains(separator)) {
-            String[] strs;
-            if ("\\".equals(separator)) {
-                strs = command.split("\\\\");
-            } else {
-                strs = command.split(separator);
-            }
-            command = strs[strs.length - 1];
-        }
-        if (command.endsWith(JAR_SUFFIX_LOWER) || command.endsWith(JAR_SUFFIX_UPPER)) {
-            command = command.substring(0, command.length() - 4);
-        }
-        appName = command;
-    }
-
     public static String getAppName() {
-        return appName;
+        return SentinelConfig.getAppName();
     }
 
-    private static boolean isEmpty(String str) {
-        return str == null || "".equals(str);
-    }
 }

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/ConfigPropertyHelper.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/ConfigPropertyHelper.java
@@ -20,6 +20,7 @@ import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.util.Properties;
 
+import com.alibaba.csp.sentinel.config.SentinelConfig;
 import com.alibaba.csp.sentinel.log.LogBase;
 import com.alibaba.csp.sentinel.util.AppNameUtil;
 
@@ -31,11 +32,11 @@ import com.alibaba.csp.sentinel.util.AppNameUtil;
 public final class ConfigPropertyHelper {
 
     public static void setAppNameProperty(String appName) {
-        System.setProperty(AppNameUtil.APP_NAME, appName);
+        System.setProperty(SentinelConfig.APP_NAME, appName);
     }
 
     public static void clearAppNameProperty() {
-        System.clearProperty(AppNameUtil.APP_NAME);
+        System.clearProperty(SentinelConfig.APP_NAME);
     }
 
     public static void runWithConfig(Properties prop, String appName, Task task) throws Exception {

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/config/SentinelConfigTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/config/SentinelConfigTest.java
@@ -69,7 +69,7 @@ public class SentinelConfigTest {
 
 
     //add Jvm parameter
-    //-Dcsp.sentinel.config.file=sentinel-propertiesTest.properties
+    //-Dcsp.sentinel.config.file=classpath:sentinel-propertiesTest.properties
     //-Dcsp.sentinel.flow.cold.factor=5
     //-Dcsp.sentinel.statistic.max.rt=1000
     //@Test
@@ -92,6 +92,8 @@ public class SentinelConfigTest {
             out.write(buildPropertyStr(COLD_FACTOR, "123"));
             out.write("\n");
             out.write(buildPropertyStr(STATISTIC_MAX_RT, "6000"));
+            out.write("\n");
+            out.write(buildPropertyStr(APP_NAME, "sentinel_test"));
             out.flush();
             out.close();
 
@@ -100,6 +102,7 @@ public class SentinelConfigTest {
             Assert.assertTrue(SentinelConfig.getConfig(TOTAL_METRIC_FILE_COUNT).equals("20"));
             Assert.assertTrue(SentinelConfig.getConfig(COLD_FACTOR).equals("5"));
             Assert.assertTrue(SentinelConfig.getConfig(STATISTIC_MAX_RT).equals("1000"));
+            Assert.assertTrue(SentinelConfig.getAppName().equals("sentinel_test"));
 
         } finally {
             if (file != null) {


### PR DESCRIPTION



### Does this pull request fix one issue?

 Fixes https://github.com/alibaba/Sentinel/issues/1191

### Describe how you did it

1. add `project.name` config in `SetinelConfig`
2. rmove the old Compatibility(**log/csp…./log/app.properties**)

### Describe how to verify it


### Special notes for reviews
