### PR TITLE
support param flow for complex param

### DIFF
--- a/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowArgument.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowArgument.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.slots.block.flow.param;
+
+/**
+ * ParamFlowArgument
+ */
+public interface ParamFlowArgument {
+
+    /**
+     * @return the object as a key of param flow limit
+     */
+    Object paramFlowKey();
+}

--- a/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowChecker.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowChecker.java
@@ -56,8 +56,14 @@ public final class ParamFlowChecker {
             return true;
         }
 
-        // Get parameter value. If value is null, then pass.
+        // Get parameter value.
         Object value = args[paramIdx];
+
+        // Assign value with the result of paramFlowKey method
+        if (value instanceof ParamFlowArgument) {
+            value = ((ParamFlowArgument) value).paramFlowKey();
+        }
+        // If value is null, then pass
         if (value == null) {
             return true;
         }


### PR DESCRIPTION
In some scenarios, we may need to limit the flow of a field of a complex object, but the current version does not support it. Therefore, we provide an interface that allows to construct and return a value as the limit object.