### PR TITLE
Refactor the mechanism of recording error (on completed)

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Entry.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Entry.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.csp.sentinel;
 
+import com.alibaba.csp.sentinel.slots.block.BlockException;
 import com.alibaba.csp.sentinel.util.TimeUtil;
 import com.alibaba.csp.sentinel.context.ContextUtil;
 import com.alibaba.csp.sentinel.node.Node;
@@ -44,6 +45,7 @@ import com.alibaba.csp.sentinel.context.Context;
  * @author qinan.qn
  * @author jialiang.linjl
  * @author leyou(lihao)
+ * @author Eric Zhao
  * @see SphU
  * @see Context
  * @see ContextUtil
@@ -52,18 +54,23 @@ public abstract class Entry implements AutoCloseable {
 
     private static final Object[] OBJECTS0 = new Object[0];
 
-    private long createTime;
+    private final long createTimestamp;
+    private long completeTimestamp;
+
     private Node curNode;
     /**
      * {@link Node} of the specific origin, Usually the origin is the Service Consumer.
      */
     private Node originNode;
+
     private Throwable error;
-    protected ResourceWrapper resourceWrapper;
+    private BlockException blockError;
+
+    protected final ResourceWrapper resourceWrapper;
 
     public Entry(ResourceWrapper resourceWrapper) {
         this.resourceWrapper = resourceWrapper;
-        this.createTime = TimeUtil.currentTimeMillis();
+        this.createTimestamp = TimeUtil.currentTimeMillis();
     }
 
     public ResourceWrapper getResourceWrapper() {
@@ -119,8 +126,17 @@ public abstract class Entry implements AutoCloseable {
      */
     public abstract Node getLastNode();
 
-    public long getCreateTime() {
-        return createTime;
+    public long getCreateTimestamp() {
+        return createTimestamp;
+    }
+
+    public long getCompleteTimestamp() {
+        return completeTimestamp;
+    }
+
+    public Entry setCompleteTimestamp(long completeTimestamp) {
+        this.completeTimestamp = completeTimestamp;
+        return this;
     }
 
     public Node getCurNode() {
@@ -129,6 +145,15 @@ public abstract class Entry implements AutoCloseable {
 
     public void setCurNode(Node node) {
         this.curNode = node;
+    }
+
+    public BlockException getBlockError() {
+        return blockError;
+    }
+
+    public Entry setBlockError(BlockException blockError) {
+        this.blockError = blockError;
+        return this;
     }
 
     public Throwable getError() {

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Tracer.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Tracer.java
@@ -18,11 +18,7 @@ package com.alibaba.csp.sentinel;
 import com.alibaba.csp.sentinel.context.Context;
 import com.alibaba.csp.sentinel.context.ContextUtil;
 import com.alibaba.csp.sentinel.context.NullContext;
-import com.alibaba.csp.sentinel.metric.extension.MetricExtensionProvider;
-import com.alibaba.csp.sentinel.node.ClusterNode;
-import com.alibaba.csp.sentinel.node.DefaultNode;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
-import com.alibaba.csp.sentinel.metric.extension.MetricExtension;
 import com.alibaba.csp.sentinel.util.AssertUtil;
 
 /**
@@ -39,22 +35,41 @@ public class Tracer {
     protected Tracer() {}
 
     /**
-     * Trace provided {@link Throwable} and increment exception count to entry in current context.
+     * Trace provided {@link Throwable} to the resource entry in current context.
      *
      * @param e exception to record
      */
     public static void trace(Throwable e) {
-        trace(e, 1);
+        traceContext(e, ContextUtil.getContext());
     }
 
     /**
-     * Trace provided {@link Throwable} and add exception count to entry in current context.
+     * Trace provided {@link Throwable} to current entry in current context.
      *
      * @param e     exception to record
      * @param count exception count to add
      */
+    @Deprecated
     public static void trace(Throwable e, int count) {
         traceContext(e, count, ContextUtil.getContext());
+    }
+
+    /**
+     * Trace provided {@link Throwable} to current entry of given entrance context.
+     *
+     * @param e     exception to record
+     * @param context target entrance context
+     * @since 1.8.0
+     */
+    public static void traceContext(Throwable e, Context context) {
+        if (!shouldTrace(e)) {
+            return;
+        }
+
+        if (context == null || context instanceof NullContext) {
+            return;
+        }
+        traceEntryInternal(e, context.getCurEntry());
     }
 
     /**
@@ -64,6 +79,7 @@ public class Tracer {
      * @param count exception count to add
      * @since 1.4.2
      */
+    @Deprecated
     public static void traceContext(Throwable e, int count, Context context) {
         if (!shouldTrace(e)) {
             return;
@@ -72,49 +88,28 @@ public class Tracer {
         if (context == null || context instanceof NullContext) {
             return;
         }
-
-        DefaultNode curNode = (DefaultNode)context.getCurNode();
-        traceExceptionToNode(e, count, context.getCurEntry(), curNode);
+        traceEntryInternal(e, context.getCurEntry());
     }
 
     /**
-     * Trace provided {@link Throwable} and increment exception count to provided entry.
+     * Trace provided {@link Throwable} to the given resource entry.
      *
      * @param e exception to record
      * @since 1.4.2
      */
     public static void traceEntry(Throwable e, Entry entry) {
-        traceEntry(e, 1, entry);
-    }
-
-    /**
-     * Trace provided {@link Throwable} and add exception count to provided entry.
-     *
-     * @param e     exception to record
-     * @param count exception count to add
-     * @since 1.4.2
-     */
-    public static void traceEntry(Throwable e, int count, Entry entry) {
         if (!shouldTrace(e)) {
             return;
         }
-        if (entry == null || entry.getCurNode() == null) {
-            return;
-        }
-
-        DefaultNode curNode = (DefaultNode)entry.getCurNode();
-        traceExceptionToNode(e, count, entry, curNode);
+        traceEntryInternal(e, entry);
     }
 
-    private static void traceExceptionToNode(Throwable t, int count, Entry entry, DefaultNode curNode) {
-        if (curNode == null) {
+    private static void traceEntryInternal(/*@NeedToTrace*/ Throwable e, Entry entry) {
+        if (entry == null) {
             return;
         }
-        for (MetricExtension m : MetricExtensionProvider.getMetricExtensions()) {
-            m.addException(entry.getResourceWrapper().getName(), count, t);
-        }
 
-        curNode.trace(t, count);
+        entry.setError(e);
     }
 
     /**

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/DefaultNode.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/DefaultNode.java
@@ -23,7 +23,6 @@ import com.alibaba.csp.sentinel.SphO;
 import com.alibaba.csp.sentinel.SphU;
 import com.alibaba.csp.sentinel.context.Context;
 import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
-import com.alibaba.csp.sentinel.slots.block.BlockException;
 import com.alibaba.csp.sentinel.slots.nodeselector.NodeSelectorSlot;
 
 /**
@@ -145,28 +144,6 @@ public class DefaultNode extends StatisticNode {
 
     public void printDefaultNode() {
         visitTree(0, this);
-    }
-
-
-    /**
-     * Add exception count only when given {@code throwable} is not a {@link BlockException}.
-     *
-     * @param throwable target exception
-     * @param count     count to add
-     */
-    public void trace(Throwable throwable, int count) {
-        if (count <= 0) {
-            return;
-        }
-        if (BlockException.isBlockException(throwable)) {
-            return;
-        }
-        super.increaseExceptionQps(count);
-
-        // clusterNode can be null when Constants.ON is false.
-        if (clusterNode != null) {
-            clusterNode.increaseExceptionQps(count);
-        }
     }
 
     private void visitTree(int level, DefaultNode node) {

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/metric/extension/callback/MetricExitCallbackTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/metric/extension/callback/MetricExitCallbackTest.java
@@ -55,7 +55,7 @@ public class MetricExitCallbackTest extends AbstractTimeBasedTest {
 
         int deltaMs = 100;
         when(entry.getError()).thenReturn(null);
-        when(entry.getCreateTime()).thenReturn(curMillis - deltaMs);
+        when(entry.getCreateTimestamp()).thenReturn(curMillis - deltaMs);
         when(context.getCurEntry()).thenReturn(entry);
         exitCallback.onExit(context, resourceWrapper, count, args);
         Assert.assertEquals(prevRt + deltaMs, extension.rt);

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/node/ClusterNodeTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/node/ClusterNodeTest.java
@@ -15,10 +15,6 @@
  */
 package com.alibaba.csp.sentinel.node;
 
-import com.alibaba.csp.sentinel.EntryType;
-import com.alibaba.csp.sentinel.slotchain.StringResourceWrapper;
-import com.alibaba.csp.sentinel.slots.block.flow.FlowException;
-
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -128,30 +124,5 @@ public class ClusterNodeTest {
                 assertTrue(clusterNode.getOriginCountMap().containsKey(origin));
             }
         }
-    }
-
-    @Test
-    public void testTraceException() {
-        ClusterNode clusterNode = new ClusterNode("test");
-        DefaultNode defaultNode = new DefaultNode(new StringResourceWrapper("test", EntryType.IN), clusterNode);
-
-        Exception exception = new RuntimeException("test");
-
-        // test count<=0, no exceptionQps added
-        defaultNode.trace(exception, 0);
-        defaultNode.trace(exception, -1);
-        assertEquals(0, defaultNode.exceptionQps(), 0.01);
-        assertEquals(0, defaultNode.totalException());
-
-        // test count=1, not BlockException, 1 exceptionQps added
-        defaultNode.trace(exception, 1);
-        assertEquals(1, defaultNode.exceptionQps(), 0.01);
-        assertEquals(1, defaultNode.totalException());
-
-        // test count=1, BlockException, no exceptionQps added
-        FlowException flowException = new FlowException("flow");
-        defaultNode.trace(flowException, 1);
-        assertEquals(1, defaultNode.exceptionQps(), 0.01);
-        assertEquals(1, defaultNode.totalException());
     }
 }

--- a/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/statistic/ParamFlowStatisticExitCallback.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/statistic/ParamFlowStatisticExitCallback.java
@@ -29,7 +29,7 @@ public class ParamFlowStatisticExitCallback implements ProcessorSlotExitCallback
 
     @Override
     public void onExit(Context context, ResourceWrapper resourceWrapper, int count, Object... args) {
-        if (context.getCurEntry().getError() == null) {
+        if (context.getCurEntry().getBlockError() == null) {
             ParameterMetric parameterMetric = ParameterMetricStorage.getParamMetric(resourceWrapper);
 
             if (parameterMetric != null) {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Refactor the mechanism of recording error (record on completed).

### Does this pull request fix one issue?

Resolves #1419 

### Describe how you did it

- Refactor for `Entry`: Separate block exception (`blockError`) and biz exception (`error`). Use `setError(ex)` to mark error for this invocation.
- Refactor for `StatisticSlot`: record the biz exception on entry completed (if `error` is present)
- Polish Tracer with `entry.setError(ex)` mechanism.
- Polish `MetricExitCallback#exit` with the new error tracing mechanism.

### Describe how to verify it

Run the test cases.

### Special notes for reviews

The upcoming refactor of circuit breaking depends on the mechanism.