### PR TITLE
Update method name of AbstractSentinelInterceptor in Spring Web adapter

### DIFF
--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/AbstractSentinelInterceptor.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/AbstractSentinelInterceptor.java
@@ -129,7 +129,7 @@ public abstract class AbstractSentinelInterceptor implements HandlerInterceptor 
         request.removeAttribute(baseWebMvcConfig.getRequestAttributeName());
     }
 
-    protected void traceExceptionAndExit(Entry entry, Exception ex) {
+    protected void traceEntryAndExit(Entry entry, Exception ex) {
         if (entry != null) {
             if (ex != null) {
                 Tracer.traceEntry(ex, entry);


### PR DESCRIPTION
The old name is a little bit unclear. So in fact in this method, it is tracking from the entry to exit in order to catch the error messages. But the old name makes people may think that this method is tracking the exception happening process. Just want to make it clear

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
