### PR TITLE
webmvc-adapter: improve set entry in request to avoid ErrorEntryFreeException

### DIFF
--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/AbstractSentinelInterceptor.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/AbstractSentinelInterceptor.java
@@ -61,9 +61,7 @@ public abstract class AbstractSentinelInterceptor implements HandlerInterceptor 
                 String origin = parseOrigin(request);
                 String contextName = getContextName(request);
                 ContextUtil.enter(contextName, origin);
-                Entry entry = SphU.entry(resourceName, ResourceTypeConstants.COMMON_WEB, EntryType.IN);
-
-                setEntryInRequest(request, baseWebMvcConfig.getRequestAttributeName(), entry);
+                setEntryInRequest(request, baseWebMvcConfig.getRequestAttributeName(), resourceName);
             }
             return true;
         } catch (BlockException e) {
@@ -110,12 +108,13 @@ public abstract class AbstractSentinelInterceptor implements HandlerInterceptor 
                            ModelAndView modelAndView) throws Exception {
     }
 
-    protected void setEntryInRequest(HttpServletRequest request, String name, Entry entry) {
+    protected void setEntryInRequest(HttpServletRequest request, String name, String resourceName) throws BlockException {
         Object attrVal = request.getAttribute(name);
         if (attrVal != null) {
             RecordLog.warn("[{}] The attribute key '{}' already exists in request, please set `requestAttributeName`",
                 getClass().getSimpleName(), name);
         } else {
+            Entry entry = SphU.entry(resourceName, ResourceTypeConstants.COMMON_WEB, EntryType.IN);
             request.setAttribute(name, entry);
         }
     }

--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/AbstractSentinelInterceptor.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/AbstractSentinelInterceptor.java
@@ -108,6 +108,15 @@ public abstract class AbstractSentinelInterceptor implements HandlerInterceptor 
                            ModelAndView modelAndView) throws Exception {
     }
 
+    /**
+     * Note:
+     * If the attribute key already exists in request, don't create new {@link Entry},
+     * to guarantee the order of {@link Entry} in pair and avoid {@link com.alibaba.csp.sentinel.ErrorEntryFreeException}.
+     *
+     * Refer to:
+     * https://github.com/alibaba/Sentinel/issues/1531
+     * https://github.com/alibaba/Sentinel/issues/1482
+     */
     protected void setEntryInRequest(HttpServletRequest request, String name, String resourceName) throws BlockException {
         Object attrVal = request.getAttribute(name);
         if (attrVal != null) {


### PR DESCRIPTION
### Describe what this PR does / why we need it

The `AbstractSentinelInterceptor` of `sentinel-spring-webmvc-adapter` may enter twice under some circumstances, such no view page exists 

### Does this pull request fix one issue?

Relate to #1531, #1482 

### Describe how you did it

Refator `setEntryInRequest` method, if attribute key already exists in request, we don't call `SphU.entry` to create Entry, then Entry get from request can exit normally in `afterCompletion` method.

### Describe how to verify it

Add a tmp test Controller in `sentinel-demo-spring-webmvc` to verify if it works.
```java
@Controller
@RequestMapping("/")
public class TmpTestController {

    @RequestMapping("/view_not_exists")
    public String view_not_exists() {
        return "/view_not_exists.html";
    }
}
```

### Special notes for reviews

The tmp test Controller is used for debug and test, so it has not been committed.
