### PR TITLE
[1416]  fix sentinel-apache-dubbo-adapter full GC problem

### DIFF
--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/pom.xml
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <java.source.version>1.8</java.source.version>
         <java.target.version>1.8</java.target.version>
-        <apache.dubbo.version>2.7.6</apache.dubbo.version>
+        <apache.dubbo.version>2.7.5</apache.dubbo.version>
     </properties>
 
     <dependencies>

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/pom.xml
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <java.source.version>1.8</java.source.version>
         <java.target.version>1.8</java.target.version>
-        <apache.dubbo.version>2.7.5</apache.dubbo.version>
+        <apache.dubbo.version>2.7.6</apache.dubbo.version>
     </properties>
 
     <dependencies>

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/BaseSentinelDubboFilter.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/BaseSentinelDubboFilter.java
@@ -81,7 +81,6 @@ public abstract class BaseSentinelDubboFilter extends ListenableFilter {
             }
             RpcContext.getContext().remove(methodResourceName);
         }
-        URL url = invoker.getUrl();
         if (CommonConstants.PROVIDER_SIDE.equals(invoker.getUrl().getParameter(CommonConstants.SIDE_KEY))) {
             ContextUtil.exit();
         }

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/BaseSentinelDubboFilter.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/BaseSentinelDubboFilter.java
@@ -16,16 +16,9 @@
 package com.alibaba.csp.sentinel.adapter.dubbo;
 
 
-import com.alibaba.csp.sentinel.Entry;
-import com.alibaba.csp.sentinel.Tracer;
-import com.alibaba.csp.sentinel.adapter.dubbo.config.DubboConfig;
-import com.alibaba.csp.sentinel.context.ContextUtil;
-import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.rpc.Filter;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
-import org.apache.dubbo.rpc.ListenableFilter;
-import org.apache.dubbo.rpc.Result;
-import org.apache.dubbo.rpc.RpcContext;
 
 /**
  * Base Class of the {@link SentinelDubboProviderFilter} and {@link SentinelDubboConsumerFilter}.
@@ -33,32 +26,8 @@ import org.apache.dubbo.rpc.RpcContext;
  * @author Zechao Zheng
  */
 
-public abstract class BaseSentinelDubboFilter extends ListenableFilter {
-    public BaseSentinelDubboFilter() {
-        this.listener = new SentinelDubboListener();
-    }
+public abstract class BaseSentinelDubboFilter implements Filter {
 
-
-    private void traceAndExit(Throwable throwable, Invoker invoker, Invocation invocation) {
-        String methodResourceName = getMethodName(invoker, invocation);
-        Entry[] entries = (Entry[]) RpcContext.getContext().get(methodResourceName);
-        if (entries != null) {
-            Entry interfaceEntry = entries[0];
-            Entry methodEntry = entries[1];
-            if (methodEntry != null) {
-                Tracer.traceEntry(throwable, methodEntry);
-                methodEntry.exit();
-            }
-            if (interfaceEntry != null) {
-                Tracer.traceEntry(throwable, interfaceEntry);
-                interfaceEntry.exit();
-            }
-            RpcContext.getContext().remove(methodResourceName);
-        }
-        if (CommonConstants.PROVIDER_SIDE.equals(invoker.getUrl().getParameter(CommonConstants.SIDE_KEY))) {
-            ContextUtil.exit();
-        }
-    }
 
     /**
      * Get method name of dubbo rpc
@@ -78,29 +47,4 @@ public abstract class BaseSentinelDubboFilter extends ListenableFilter {
     abstract String getInterfaceName(Invoker invoker);
 
 
-    private class SentinelDubboListener implements Listener {
-
-        public void onResponse(Result appResponse, Invoker<?> invoker, Invocation invocation) {
-            onSuccess(appResponse, invoker, invocation);
-        }
-
-        //for compatible dubbo 2.7.5 rename onResponse to onMessage
-        public void onMessage(Result appResponse, Invoker<?> invoker, Invocation invocation) {
-            onSuccess(appResponse, invoker, invocation);
-        }
-
-        private void onSuccess(Result appResponse, Invoker<?> invoker, Invocation invocation) {
-            if (DubboConfig.getDubboBizExceptionTraceEnabled()) {
-                traceAndExit(appResponse.getException(), invoker, invocation);
-            } else {
-                traceAndExit(null, invoker, invocation);
-            }
-        }
-
-        @Override
-        public void onError(Throwable t, Invoker<?> invoker, Invocation invocation) {
-            traceAndExit(t, invoker, invocation);
-        }
-
-    }
 }

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/DubboUtils.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/DubboUtils.java
@@ -26,8 +26,6 @@ import org.apache.dubbo.rpc.Invoker;
 public final class DubboUtils {
 
     public static final String SENTINEL_DUBBO_APPLICATION_KEY = "dubboApplication";
-    public static final String DUBBO_METHOD_ENTRY_KEY = "dubboMethodEntry";
-    public static final String DUBBO_INTERFACE_ENTRY_KEY = "dubboInterfaceEntry";
 
     public static String getApplication(Invocation invocation, String defaultValue) {
         if (invocation == null || invocation.getAttachments() == null) {
@@ -69,6 +67,13 @@ public final class DubboUtils {
             return getResourceName(invoker, invocation, DubboConfig.getDubboInterfaceGroupAndVersionEnabled());
         }
     }
+
+
+    public static String getInterfaceName(Invoker invoker) {
+        return DubboConfig.getDubboInterfaceGroupAndVersionEnabled() ? invoker.getUrl().getColonSeparatedKey()
+                : invoker.getInterface().getName();
+    }
+
     private DubboUtils() {
     }
 }

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboConsumerFilter.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboConsumerFilter.java
@@ -118,12 +118,10 @@ public class SentinelDubboConsumerFilter extends BaseSentinelDubboFilter {
             result.whenCompleteWithContext(new BiConsumer<Result, Throwable>() {
                 @Override
                 public void accept(Result result, Throwable throwable) {
-                    if (result.hasException()) {
                         while (entryStack.size() > 0) {
                             Entry entry = entryStack.pop();
                             Tracer.traceEntry(result.getException(), entry);
                             entry.exit();
-                        }
                     }
                 }
             });

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboConsumerFilter.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboConsumerFilter.java
@@ -53,13 +53,23 @@ public class SentinelDubboConsumerFilter extends BaseSentinelDubboFilter {
     }
 
     @Override
+    String getMethodName(Invoker invoker, Invocation invocation) {
+        return DubboUtils.getResourceName(invoker, invocation, DubboConfig.getDubboConsumerPrefix());
+    }
+
+    @Override
+    String getInterfaceName(Invoker invoker) {
+        return DubboUtils.getInterfaceName(invoker);
+    }
+
+    @Override
     public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {
         Entry interfaceEntry = null;
         Entry methodEntry = null;
         RpcContext rpcContext = RpcContext.getContext();
         try {
-            String methodResourceName = DubboUtils.getResourceName(invoker, invocation, DubboConfig.getDubboConsumerPrefix());
-            String interfaceResourceName = DubboUtils.getInterfaceName(invoker);
+            String methodResourceName = getMethodName(invoker, invocation);
+            String interfaceResourceName = getInterfaceName(invoker);
             InvokeMode invokeMode = RpcUtils.getInvokeMode(invoker.getUrl(), invocation);
 
             if (InvokeMode.SYNC == invokeMode) {

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboProviderFilter.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboProviderFilter.java
@@ -53,6 +53,16 @@ public class SentinelDubboProviderFilter extends BaseSentinelDubboFilter {
     }
 
     @Override
+    String getMethodName(Invoker invoker, Invocation invocation) {
+        return DubboUtils.getResourceName(invoker, invocation, DubboConfig.getDubboProviderPrefix());
+    }
+
+    @Override
+    String getInterfaceName(Invoker invoker) {
+        return DubboUtils.getInterfaceName(invoker);
+    }
+
+    @Override
     public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {
         // Get origin caller.
         String application = DubboUtils.getApplication(invocation, "");
@@ -60,8 +70,8 @@ public class SentinelDubboProviderFilter extends BaseSentinelDubboFilter {
         Entry interfaceEntry = null;
         Entry methodEntry = null;
         try {
-            String methodResourceName = DubboUtils.getResourceName(invoker, invocation, DubboConfig.getDubboProviderPrefix());
-            String interfaceResourceName = DubboUtils.getInterfaceName(invoker);
+            String methodResourceName = getMethodName(invoker, invocation);
+            String interfaceResourceName = getInterfaceName(invoker);
             // Only need to create entrance context at provider side, as context will take effect
             // at entrance of invocation chain only (for inbound traffic).
             ContextUtil.enter(methodResourceName, application);

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboProviderFilter.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboProviderFilter.java
@@ -19,16 +19,17 @@ import com.alibaba.csp.sentinel.Entry;
 import com.alibaba.csp.sentinel.EntryType;
 import com.alibaba.csp.sentinel.ResourceTypeConstants;
 import com.alibaba.csp.sentinel.SphU;
+import com.alibaba.csp.sentinel.Tracer;
 import com.alibaba.csp.sentinel.adapter.dubbo.config.DubboConfig;
 import com.alibaba.csp.sentinel.adapter.dubbo.fallback.DubboFallbackRegistry;
 import com.alibaba.csp.sentinel.context.ContextUtil;
 import com.alibaba.csp.sentinel.log.RecordLog;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
 import org.apache.dubbo.common.extension.Activate;
+import org.apache.dubbo.rpc.Filter;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Result;
-import org.apache.dubbo.rpc.RpcContext;
 import org.apache.dubbo.rpc.RpcException;
 
 import static org.apache.dubbo.common.constants.CommonConstants.PROVIDER;
@@ -66,21 +67,36 @@ public class SentinelDubboProviderFilter extends BaseSentinelDubboFilter {
     public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {
         // Get origin caller.
         String application = DubboUtils.getApplication(invocation, "");
-        RpcContext rpcContext = RpcContext.getContext();
         Entry interfaceEntry = null;
         Entry methodEntry = null;
+        String methodResourceName = getMethodName(invoker, invocation);
+        String interfaceResourceName = getInterfaceName(invoker);
         try {
-            String methodResourceName = getMethodName(invoker, invocation);
-            String interfaceResourceName = getInterfaceName(invoker);
             // Only need to create entrance context at provider side, as context will take effect
             // at entrance of invocation chain only (for inbound traffic).
             ContextUtil.enter(methodResourceName, application);
             interfaceEntry = SphU.entry(interfaceResourceName, ResourceTypeConstants.COMMON_RPC, EntryType.IN);
             methodEntry = SphU.entry(methodResourceName, ResourceTypeConstants.COMMON_RPC, EntryType.IN, invocation.getArguments());
-            rpcContext.set(methodResourceName, new Entry[]{interfaceEntry, methodEntry});
-            return invoker.invoke(invocation);
+            Result result = invoker.invoke(invocation);
+            if (result.hasException()) {
+                Tracer.traceEntry(result.getException(), interfaceEntry);
+                Tracer.traceEntry(result.getException(), methodEntry);
+            }
+            return result;
         } catch (BlockException e) {
             return DubboFallbackRegistry.getProviderFallback().handle(invoker, invocation, e);
+        } catch (RpcException e) {
+            Tracer.traceEntry(e, interfaceEntry);
+            Tracer.traceEntry(e, methodEntry);
+            throw e;
+        } finally {
+            if (methodEntry != null) {
+                methodEntry.exit(1, invocation.getArguments());
+            }
+            if (interfaceEntry != null) {
+                interfaceEntry.exit();
+            }
+            ContextUtil.exit();
         }
     }
 

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboProviderFilter.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboProviderFilter.java
@@ -61,15 +61,13 @@ public class SentinelDubboProviderFilter extends BaseSentinelDubboFilter {
         Entry methodEntry = null;
         try {
             String methodResourceName = DubboUtils.getResourceName(invoker, invocation, DubboConfig.getDubboProviderPrefix());
-            String interfaceResourceName = DubboConfig.getDubboInterfaceGroupAndVersionEnabled() ? invoker.getUrl().getColonSeparatedKey()
-                    : invoker.getInterface().getName();
+            String interfaceResourceName = DubboUtils.getInterfaceName(invoker);
             // Only need to create entrance context at provider side, as context will take effect
             // at entrance of invocation chain only (for inbound traffic).
             ContextUtil.enter(methodResourceName, application);
             interfaceEntry = SphU.entry(interfaceResourceName, ResourceTypeConstants.COMMON_RPC, EntryType.IN);
-            rpcContext.set(DubboUtils.DUBBO_INTERFACE_ENTRY_KEY, interfaceEntry);
             methodEntry = SphU.entry(methodResourceName, ResourceTypeConstants.COMMON_RPC, EntryType.IN, invocation.getArguments());
-            rpcContext.set(DubboUtils.DUBBO_METHOD_ENTRY_KEY, methodEntry);
+            rpcContext.set(methodResourceName, new Entry[]{interfaceEntry, methodEntry});
             return invoker.invoke(invocation);
         } catch (BlockException e) {
             return DubboFallbackRegistry.getProviderFallback().handle(invoker, invocation, e);

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/BaseTest.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/BaseTest.java
@@ -16,24 +16,18 @@
 package com.alibaba.csp.sentinel;
 
 import com.alibaba.csp.sentinel.adapter.dubbo.config.DubboConfig;
-import com.alibaba.csp.sentinel.adapter.dubbo.provider.DemoService;
+import com.alibaba.csp.sentinel.adapter.dubbo.fallback.DefaultDubboFallback;
+import com.alibaba.csp.sentinel.adapter.dubbo.fallback.DubboFallbackRegistry;
 import com.alibaba.csp.sentinel.config.SentinelConfig;
 import com.alibaba.csp.sentinel.context.ContextUtil;
 import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRuleManager;
 import com.alibaba.csp.sentinel.slots.block.flow.FlowRuleManager;
 import com.alibaba.csp.sentinel.slots.clusterbuilder.ClusterBuilderSlot;
-import org.apache.dubbo.common.URL;
-import org.apache.dubbo.common.constants.CommonConstants;
-import org.apache.dubbo.rpc.Invocation;
-import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.RpcContext;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Base test class, provide common methods for subClass
@@ -42,46 +36,41 @@ import static org.mockito.Mockito.when;
  * Note: Only for test. DO NOT USE IN PRODUCTION!
  *
  * @author cdfive
+ * @author lianglin
  */
 public class BaseTest {
 
 
-    protected Invoker invoker;
-    protected Invocation invocation;
-
-    public void constructInvokerAndInvocation() {
-        invoker = mock(Invoker.class);
-        URL url = URL.valueOf("dubbo://127.0.0.1:2181")
-                .addParameter(CommonConstants.VERSION_KEY, "1.0.0")
-                .addParameter(CommonConstants.GROUP_KEY, "grp1")
-                .addParameter(CommonConstants.INTERFACE_KEY, DemoService.class.getName());
-        when(invoker.getUrl()).thenReturn(url);
-        when(invoker.getInterface()).thenReturn(DemoService.class);
-
-        invocation = mock(Invocation.class);
-        Method method = DemoService.class.getMethods()[0];
-        when(invocation.getMethodName()).thenReturn(method.getName());
-        when(invocation.getParameterTypes()).thenReturn(method.getParameterTypes());
-
-    }
-
     /**
      * Clean up resources for context, clusterNodeMap, processorSlotChainMap
      */
-    protected static void cleanUpAll() {
+    public void cleanUpAll() {
         try {
-            RpcContext.removeContext();
-            ClusterBuilderSlot.getClusterNodeMap().clear();
-            CtSph.resetChainMap();
-            Method method = ContextUtil.class.getDeclaredMethod("resetContextMap");
-            method.setAccessible(true);
-            method.invoke(null, null);
-            ContextUtil.exit();
-            SentinelConfig.setConfig(DubboConfig.DUBBO_INTERFACE_GROUP_VERSION_ENABLED, "true");
-            FlowRuleManager.loadRules(new ArrayList<>());
-            DegradeRuleManager.loadRules(new ArrayList<>());
+            clearDubboContext();
+            cleanUpCstContext();
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
             e.printStackTrace();
         }
+    }
+
+    private void cleanUpCstContext() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        ClusterBuilderSlot.getClusterNodeMap().clear();
+        CtSph.resetChainMap();
+        Method method = ContextUtil.class.getDeclaredMethod("resetContextMap");
+        method.setAccessible(true);
+        method.invoke(null, null);
+        ContextUtil.exit();
+        FlowRuleManager.loadRules(new ArrayList<>());
+        DegradeRuleManager.loadRules(new ArrayList<>());
+    }
+
+    private void clearDubboContext() {
+        SentinelConfig.setConfig("csp.sentinel.dubbo.resource.use.prefix", "false");
+        SentinelConfig.setConfig(DubboConfig.DUBBO_PROVIDER_PREFIX, "");
+        SentinelConfig.setConfig(DubboConfig.DUBBO_CONSUMER_PREFIX, "");
+        SentinelConfig.setConfig(DubboConfig.DUBBO_INTERFACE_GROUP_VERSION_ENABLED, "false");
+        DubboFallbackRegistry.setConsumerFallback(new DefaultDubboFallback());
+        RpcContext.removeContext();
+
     }
 }

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/DubboTestUtil.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/DubboTestUtil.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel;
+
+import com.alibaba.csp.sentinel.adapter.dubbo.provider.DemoService;
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Invoker;
+
+import java.lang.reflect.Method;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author lianglin
+ */
+public class DubboTestUtil {
+
+
+    public static Class<?> DEFAULT_TEST_SERVICE = DemoService.class;
+    public static Method DEFAULT_TEST_METHOD_ONE = DEFAULT_TEST_SERVICE.getMethods()[0];
+    public static Method DEFAULT_TEST_METHOD_TWO = DEFAULT_TEST_SERVICE.getMethods()[1];
+
+    public static Invoker getMockInvoker(URL url, Class<?> cls) {
+        Invoker invoker = mock(Invoker.class);
+        when(invoker.getUrl()).thenReturn(url);
+        when(invoker.getInterface()).thenReturn(cls);
+        return invoker;
+    }
+
+    public static Invoker getDefaultMockInvoker() {
+        return getMockInvoker(getDefaultTestURL(), DEFAULT_TEST_SERVICE);
+    }
+
+    public static Invocation getMockInvocation(Method method) {
+        Invocation invocation = mock(Invocation.class);
+        when(invocation.getMethodName()).thenReturn(method.getName());
+        when(invocation.getParameterTypes()).thenReturn(method.getParameterTypes());
+        return invocation;
+    }
+
+    public static Invocation getDefaultMockInvocationOne() {
+        Invocation invocation = mock(Invocation.class);
+        when(invocation.getMethodName()).thenReturn(DEFAULT_TEST_METHOD_ONE.getName());
+        when(invocation.getParameterTypes()).thenReturn(DEFAULT_TEST_METHOD_ONE.getParameterTypes());
+        return invocation;
+    }
+
+    public static Invocation getDefaultMockInvocationTwo() {
+        Invocation invocation = mock(Invocation.class);
+        when(invocation.getMethodName()).thenReturn(DEFAULT_TEST_METHOD_TWO.getName());
+        when(invocation.getParameterTypes()).thenReturn(DEFAULT_TEST_METHOD_TWO.getParameterTypes());
+        return invocation;
+    }
+
+    public static URL getDefaultTestURL() {
+        URL url = URL.valueOf("dubbo://127.0.0.1:2181")
+                .addParameter(CommonConstants.VERSION_KEY, "1.0.0")
+                .addParameter(CommonConstants.GROUP_KEY, "grp1")
+                .addParameter(CommonConstants.INTERFACE_KEY, DEFAULT_TEST_SERVICE.getName());
+        return url;
+    }
+
+
+}

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/DubboUtilsTest.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/DubboUtilsTest.java
@@ -29,11 +29,10 @@ import org.junit.Test;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 
+import static com.alibaba.csp.sentinel.adapter.dubbo.config.DubboConfig.DUBBO_INTERFACE_GROUP_VERSION_ENABLED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * @author cdfive
@@ -45,7 +44,7 @@ public class DubboUtilsTest {
         SentinelConfig.setConfig("csp.sentinel.dubbo.resource.use.prefix", "true");
         SentinelConfig.setConfig(DubboConfig.DUBBO_PROVIDER_PREFIX, "");
         SentinelConfig.setConfig(DubboConfig.DUBBO_CONSUMER_PREFIX, "");
-        SentinelConfig.setConfig(DubboConfig.DUBBO_INTERFACE_GROUP_VERSION_ENABLED, "false");
+        SentinelConfig.setConfig(DUBBO_INTERFACE_GROUP_VERSION_ENABLED, "false");
     }
 
 
@@ -54,7 +53,7 @@ public class DubboUtilsTest {
         SentinelConfig.setConfig("csp.sentinel.dubbo.resource.use.prefix", "false");
         SentinelConfig.setConfig(DubboConfig.DUBBO_PROVIDER_PREFIX, "");
         SentinelConfig.setConfig(DubboConfig.DUBBO_CONSUMER_PREFIX, "");
-        SentinelConfig.setConfig(DubboConfig.DUBBO_INTERFACE_GROUP_VERSION_ENABLED, "false");
+        SentinelConfig.setConfig(DUBBO_INTERFACE_GROUP_VERSION_ENABLED, "false");
     }
 
 
@@ -144,6 +143,25 @@ public class DubboUtilsTest {
         assertEquals("my:dubbo:provider:com.alibaba.csp.sentinel.adapter.dubbo.provider.DemoService:sayHello(java.lang.String,int)", resourceName);
         resourceName = DubboUtils.getResourceName(invoker, invocation, DubboConfig.getDubboConsumerPrefix());
         assertEquals("my:dubbo:consumer:com.alibaba.csp.sentinel.adapter.dubbo.provider.DemoService:sayHello(java.lang.String,int)", resourceName);
+
+    }
+
+    @Test
+    public void testGetInterfaceName() {
+
+        URL url = URL.valueOf("dubbo://127.0.0.1:2181")
+                .addParameter(CommonConstants.VERSION_KEY, "1.0.0")
+                .addParameter(CommonConstants.GROUP_KEY, "grp1")
+                .addParameter(CommonConstants.INTERFACE_KEY, DemoService.class.getName());
+        Invoker invoker = mock(Invoker.class);
+        when(invoker.getUrl()).thenReturn(url);
+        when(invoker.getInterface()).thenReturn(DemoService.class);
+
+        SentinelConfig.setConfig(DUBBO_INTERFACE_GROUP_VERSION_ENABLED, "false");
+        assertEquals("com.alibaba.csp.sentinel.adapter.dubbo.provider.DemoService", DubboUtils.getInterfaceName(invoker));
+
+        SentinelConfig.setConfig(DUBBO_INTERFACE_GROUP_VERSION_ENABLED, "true");
+        assertEquals("com.alibaba.csp.sentinel.adapter.dubbo.provider.DemoService:1.0.0:grp1", DubboUtils.getInterfaceName(invoker));
 
     }
 }

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboConsumerFilterTest.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboConsumerFilterTest.java
@@ -264,10 +264,10 @@ public class SentinelDubboConsumerFilterTest extends BaseTest {
         // As SphU.entry(interfaceName, EntryType.OUT);
         Set<Node> childList = entranceNode.getChildList();
         assertEquals(1, childList.size());
-        DefaultNode interfaceNode = getNode(invoker.getUrl().getColonSeparatedKey(), entranceNode);
+        DefaultNode interfaceNode = getNode(DubboUtils.getInterfaceName(invoker), entranceNode);
         ResourceWrapper interfaceResource = interfaceNode.getId();
 
-        assertEquals(invoker.getUrl().getColonSeparatedKey(), interfaceResource.getName());
+        assertEquals(DubboUtils.getInterfaceName(invoker), interfaceResource.getName());
         assertSame(EntryType.OUT, interfaceResource.getEntryType());
 
         // As SphU.entry(resourceName, EntryType.OUT);

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboConsumerFilterTest.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboConsumerFilterTest.java
@@ -19,7 +19,6 @@ import com.alibaba.csp.sentinel.BaseTest;
 import com.alibaba.csp.sentinel.DubboTestUtil;
 import com.alibaba.csp.sentinel.Entry;
 import com.alibaba.csp.sentinel.EntryType;
-import com.alibaba.csp.sentinel.adapter.dubbo.config.DubboConfig;
 import com.alibaba.csp.sentinel.adapter.dubbo.fallback.DubboFallback;
 import com.alibaba.csp.sentinel.adapter.dubbo.fallback.DubboFallbackRegistry;
 import com.alibaba.csp.sentinel.context.Context;
@@ -66,7 +65,6 @@ public class SentinelDubboConsumerFilterTest extends BaseTest {
     private SentinelDubboConsumerFilter consumerFilter = new SentinelDubboConsumerFilter();
 
 
-
     @Before
     public void setUp() {
         cleanUpAll();
@@ -75,7 +73,7 @@ public class SentinelDubboConsumerFilterTest extends BaseTest {
 
     @After
     public void destroy() {
-       cleanUpAll();
+        cleanUpAll();
     }
 
 
@@ -176,7 +174,7 @@ public class SentinelDubboConsumerFilterTest extends BaseTest {
         Invoker invoker = DubboTestUtil.getDefaultMockInvoker();
 
         when(invocation.getAttachment(ASYNC_KEY)).thenReturn(Boolean.TRUE.toString());
-        initFlowRule(DubboUtils.getResourceName(invoker, invocation, DubboConfig.getDubboConsumerPrefix()));
+        initFlowRule(consumerFilter.getMethodName(invoker, invocation));
         invokeDubboRpc(false, invoker, invocation);
         invokeDubboRpc(false, invoker, invocation);
 
@@ -238,7 +236,6 @@ public class SentinelDubboConsumerFilterTest extends BaseTest {
     }
 
 
-
     /**
      * Simply verify invocation structure in memory:
      * EntranceNode(defaultContextName)
@@ -251,7 +248,7 @@ public class SentinelDubboConsumerFilterTest extends BaseTest {
         // As not call ContextUtil.enter(resourceName, application) in SentinelDubboConsumerFilter, use default context
         // In actual project, a consumer is usually also a provider, the context will be created by SentinelDubboProviderFilter
         // If consumer is on the top of Dubbo RPC invocation chain, use default context
-        String resourceName = DubboUtils.getResourceName(invoker, invocation, DubboConfig.getDubboProviderPrefix());
+        String resourceName = consumerFilter.getMethodName(invoker, invocation);
         assertEquals(com.alibaba.csp.sentinel.Constants.CONTEXT_DEFAULT_NAME, context.getName());
         assertEquals("", context.getOrigin());
 
@@ -304,7 +301,7 @@ public class SentinelDubboConsumerFilterTest extends BaseTest {
         // As not call ContextUtil.enter(resourceName, application) in SentinelDubboConsumerFilter, use default context
         // In actual project, a consumer is usually also a provider, the context will be created by SentinelDubboProviderFilter
         // If consumer is on the top of Dubbo RPC invocation chain, use default context
-        String resourceName = DubboUtils.getResourceName(invoker, invocation, DubboConfig.getDubboProviderPrefix());
+        String resourceName = consumerFilter.getMethodName(invoker, invocation);
         assertEquals(com.alibaba.csp.sentinel.Constants.CONTEXT_DEFAULT_NAME, context.getName());
         assertEquals("", context.getOrigin());
 
@@ -351,7 +348,7 @@ public class SentinelDubboConsumerFilterTest extends BaseTest {
     private void verifyInvocationStructureForCallFinish(Invoker invoker, Invocation invocation) {
         Context context = ContextUtil.getContext();
         assertNull(context);
-        String methodResourceName = DubboUtils.getResourceName(invoker, invocation, DubboConfig.getDubboConsumerPrefix());
+        String methodResourceName = consumerFilter.getMethodName(invoker, invocation);
         Entry[] entries = (Entry[]) RpcContext.getContext().get(methodResourceName);
         assertNull(entries);
     }

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboProviderFilterTest.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboProviderFilterTest.java
@@ -104,7 +104,7 @@ public class SentinelDubboProviderFilterTest extends BaseTest {
         assertNotNull(context);
 
         // As ContextUtil.enter(resourceName, application) in SentinelDubboProviderFilter
-        String methodResourceName = DubboUtils.getResourceName(invoker, invocation, DubboConfig.getDubboConsumerPrefix());
+        String methodResourceName = filter.getMethodName(invoker, invocation);
         assertEquals(methodResourceName, context.getName());
         assertEquals(originApplication, context.getOrigin());
 

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboProviderFilterTest.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboProviderFilterTest.java
@@ -16,8 +16,10 @@
 package com.alibaba.csp.sentinel.adapter.dubbo;
 
 import com.alibaba.csp.sentinel.BaseTest;
+import com.alibaba.csp.sentinel.DubboTestUtil;
 import com.alibaba.csp.sentinel.Entry;
 import com.alibaba.csp.sentinel.EntryType;
+import com.alibaba.csp.sentinel.adapter.dubbo.config.DubboConfig;
 import com.alibaba.csp.sentinel.adapter.dubbo.provider.DemoService;
 import com.alibaba.csp.sentinel.context.Context;
 import com.alibaba.csp.sentinel.context.ContextUtil;
@@ -35,52 +37,49 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 /**
  * @author cdfive
+ * @author lianglin
  */
 public class SentinelDubboProviderFilterTest extends BaseTest {
 
+
     private SentinelDubboProviderFilter filter = new SentinelDubboProviderFilter();
+
 
     @Before
     public void setUp() {
-        constructInvokerAndInvocation();
         cleanUpAll();
     }
 
     @After
-    public void cleanUp() {
+    public void destroy() {
         cleanUpAll();
     }
 
     @Test
     public void testInvoke() {
+
         final String originApplication = "consumerA";
 
-        URL url = invoker.getUrl()
-                .addParameter(CommonConstants.SIDE_KEY, CommonConstants.PROVIDER_SIDE);
-        when(invoker.getUrl()).thenReturn(url);
+        URL url = DubboTestUtil.getDefaultTestURL();
+        url = url.addParameter(CommonConstants.SIDE_KEY, CommonConstants.PROVIDER_SIDE);
+        Invoker invoker = DubboTestUtil.getMockInvoker(url, DemoService.class);
 
+        Invocation invocation = DubboTestUtil.getMockInvocation(DemoService.class.getMethods()[0]);
         when(invocation.getAttachment(DubboUtils.SENTINEL_DUBBO_APPLICATION_KEY, ""))
                 .thenReturn(originApplication);
 
         final Result result = mock(Result.class);
         when(result.hasException()).thenReturn(false);
         when(result.getException()).thenReturn(new Exception());
+
         when(invoker.invoke(invocation)).thenAnswer(invocationOnMock -> {
             verifyInvocationStructure(originApplication, invoker, invocation);
             return result;
@@ -96,22 +95,22 @@ public class SentinelDubboProviderFilterTest extends BaseTest {
 
     /**
      * Simply verify invocation structure in memory:
-     * EntranceNode(resourceName)
+     * EntranceNode(methodResourceName)
      * --InterfaceNode(interfaceName)
-     * ----MethodNode(resourceName)
+     * ----MethodNode(methodResourceName)
      */
     private void verifyInvocationStructure(String originApplication, Invoker invoker, Invocation invocation) {
         Context context = ContextUtil.getContext();
         assertNotNull(context);
 
         // As ContextUtil.enter(resourceName, application) in SentinelDubboProviderFilter
-        String resourceName = DubboUtils.getResourceName(invoker, invocation, true);
-        assertEquals(resourceName, context.getName());
+        String methodResourceName = DubboUtils.getResourceName(invoker, invocation, DubboConfig.getDubboConsumerPrefix());
+        assertEquals(methodResourceName, context.getName());
         assertEquals(originApplication, context.getOrigin());
 
         DefaultNode entranceNode = context.getEntranceNode();
         ResourceWrapper entranceResource = entranceNode.getId();
-        assertEquals(resourceName, entranceResource.getName());
+        assertEquals(methodResourceName, entranceResource.getName());
         assertSame(EntryType.IN, entranceResource.getEntryType());
 
         // As SphU.entry(interfaceName, EntryType.IN);
@@ -120,7 +119,11 @@ public class SentinelDubboProviderFilterTest extends BaseTest {
         DefaultNode interfaceNode = (DefaultNode) childList.iterator().next();
         ResourceWrapper interfaceResource = interfaceNode.getId();
 
-        assertEquals(invoker.getUrl().getColonSeparatedKey(), interfaceResource.getName());
+        if (DubboConfig.getDubboInterfaceGroupAndVersionEnabled()) {
+            assertEquals(invoker.getUrl().getColonSeparatedKey(), interfaceResource.getName());
+        } else {
+            assertEquals(invoker.getInterface().getName(), interfaceResource.getName());
+        }
         assertSame(EntryType.IN, interfaceResource.getEntryType());
 
         // As SphU.entry(resourceName, EntryType.IN, 1, invocation.getArguments());
@@ -128,7 +131,7 @@ public class SentinelDubboProviderFilterTest extends BaseTest {
         assertEquals(1, childList.size());
         DefaultNode methodNode = (DefaultNode) childList.iterator().next();
         ResourceWrapper methodResource = methodNode.getId();
-        assertEquals(resourceName, methodResource.getName());
+        assertEquals(methodResourceName, methodResource.getName());
         assertSame(EntryType.IN, methodResource.getEntryType());
 
         // Verify curEntry
@@ -151,4 +154,6 @@ public class SentinelDubboProviderFilterTest extends BaseTest {
         assertEquals(1, interfaceOriginCountMap.size());
         assertTrue(interfaceOriginCountMap.containsKey(originApplication));
     }
+
+
 }

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboProviderFilterTest.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboProviderFilterTest.java
@@ -19,7 +19,6 @@ import com.alibaba.csp.sentinel.BaseTest;
 import com.alibaba.csp.sentinel.DubboTestUtil;
 import com.alibaba.csp.sentinel.Entry;
 import com.alibaba.csp.sentinel.EntryType;
-import com.alibaba.csp.sentinel.adapter.dubbo.config.DubboConfig;
 import com.alibaba.csp.sentinel.adapter.dubbo.provider.DemoService;
 import com.alibaba.csp.sentinel.context.Context;
 import com.alibaba.csp.sentinel.context.ContextUtil;
@@ -88,7 +87,6 @@ public class SentinelDubboProviderFilterTest extends BaseTest {
         filter.invoke(invoker, invocation);
         verify(invoker).invoke(invocation);
 
-        filter.listener().onMessage(result, invoker, invocation);
         Context context = ContextUtil.getContext();
         assertNull(context);
     }
@@ -119,11 +117,7 @@ public class SentinelDubboProviderFilterTest extends BaseTest {
         DefaultNode interfaceNode = (DefaultNode) childList.iterator().next();
         ResourceWrapper interfaceResource = interfaceNode.getId();
 
-        if (DubboConfig.getDubboInterfaceGroupAndVersionEnabled()) {
-            assertEquals(invoker.getUrl().getColonSeparatedKey(), interfaceResource.getName());
-        } else {
-            assertEquals(invoker.getInterface().getName(), interfaceResource.getName());
-        }
+        assertEquals(filter.getInterfaceName(invoker), interfaceResource.getName());
         assertSame(EntryType.IN, interfaceResource.getEntryType());
 
         // As SphU.entry(resourceName, EntryType.IN, 1, invocation.getArguments());


### PR DESCRIPTION


### Does this pull request fix one issue?

fix https://github.com/alibaba/Sentinel/issues/1416

### Describe how you did it

The reason for  Full GC is  **CtEntry**   stored in **RpcContext** can't be clear correctly when application process a nested dubbo-rpc. For example: [A(client)] -> [B(provider) -> C(provider)].

 As we know that, one-time dubbo-rpc in sentinel will create two CtEntry: **interfaceEntry**, **methodEntry**. According to design, at the beginning of  rpc  we create refer-CtEntries and  put them it Dubbo#RpcContext, clear the Dubbo#RpcContext's refer-CtEntries when finised. It does well when just do a direct rpc. But while lauch a  nested dubbo-rpc **[B(provider) -> C(provider)]**), The B(provider)'s CtEntries will not be clear correctly. Because B and C use the fixed-same key for store CtEntries. C  remove the key firstly, B will not find the key ,skip the clear logic   lead to  ` ContextUtil.exit()`  take no effect  the key point lead to Full GC.

Store Logic
```
interfaceEntry = SphU.entry(interfaceResourceName, ResourceTypeConstants.COMMON_RPC, EntryType.IN);
rpcContext.set(DubboUtils.DUBBO_INTERFACE_ENTRY_KEY, interfaceEntry);
methodEntry = SphU.entry(methodResourceName, ResourceTypeConstants.COMMON_RPC, EntryType.IN, invocation.getArguments());
rpcContext.set(DubboUtils.DUBBO_METHOD_ENTRY_KEY, methodEntry);
```

Clear Logic
```
Entry interfaceEntry = (Entry) RpcContext.getContext().get(DubboUtils.DUBBO_INTERFACE_ENTRY_KEY);
Entry methodEntry = (Entry) RpcContext.getContext().get(DubboUtils.DUBBO_METHOD_ENTRY_KEY);
  if (methodEntry != null) {
            Tracer.traceEntry(throwable, methodEntry);
            methodEntry.exit();
            RpcContext.getContext().remove(DubboUtils.DUBBO_METHOD_ENTRY_KEY);
 }
 if (interfaceEntry != null) {
            Tracer.traceEntry(throwable, interfaceEntry);
            interfaceEntry.exit();
            RpcContext.getContext().remove(DubboUtils.DUBBO_INTERFACE_ENTRY_KEY);
  }
```

Sentinel ContextUtil is a Thread-Local Design, Dubbo use thread-pool manager dubbo-rpc thread.
if ` ContextUtil.exit()` don't take effect, when new Request come in the _**context**_  the  more entries will refer which can't be collected by  gc.  Over time the full gc will occr.

And  the solution is also simple: just assign different key to different request.

### Describe how to verify it


### Special notes for reviews
