### PR TITLE
Refactor the flow of request to fix #1638 for circuit breakers

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Entry.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Entry.java
@@ -17,6 +17,7 @@ package com.alibaba.csp.sentinel;
 
 import com.alibaba.csp.sentinel.slots.block.BlockException;
 import com.alibaba.csp.sentinel.util.TimeUtil;
+import com.alibaba.csp.sentinel.util.function.BiConsumer;
 import com.alibaba.csp.sentinel.context.ContextUtil;
 import com.alibaba.csp.sentinel.node.Node;
 import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
@@ -178,4 +179,13 @@ public abstract class Entry implements AutoCloseable {
         this.originNode = originNode;
     }
 
+    /**
+     * Like `CompletableFuture` since JDK8 it guarantees specified consumer
+     * is invoked when this entry exited.
+     * Use it when you did some STATEFUL operations on entries.
+     * 
+     * @param consumer
+     */
+    public abstract void whenComplete(BiConsumer<Context, Entry> consumer);
+    
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeSlot.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeSlot.java
@@ -26,7 +26,6 @@ import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
 import com.alibaba.csp.sentinel.slots.block.degrade.circuitbreaker.CircuitBreaker;
 import com.alibaba.csp.sentinel.spi.SpiOrder;
-import com.alibaba.csp.sentinel.util.TimeUtil;
 
 /**
  * A {@link ProcessorSlot} dedicates to circuit breaking.
@@ -40,18 +39,18 @@ public class DegradeSlot extends AbstractLinkedProcessorSlot<DefaultNode> {
     @Override
     public void entry(Context context, ResourceWrapper resourceWrapper, DefaultNode node, int count,
                       boolean prioritized, Object... args) throws Throwable {
-        performChecking(resourceWrapper);
+        performChecking(context, resourceWrapper);
 
         fireEntry(context, resourceWrapper, node, count, prioritized, args);
     }
 
-    void performChecking(ResourceWrapper r) throws BlockException {
+    void performChecking(Context context, ResourceWrapper r) throws BlockException {
         List<CircuitBreaker> circuitBreakers = DegradeRuleManager.getCircuitBreakers(r.getName());
         if (circuitBreakers == null || circuitBreakers.isEmpty()) {
             return;
         }
         for (CircuitBreaker cb : circuitBreakers) {
-            if (!cb.tryPass()) {
+            if (!cb.tryPass(context, r)) {
                 throw new DegradeException(cb.getRule().getLimitApp(), cb.getRule());
             }
         }
@@ -71,14 +70,9 @@ public class DegradeSlot extends AbstractLinkedProcessorSlot<DefaultNode> {
         }
 
         if (curEntry.getBlockError() == null) {
-            long completeTime = curEntry.getCompleteTimestamp();
-            if (completeTime <= 0) {
-                completeTime = TimeUtil.currentTimeMillis();
-            }
-            long rt = completeTime - curEntry.getCreateTimestamp();
-            Throwable error = curEntry.getError();
+            // passed request
             for (CircuitBreaker circuitBreaker : circuitBreakers) {
-                circuitBreaker.onRequestComplete(rt, error);
+                circuitBreaker.afterRequestPassed(context, r);
             }
         }
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeSlot.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeSlot.java
@@ -72,7 +72,7 @@ public class DegradeSlot extends AbstractLinkedProcessorSlot<DefaultNode> {
         if (curEntry.getBlockError() == null) {
             // passed request
             for (CircuitBreaker circuitBreaker : circuitBreakers) {
-                circuitBreaker.afterRequestPassed(context, r);
+                circuitBreaker.onRequestComplete(context, r);
             }
         }
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/AbstractCircuitBreaker.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/AbstractCircuitBreaker.java
@@ -22,11 +22,9 @@ import com.alibaba.csp.sentinel.context.Context;
 import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
 import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRule;
 import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRuleManager;
-import com.alibaba.csp.sentinel.slots.block.degrade.circuitbreaker.CircuitBreaker.State;
 import com.alibaba.csp.sentinel.util.AssertUtil;
 import com.alibaba.csp.sentinel.util.TimeUtil;
 import com.alibaba.csp.sentinel.util.function.BiConsumer;
-import com.alibaba.csp.sentinel.util.function.Consumer;
 
 /**
  * @author Eric Zhao

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/CircuitBreaker.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/CircuitBreaker.java
@@ -15,6 +15,8 @@
  */
 package com.alibaba.csp.sentinel.slots.block.degrade.circuitbreaker;
 
+import com.alibaba.csp.sentinel.context.Context;
+import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
 import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRule;
 
 /**
@@ -32,11 +34,13 @@ public interface CircuitBreaker {
     DegradeRule getRule();
 
     /**
-     * Acquires permission of an invocation only if it is available at the time of invocation.
+     * Acquires permission of an invocation only if it is available at the time of invoking.
      *
+     * @param context
+     * @param r
      * @return {@code true} if permission was acquired and {@code false} otherwise
      */
-    boolean tryPass();
+    boolean tryPass(Context context, ResourceWrapper r);
 
     /**
      * Get current state of the circuit breaker.
@@ -46,13 +50,12 @@ public interface CircuitBreaker {
     State currentState();
 
     /**
-     * Record a completed request with the given response time and error (if present) and
-     * handle state transformation of the circuit breaker.
+     * Called when a passed invocation finished.
      *
-     * @param rt the response time of this entry
-     * @param error the error of this entry (if present)
+     * @param context context of current invocation
+     * @param wrapper current resource
      */
-    void onRequestComplete(long rt, Throwable error);
+    void afterRequestPassed(Context context, ResourceWrapper wrapper);
 
     /**
      * Circuit breaker state.

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/CircuitBreaker.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/CircuitBreaker.java
@@ -50,12 +50,12 @@ public interface CircuitBreaker {
     State currentState();
 
     /**
-     * Called when a passed invocation finished.
+     * Called when a `passed` invocation finished.
      *
      * @param context context of current invocation
      * @param wrapper current resource
      */
-    void afterRequestPassed(Context context, ResourceWrapper wrapper);
+    void onRequestComplete(Context context, ResourceWrapper wrapper);
 
     /**
      * Circuit breaker state.

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ExceptionCircuitBreaker.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ExceptionCircuitBreaker.java
@@ -17,6 +17,9 @@ package com.alibaba.csp.sentinel.slots.block.degrade.circuitbreaker;
 
 import java.util.List;
 
+import com.alibaba.csp.sentinel.Entry;
+import com.alibaba.csp.sentinel.context.Context;
+import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
 import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRule;
 import com.alibaba.csp.sentinel.slots.statistic.base.LeapArray;
 import com.alibaba.csp.sentinel.slots.statistic.base.LongAdder;
@@ -60,7 +63,12 @@ public class ExceptionCircuitBreaker extends AbstractCircuitBreaker {
     }
 
     @Override
-    public void onRequestComplete(long rt, Throwable error) {
+    public void afterRequestPassed(Context context, ResourceWrapper r) {
+        Entry entry = context.getCurEntry();
+        if (entry == null) {
+            return;
+        }
+        Throwable error = entry.getError();
         SimpleErrorCounter counter = stat.currentWindow().value();
         if (error != null) {
             counter.getErrorCount().add(1);
@@ -74,7 +82,9 @@ public class ExceptionCircuitBreaker extends AbstractCircuitBreaker {
         if (currentState.get() == State.OPEN) {
             return;
         }
+        
         if (currentState.get() == State.HALF_OPEN) {
+            // In detecting request
             if (error == null) {
                 fromHalfOpenToClose();
             } else {
@@ -82,6 +92,7 @@ public class ExceptionCircuitBreaker extends AbstractCircuitBreaker {
             }
             return;
         }
+        
         List<SimpleErrorCounter> counters = stat.values();
         long errCount = 0;
         long totalCount = 0;

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ExceptionCircuitBreaker.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ExceptionCircuitBreaker.java
@@ -63,7 +63,7 @@ public class ExceptionCircuitBreaker extends AbstractCircuitBreaker {
     }
 
     @Override
-    public void afterRequestPassed(Context context, ResourceWrapper r) {
+    public void onRequestComplete(Context context, ResourceWrapper r) {
         Entry entry = context.getCurEntry();
         if (entry == null) {
             return;

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ResponseTimeCircuitBreaker.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ResponseTimeCircuitBreaker.java
@@ -61,7 +61,7 @@ public class ResponseTimeCircuitBreaker extends AbstractCircuitBreaker {
     }
 
     @Override
-    public void afterRequestPassed(Context context, ResourceWrapper wrapper) {
+    public void onRequestComplete(Context context, ResourceWrapper wrapper) {
         SlowRequestCounter counter = slidingCounter.currentWindow().value();
         Entry entry = context.getCurEntry();
         if (entry == null) {

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ResponseTimeCircuitBreaker.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ResponseTimeCircuitBreaker.java
@@ -17,12 +17,16 @@ package com.alibaba.csp.sentinel.slots.block.degrade.circuitbreaker;
 
 import java.util.List;
 
+import com.alibaba.csp.sentinel.Entry;
+import com.alibaba.csp.sentinel.context.Context;
+import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
 import com.alibaba.csp.sentinel.slots.block.RuleConstant;
 import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRule;
 import com.alibaba.csp.sentinel.slots.statistic.base.LeapArray;
 import com.alibaba.csp.sentinel.slots.statistic.base.LongAdder;
 import com.alibaba.csp.sentinel.slots.statistic.base.WindowWrap;
 import com.alibaba.csp.sentinel.util.AssertUtil;
+import com.alibaba.csp.sentinel.util.TimeUtil;
 
 /**
  * @author Eric Zhao
@@ -57,8 +61,17 @@ public class ResponseTimeCircuitBreaker extends AbstractCircuitBreaker {
     }
 
     @Override
-    public void onRequestComplete(long rt, Throwable error) {
+    public void afterRequestPassed(Context context, ResourceWrapper wrapper) {
         SlowRequestCounter counter = slidingCounter.currentWindow().value();
+        Entry entry = context.getCurEntry();
+        if (entry == null) {
+            return;
+        }
+        long completeTime = entry.getCompleteTimestamp();
+        if (completeTime <= 0) {
+            completeTime = TimeUtil.currentTimeMillis();
+        }
+        long rt = completeTime - entry.getCreateTimestamp();
         if (rt > maxAllowedRt) {
             counter.slowCount.add(1);
         }
@@ -71,7 +84,9 @@ public class ResponseTimeCircuitBreaker extends AbstractCircuitBreaker {
         if (currentState.get() == State.OPEN) {
             return;
         }
+        
         if (currentState.get() == State.HALF_OPEN) {
+            // In detecting request
             // TODO: improve logic for half-open recovery
             if (rt > maxAllowedRt) {
                 fromHalfOpenToOpen(1.0d);

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/function/BiConsumer.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/function/BiConsumer.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.util.function;
+
+/**
+ * BiConsumer interface from JDK 8.
+ */
+public interface BiConsumer<T, U> {
+
+    void accept(T t, U u);
+}

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/EntryTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/EntryTest.java
@@ -1,8 +1,10 @@
 package com.alibaba.csp.sentinel;
 
+import com.alibaba.csp.sentinel.context.Context;
 import com.alibaba.csp.sentinel.node.Node;
 import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
 import com.alibaba.csp.sentinel.slotchain.StringResourceWrapper;
+import com.alibaba.csp.sentinel.util.function.BiConsumer;
 
 import org.junit.Test;
 
@@ -63,6 +65,11 @@ public class EntryTest {
         @Override
         public Node getLastNode() {
             return null;
+        }
+
+        @Override
+        public void whenComplete(BiConsumer<Context, Entry> consumer) {
+            // do nothing
         }
     }
 }

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/degrade/CircuitBreakingIntegrationTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/degrade/CircuitBreakingIntegrationTest.java
@@ -15,10 +15,6 @@
  */
 package com.alibaba.csp.sentinel.slots.block.degrade;
 
-import com.alibaba.csp.sentinel.Entry;
-import com.alibaba.csp.sentinel.SphU;
-import com.alibaba.csp.sentinel.Tracer;
-import com.alibaba.csp.sentinel.slots.block.BlockException;
 import com.alibaba.csp.sentinel.slots.block.RuleConstant;
 import com.alibaba.csp.sentinel.slots.block.degrade.circuitbreaker.CircuitBreaker;
 import com.alibaba.csp.sentinel.slots.block.degrade.circuitbreaker.CircuitBreaker.State;
@@ -54,41 +50,6 @@ public class CircuitBreakingIntegrationTest extends AbstractTimeBasedTest {
     @After
     public void tearDown() throws Exception {
         DegradeRuleManager.loadRules(new ArrayList<DegradeRule>());
-    }
-
-    private boolean entryAndSleepFor(String res, int sleepMs) {
-        Entry entry = null;
-        try {
-            entry = SphU.entry(res);
-            sleep(sleepMs);
-        } catch (BlockException ex) {
-            return false;
-        } catch (Exception ex) {
-            Tracer.traceEntry(ex, entry);
-        } finally {
-            if (entry != null) {
-                entry.exit();
-            }
-        }
-        return true;
-    }
-
-    private boolean entryWithErrorIfPresent(String res, Exception ex) {
-        Entry entry = null;
-        try {
-            entry = SphU.entry(res);
-            if (ex != null) {
-                Tracer.traceEntry(ex, entry);
-            }
-            sleep(ThreadLocalRandom.current().nextInt(5, 10));
-        } catch (BlockException b) {
-            return false;
-        } finally {
-            if (entry != null) {
-                entry.exit();
-            }
-        }
-        return true;
     }
 
     @Test


### PR DESCRIPTION
### Describe what this PR does / why we need it

Current implementation of circuit breakers will fire a bug when do examination in half-open state. The examination will be interrupted if the detecting request was blocked by other breakers or slots.

For details please refer to https://github.com/alibaba/Sentinel/pull/1490#discussion_r462079959

### Does this pull request fix one issue?

#1638

### Describe how you did it

For initial concepts we can illustrate design of circuit breakers, including below scenarios:

![Scenarios](https://user-images.githubusercontent.com/17573073/89366045-96ec4c00-d708-11ea-9281-dc7795fab93e.png)

And a new design could be shown as:

![Flow](https://user-images.githubusercontent.com/17573073/89277653-b2f3dd00-d677-11ea-92c6-3c17ffc26eb4.png)

In `afterRequestPassed` we:

* Do calculations needed by specific breaker
* Determine the new state(closed -> open, half-open -> open/closed)

In `Exit Handlers` we:

* Execute extra blocks bond to specific entry(Which we should do only if necessary because it will cost extra memory)

Thus, we recycle failed detecting attempt in handler bond to specific entry. `Handlers` also enable users or developers of adapter doing necessary extra work.

### Describe how to verify it

A new unit test can verify it which will fail in previous design: `CircuitBreakingIntegrationTest.testMultipleHalfOpenedBreaders`

### Special notes for reviews

No.