### PR TITLE
[bugfix]FLowRule class equals() function is wrong

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRule.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRule.java
@@ -19,6 +19,7 @@ import com.alibaba.csp.sentinel.context.Context;
 import com.alibaba.csp.sentinel.node.DefaultNode;
 import com.alibaba.csp.sentinel.slots.block.AbstractRule;
 import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+import java.util.Objects;
 
 /**
  * <p>
@@ -206,8 +207,9 @@ public class FlowRule extends AbstractRule {
         if (warmUpPeriodSec != rule.warmUpPeriodSec) { return false; }
         if (maxQueueingTimeMs != rule.maxQueueingTimeMs) { return false; }
         if (clusterMode != rule.clusterMode) { return false; }
-        if (refResource != null ? !refResource.equals(rule.refResource) : rule.refResource != null) { return false; }
-        return clusterConfig != null ? clusterConfig.equals(rule.clusterConfig) : rule.clusterConfig == null;
+        if (!Objects.equals(refResource, rule.refResource)) { return false; }
+        if(!Objects.equals(controller,rule.controller)){ return false; }
+        return Objects.equals(clusterConfig, rule.clusterConfig);
     }
 
     @Override
@@ -224,6 +226,7 @@ public class FlowRule extends AbstractRule {
         result = 31 * result + maxQueueingTimeMs;
         result = 31 * result + (clusterMode ? 1 : 0);
         result = 31 * result + (clusterConfig != null ? clusterConfig.hashCode() : 0);
+        result = 31 * result + (controller != null ? controller.hashCode() : 0);
         return result;
     }
 


### PR DESCRIPTION
Signed-off-by: yunfeiyanggzq <yunfeiyang@buaa.edu.cn>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
The previous code forgot to compare `controller`,so even the controller is different,the ruleFlow is equal

### Special notes for reviews
I am an asoc participant. I will be mainly responsible for the cluster flow control. I will supplement the missing unit tests while reading the relative code.Thanks for your review and help!!!
