### PR TITLE
provide add single rule for xRuleManager

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/authority/AuthorityRuleManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/authority/AuthorityRuleManager.java
@@ -89,6 +89,27 @@ public final class AuthorityRuleManager {
         return rules;
     }
 
+    /**
+     * add a single AuthorityRule
+     *
+     * @param rule
+     * @return void
+     */
+    public static void addRule(AuthorityRule rule){
+        if (isValidRule(rule)) {
+            String resource = rule.getResource();
+            Set<AuthorityRule> oldSet = authorityRules.get(resource);
+            if (null != oldSet) {
+                oldSet.add(rule);
+                authorityRules.put(resource, oldSet);
+                return;
+            }
+            Set<AuthorityRule> newSet = new HashSet<>();
+            newSet.add(rule);
+            authorityRules.put(resource, newSet);
+        }
+    }
+
     private static class RulePropertyListener implements PropertyListener<List<AuthorityRule>> {
 
         @Override

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeRuleManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeRuleManager.java
@@ -118,6 +118,27 @@ public final class DegradeRuleManager {
     }
 
     /**
+     * add a single DegradeRule
+     *
+     * @param rule
+     * @return void
+     */
+    public static void addRule(DegradeRule rule){
+        if (isValidRule(rule)) {
+            String resource = rule.getResource();
+            Set<DegradeRule> oldSet = degradeRules.get(resource);
+            if (null != oldSet) {
+                oldSet.add(rule);
+                degradeRules.put(resource, oldSet);
+                return;
+            }
+            Set<DegradeRule> newSet = new HashSet<>();
+            newSet.add(rule);
+            degradeRules.put(resource, newSet);
+        }
+    }
+
+    /**
      * Set degrade rules for provided resource. Former rules of the resource will be replaced.
      *
      * @param resourceName valid resource name

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManager.java
@@ -15,9 +15,7 @@
  */
 package com.alibaba.csp.sentinel.slots.block.flow;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -90,6 +88,27 @@ public class FlowRuleManager {
     }
 
     /**
+     * add a single FlowRule
+     *
+     * @param rule
+     * @return void
+     */
+    public static void addRule(FlowRule rule){
+        if (isValidRule(rule)) {
+            String resource = rule.getResource();
+            List<FlowRule> oldSet = flowRules.get(resource);
+            if (null != oldSet) {
+                oldSet.add(rule);
+                flowRules.put(resource, oldSet);
+                return;
+            }
+            List<FlowRule> newSet = new ArrayList<>();
+            newSet.add(rule);
+            flowRules.put(resource, newSet);
+        }
+    }
+
+    /**
      * Load {@link FlowRule}s, former rules will be replaced.
      *
      * @param rules new rules to load.
@@ -147,4 +166,8 @@ public class FlowRuleManager {
         }
     }
 
+    public static boolean isValidRule(FlowRule rule) {
+        return rule != null && StringUtil.isNotBlank(rule.getResource())
+                && rule.getCount() >= 0 && StringUtil.isNotBlank(rule.getLimitApp());
+    }
 }

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/authority/AuthorityRuleManagerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/authority/AuthorityRuleManagerTest.java
@@ -60,4 +60,30 @@ public class AuthorityRuleManagerTest {
     public void tearDown() {
         AuthorityRuleManager.loadRules(null);
     }
+
+
+    @Test
+    public void testAddRule() {
+        AuthorityRule rule1 = new AuthorityRule();
+        rule1.setResource("newRule");
+        rule1.setLimitApp("a,b");
+        rule1.setStrategy(RuleConstant.AUTHORITY_WHITE);
+        AuthorityRuleManager.addRule(rule1);
+        assertTrue(AuthorityRuleManager.hasConfig("newRule"));
+
+        AuthorityRule rule2 = new AuthorityRule();
+        rule2.setResource("abc");
+        AuthorityRuleManager.addRule(rule2);
+        assertFalse(AuthorityRuleManager.hasConfig("abc"));
+
+        AuthorityRule rule3 = new AuthorityRule();
+        rule3.setResource("newRule");
+        rule3.setLimitApp("a,c");
+        rule3.setStrategy(RuleConstant.AUTHORITY_BLACK);
+        AuthorityRuleManager.addRule(rule3);
+        List<AuthorityRule> rules = AuthorityRuleManager.getRules();
+        for (AuthorityRule r : rules){
+            assertTrue(r == rule1 || r == rule3);
+        }
+    }
 }

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeRuleManagerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeRuleManagerTest.java
@@ -19,6 +19,8 @@ import com.alibaba.csp.sentinel.slots.block.RuleConstant;
 
 import org.junit.Test;
 
+import java.util.List;
+
 import static org.junit.Assert.*;
 
 /**
@@ -61,5 +63,31 @@ public class DegradeRuleManagerTest {
         assertFalse(DegradeRuleManager.isValidRule(rule4));
         assertFalse(DegradeRuleManager.isValidRule(rule5));
         assertFalse(DegradeRuleManager.isValidRule(rule6));
+    }
+
+    @Test
+    public void testAddRule() {
+        DegradeRule rule1 = new DegradeRule("newRule")
+                .setCount(0.93d)
+                .setGrade(RuleConstant.DEGRADE_GRADE_RT)
+                .setTimeWindow(20)
+                .setMinRequestAmount(0);
+        DegradeRuleManager.addRule(rule1);
+        assertTrue(DegradeRuleManager.hasConfig("newRule"));
+
+        DegradeRule rule2 = new DegradeRule("abc");
+        DegradeRuleManager.addRule(rule2);
+        assertFalse(DegradeRuleManager.hasConfig("abc"));
+
+        DegradeRule rule3 = new DegradeRule("newRule")
+                .setCount(0.93d)
+                .setGrade(RuleConstant.DEGRADE_GRADE_EXCEPTION_COUNT)
+                .setTimeWindow(10)
+                .setMinRequestAmount(0);
+        DegradeRuleManager.addRule(rule3);
+        List<DegradeRule> rules = DegradeRuleManager.getRules();
+        for (DegradeRule r : rules){
+            assertTrue(r == rule1 || r == rule3);
+        }
     }
 }

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManagerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManagerTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.slots.block.flow;
+
+import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRule;
+import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRuleManager;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test cases for {@link FlowRuleManager}.
+ *
+ * @author Lovnx
+ */
+public class FlowRuleManagerTest {
+
+    @Test
+    public void testAddRule() {
+        FlowRule rule1 = new FlowRule("newRule");
+        rule1.setGrade(RuleConstant.FLOW_GRADE_QPS);
+        rule1.setCount(1);
+        rule1.setLimitApp("default");
+        rule1.setStrategy(RuleConstant.STRATEGY_DIRECT);
+        FlowRuleManager.addRule(rule1);
+        assertTrue(FlowRuleManager.hasConfig("newRule"));
+
+        FlowRule rule2 = new FlowRule("abc");
+        rule2.setCount(-1);
+        FlowRuleManager.addRule(rule2);
+        assertFalse(FlowRuleManager.hasConfig("abc"));
+
+        FlowRule rule3 = new FlowRule("newRule");
+        rule3.setGrade(RuleConstant.FLOW_GRADE_THREAD);
+        rule3.setCount(1);
+        rule3.setLimitApp("default");
+        rule3.setStrategy(RuleConstant.STRATEGY_DIRECT);
+        FlowRuleManager.addRule(rule3);
+        List<FlowRule> rules = FlowRuleManager.getRules();
+        for (FlowRule r : rules){
+            assertTrue(r == rule1 || r == rule3);
+        }
+    }
+}

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManagerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManagerTest.java
@@ -16,8 +16,6 @@
 package com.alibaba.csp.sentinel.slots.block.flow;
 
 import com.alibaba.csp.sentinel.slots.block.RuleConstant;
-import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRule;
-import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRuleManager;
 import org.junit.Test;
 
 import java.util.List;


### PR DESCRIPTION
### Describe what this PR does / why we need it
In a specific scenario, which Rules are not controlled and updated by using Sentinel dashboard, only initialize it and update it by code. you have to add a new Rule only like this below:
```
            List<DegradeRule> rules = DegradeRuleManager.getRules();
            rules.add(rule);
            DegradeRuleManager.loadRules(rules);
```
It may cause concurrency problem.

### Does this pull request fix one issue?

Fixes #1614 

### Describe how you did it
provide a new method to add single Rule.

### Describe how to verify it
I provide some test case with this PR.

### Special notes for reviews
