### PR TITLE
add args to make all test cases can pass when running mvn test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -272,6 +272,7 @@
                 <configuration>
                     <!-- CircleCI build workaround -->
                     <argLine>@{argLine} -Xms1024m -Xmx2048m</argLine>
+                    <argLine>-Dfile.encoding=UTF-8</argLine>
                     <useSystemClassLoader>false</useSystemClassLoader>
                 </configuration>
             </plugin>


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

fix the problem when run mvn test in terminal, not all test cases can pass.

### Does this pull request fix one issue?

Fixes #1549
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

add JVM args of maven-surefire-plugin

### Describe how to verify it

run mvn test under the root directory of Sentinel

### Special notes for reviews
