### PR TITLE
Refactor the extended MetricExtension interface to match fundamental events in Sentinel

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/metric/extension/AdvancedMetricExtension.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/metric/extension/AdvancedMetricExtension.java
@@ -1,97 +1,74 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.csp.sentinel.metric.extension;
 
 import com.alibaba.csp.sentinel.EntryType;
+import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
 
 /**
- * Advanced {@link MetricExtension} extending input parameters of each metric
- * collection method with the name of {@link EntryType}.
- * 
+ * Extended {@link MetricExtension} extending input parameters of each metric
+ * collection method with {@link EntryType}.
+ *
  * @author bill_yip
+ * @author Eric Zhao
  * @since 1.8.0
  */
 public interface AdvancedMetricExtension extends MetricExtension {
-	/**
-	 * Add current pass count of the resource name.
-	 *
-	 * @param n         count to add
-	 * @param resource  resource name
-	 * @param entryType {@link EntryType} name, [IN] as provider, [OUT] as consumer.
-	 * @param args      additional arguments of the resource, eg. if the resource is
-	 *                  a method name, the args will be the parameters of the
-	 *                  method.
-	 */
-	void addPass(String resource, String entryType, int n, Object... args);
 
-	/**
-	 * Add current block count of the resource name.
-	 *
-	 * @param n              count to add
-	 * @param resource       resource name
-	 * @param entryType      {@link EntryType} name, [IN] as provider, [OUT] as
-	 *                       consumer.
-	 * @param origin         the original invoker.
-	 * @param blockException block exception related.
-	 * @param args           additional arguments of the resource, eg. if the
-	 *                       resource is a method name, the args will be the
-	 *                       parameters of the method.
-	 */
-	void addBlock(String resource, String entryType, int n, String origin, BlockException blockException,
-			Object... args);
+    /**
+     * Add current pass count of the resource name.
+     *
+     * @param rw          resource representation (including resource name, traffic type, etc.)
+     * @param batchCount  count to add
+     * @param args        additional arguments of the resource, eg. if the resource is a method name,
+     *                    the args will be the parameters of the method.
+     */
+    void onPass(ResourceWrapper rw, int batchCount, Object[] args);
 
-	/**
-	 * Add current completed count of the resource name.
-	 *
-	 * @param n         count to add
-	 * @param resource  resource name
-	 * @param entryType {@link EntryType} name, [IN] as provider, [OUT] as consumer.
-	 * @param args      additional arguments of the resource, eg. if the resource is
-	 *                  a method name, the args will be the parameters of the
-	 *                  method.
-	 */
-	void addSuccess(String resource, String entryType, int n, Object... args);
+    /**
+     * Add current block count of the resource name.
+     *
+     * @param rw         resource representation (including resource name, traffic type, etc.)
+     * @param batchCount count to add
+     * @param origin     the origin of caller (if present)
+     * @param e          the associated {@code BlockException}
+     * @param args       additional arguments of the resource, eg. if the resource is a method name,
+     *                   the args will be the parameters of the method.
+     */
+    void onBlocked(ResourceWrapper rw, int batchCount, String origin, BlockException e,
+                   Object[] args);
 
-	/**
-	 * Add current exception count of the resource name.
-	 *
-	 * @param n         count to add
-	 * @param resource  resource name
-	 * @param entryType {@link EntryType} name, [IN] as provider, [OUT] as consumer.
-	 * @param throwable exception related.
-	 */
-	void addException(String resource, String entryType, int n, Throwable throwable);
+    /**
+     * Add current completed count of the resource name.
+     *
+     * @param rw         resource representation (including resource name, traffic type, etc.)
+     * @param batchCount count to add
+     * @param rt         response time of current invocation
+     * @param args       additional arguments of the resource
+     */
+    void onComplete(ResourceWrapper rw, long rt, int batchCount, Object[] args);
 
-	/**
-	 * Add response time of the resource name.
-	 *
-	 * @param rt        response time in millisecond
-	 * @param resource  resource name
-	 * @param entryType {@link EntryType} name, [IN] as provider, [OUT] as consumer.
-	 * @param args      additional arguments of the resource, eg. if the resource is
-	 *                  a method name, the args will be the parameters of the
-	 *                  method.
-	 */
-	void addRt(String resource, String entryTypeTag, long rt, Object... args);
-
-	/**
-	 * Increase current thread count of the resource name.
-	 *
-	 * @param resource  resource name
-	 * @param entryType {@link EntryType} name, [IN] as provider, [OUT] as consumer.
-	 * @param args      additional arguments of the resource, eg. if the resource is
-	 *                  a method name, the args will be the parameters of the
-	 *                  method.
-	 */
-	void increaseThreadNum(String resource, String entryType, Object... args);
-
-	/**
-	 * Decrease current thread count of the resource name.
-	 *
-	 * @param resource  resource name
-	 * @param entryType {@link EntryType} name, [IN] as provider, [OUT] as consumer.
-	 * @param args      additional arguments of the resource, eg. if the resource is
-	 *                  a method name, the args will be the parameters of the
-	 *                  method.
-	 */
-	void decreaseThreadNum(String resource, String entryType, Object... args);
+    /**
+     * Add current exception count of the resource name.
+     *
+     * @param rw         resource representation (including resource name, traffic type, etc.)
+     * @param batchCount count to add
+     * @param throwable  exception related.
+     * @param args       additional arguments of the resource
+     */
+    void onError(ResourceWrapper rw, Throwable throwable, int batchCount, Object[] args);
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/metric/extension/MetricCallbackInit.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/metric/extension/MetricCallbackInit.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.csp.sentinel.metric.extension;
 
 import com.alibaba.csp.sentinel.init.InitFunc;

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/metric/extension/MetricExtension.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/metric/extension/MetricExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.csp.sentinel.metric.extension;
 
 import com.alibaba.csp.sentinel.slots.block.BlockException;

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/metric/extension/MetricExtensionProvider.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/metric/extension/MetricExtensionProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.csp.sentinel.metric.extension;
 
 import java.util.ArrayList;
@@ -7,7 +22,7 @@ import com.alibaba.csp.sentinel.log.RecordLog;
 import com.alibaba.csp.sentinel.util.SpiLoader;
 
 /**
- * Get all {@link MetricExtension}s via SPI.
+ * Get all {@link MetricExtension} via SPI.
  *
  * @author Carpenter Lee
  * @since 1.6.1
@@ -22,8 +37,8 @@ public class MetricExtensionProvider {
     private static void resolveInstance() {
         List<MetricExtension> extensions = SpiLoader.loadInstanceList(MetricExtension.class);
 
-        if (extensions == null) {
-            RecordLog.warn("[MetricExtensionProvider] WARN: No existing MetricExtension found");
+        if (extensions.isEmpty()) {
+            RecordLog.info("[MetricExtensionProvider] No existing MetricExtension found");
         } else {
             metricExtensions.addAll(extensions);
             RecordLog.info("[MetricExtensionProvider] MetricExtension resolved, size=" + extensions.size());
@@ -31,9 +46,10 @@ public class MetricExtensionProvider {
     }
 
     /**
-     * Get all metric extensions. DO NOT MODIFY the returned list, use {@link #addMetricExtension(MetricExtension)}.
+     * <p>Get all registered metric extensions.</p>
+     * <p>DO NOT MODIFY the returned list, use {@link #addMetricExtension(MetricExtension)}.</p>
      *
-     * @return all metric extensions.
+     * @return all registered metric extensions
      */
     public static List<MetricExtension> getMetricExtensions() {
         return metricExtensions;
@@ -42,7 +58,7 @@ public class MetricExtensionProvider {
     /**
      * Add metric extension.
      * <p>
-     * Not that this method is NOT thread safe.
+     * Note that this method is NOT thread safe.
      * </p>
      *
      * @param metricExtension the metric extension to add.

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/metric/extension/callback/MetricEntryCallback.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/metric/extension/callback/MetricEntryCallback.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.csp.sentinel.metric.extension.callback;
 
 import com.alibaba.csp.sentinel.context.Context;
@@ -16,32 +31,29 @@ import com.alibaba.csp.sentinel.slots.block.BlockException;
  * @since 1.6.1
  */
 public class MetricEntryCallback implements ProcessorSlotEntryCallback<DefaultNode> {
-	@Override
-	public void onPass(Context context, ResourceWrapper resourceWrapper, DefaultNode param, int count, Object... args)
-			throws Exception {
-		for (MetricExtension m : MetricExtensionProvider.getMetricExtensions()) {
-			if (m instanceof AdvancedMetricExtension) {
-				((AdvancedMetricExtension) m).increaseThreadNum(resourceWrapper.getName(),
-						resourceWrapper.getEntryType().name(), args);
-				((AdvancedMetricExtension) m).addPass(resourceWrapper.getName(), resourceWrapper.getEntryType().name(),
-						count, args);
-			} else {
-				m.increaseThreadNum(resourceWrapper.getName(), args);
-				m.addPass(resourceWrapper.getName(), count, args);
-			}
-		}
-	}
 
-	@Override
-	public void onBlocked(BlockException ex, Context context, ResourceWrapper resourceWrapper, DefaultNode param,
-			int count, Object... args) {
-		for (MetricExtension m : MetricExtensionProvider.getMetricExtensions()) {
-			if (m instanceof AdvancedMetricExtension) {
-				((AdvancedMetricExtension) m).addBlock(resourceWrapper.getName(), resourceWrapper.getEntryType().name(),
-						count, context.getOrigin(), ex, args);
-			} else {
-				m.addBlock(resourceWrapper.getName(), count, context.getOrigin(), ex, args);
-			}
-		}
-	}
+    @Override
+    public void onPass(Context context, ResourceWrapper rw, DefaultNode param, int count, Object... args)
+        throws Exception {
+        for (MetricExtension m : MetricExtensionProvider.getMetricExtensions()) {
+            if (m instanceof AdvancedMetricExtension) {
+                ((AdvancedMetricExtension) m).onPass(rw, count, args);
+            } else {
+                m.increaseThreadNum(rw.getName(), args);
+                m.addPass(rw.getName(), count, args);
+            }
+        }
+    }
+
+    @Override
+    public void onBlocked(BlockException ex, Context context, ResourceWrapper resourceWrapper, DefaultNode param,
+                          int count, Object... args) {
+        for (MetricExtension m : MetricExtensionProvider.getMetricExtensions()) {
+            if (m instanceof AdvancedMetricExtension) {
+                ((AdvancedMetricExtension) m).onBlocked(resourceWrapper, count, context.getOrigin(), ex, args);
+            } else {
+                m.addBlock(resourceWrapper.getName(), count, context.getOrigin(), ex, args);
+            }
+        }
+    }
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/metric/extension/callback/MetricExitCallback.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/metric/extension/callback/MetricExitCallback.java
@@ -1,5 +1,21 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.csp.sentinel.metric.extension.callback;
 
+import com.alibaba.csp.sentinel.Entry;
 import com.alibaba.csp.sentinel.context.Context;
 import com.alibaba.csp.sentinel.metric.extension.AdvancedMetricExtension;
 import com.alibaba.csp.sentinel.metric.extension.MetricExtension;
@@ -12,35 +28,43 @@ import com.alibaba.csp.sentinel.util.TimeUtil;
  * Metric extension exit callback.
  *
  * @author Carpenter Lee
+ * @author Eric Zhao
  * @since 1.6.1
  */
 public class MetricExitCallback implements ProcessorSlotExitCallback {
 
-	@Override
-	public void onExit(Context context, ResourceWrapper resourceWrapper, int count, Object... args) {
-		for (MetricExtension m : MetricExtensionProvider.getMetricExtensions()) {
-			if (context.getCurEntry().getBlockError() != null) {
-				continue;
-			}
-			String resource = resourceWrapper.getName();
-			String entryType = resourceWrapper.getEntryType().name();
-			Throwable ex = context.getCurEntry().getError();
-			long realRt = TimeUtil.currentTimeMillis() - context.getCurEntry().getCreateTimestamp();
-			if (m instanceof AdvancedMetricExtension) {
-				((AdvancedMetricExtension) m).addRt(resource, entryType, realRt, args);
-				((AdvancedMetricExtension) m).addSuccess(resource, entryType, count, args);
-				((AdvancedMetricExtension) m).decreaseThreadNum(resource, entryType, args);
-				if (null != ex) {
-					((AdvancedMetricExtension) m).addException(resource, entryType, count, ex);
-				}
-			} else {
-				m.addRt(resource, realRt, args);
-				m.addSuccess(resource, count, args);
-				m.decreaseThreadNum(resource, args);
-				if (null != ex) {
-					m.addException(resource, count, ex);
-				}
-			}
-		}
-	}
+    @Override
+    public void onExit(Context context, ResourceWrapper rw, int acquireCount, Object... args) {
+        Entry curEntry = context.getCurEntry();
+        if (curEntry == null) {
+            return;
+        }
+        for (MetricExtension m : MetricExtensionProvider.getMetricExtensions()) {
+            if (curEntry.getBlockError() != null) {
+                continue;
+            }
+            String resource = rw.getName();
+            Throwable ex = curEntry.getError();
+            long completeTime = curEntry.getCompleteTimestamp();
+            if (completeTime <= 0) {
+                completeTime = TimeUtil.currentTimeMillis();
+            }
+            long rt = completeTime - curEntry.getCreateTimestamp();
+
+            if (m instanceof AdvancedMetricExtension) {
+                // Since 1.8.0 (as a temporary workaround for compatibility)
+                ((AdvancedMetricExtension) m).onComplete(rw, rt, acquireCount, args);
+                if (ex != null) {
+                    ((AdvancedMetricExtension) m).onError(rw, ex, acquireCount, args);
+                }
+            } else {
+                m.addRt(resource, rt, args);
+                m.addSuccess(resource, acquireCount, args);
+                m.decreaseThreadNum(resource, args);
+                if (null != ex) {
+                    m.addException(resource, acquireCount, ex);
+                }
+            }
+        }
+    }
 }

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/metric/extension/callback/FakeAdvancedMetricExtension.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/metric/extension/callback/FakeAdvancedMetricExtension.java
@@ -1,85 +1,93 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.csp.sentinel.metric.extension.callback;
 
 import com.alibaba.csp.sentinel.metric.extension.AdvancedMetricExtension;
+import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
 
+/**
+ * @author bill_yip
+ * @author Eric Zhao
+ */
 class FakeAdvancedMetricExtension implements AdvancedMetricExtension {
+
     long pass = 0;
     long block = 0;
-    long success = 0;
+    long complete = 0;
     long exception = 0;
     long rt = 0;
-    long thread = 0;
 
-	@Override
-	public void addPass(String resource, int n, Object... args) {
-		// Do nothing because of using the enhanced one		
-	}
+    long concurrency = 0;
 
-	@Override
-	public void addBlock(String resource, int n, String origin, BlockException blockException, Object... args) {
-		// Do nothing because of using the enhanced one		
-	}
+    @Override
+    public void onPass(ResourceWrapper rw, int batchCount, Object[] args) {
+        this.pass += batchCount;
+        this.concurrency++;
+    }
 
-	@Override
-	public void addSuccess(String resource, int n, Object... args) {
-		// Do nothing because of using the enhanced one		
-	}
+    @Override
+    public void onBlocked(ResourceWrapper rw, int batchCount, String origin, BlockException e, Object[] args) {
+        this.block += batchCount;
+    }
 
-	@Override
-	public void addException(String resource, int n, Throwable throwable) {
-		// Do nothing because of using the enhanced one		
-	}
+    @Override
+    public void onComplete(ResourceWrapper rw, long rt, int batchCount, Object[] args) {
+        this.complete += batchCount;
+        this.rt += rt;
+        this.concurrency--;
+    }
 
-	@Override
-	public void addRt(String resource, long rt, Object... args) {
-		// Do nothing because of using the enhanced one		
-	}
+    @Override
+    public void onError(ResourceWrapper rw, Throwable throwable, int batchCount, Object[] args) {
+        this.exception += batchCount;
+    }
 
-	@Override
-	public void increaseThreadNum(String resource, Object... args) {
-		// Do nothing because of using the enhanced one		
-	}
+    @Override
+    public void addPass(String resource, int n, Object... args) {
+        // Do nothing because of using the enhanced one
+    }
 
-	@Override
-	public void decreaseThreadNum(String resource, Object... args) {
-		// Do nothing because of using the enhanced one		
-	}
+    @Override
+    public void addBlock(String resource, int n, String origin, BlockException blockException, Object... args) {
+        // Do nothing because of using the enhanced one
+    }
 
-	@Override
-	public void addPass(String resource, String entryType, int n, Object... args) {
-		pass += n;
-	}
+    @Override
+    public void addSuccess(String resource, int n, Object... args) {
+        // Do nothing because of using the enhanced one
+    }
 
-	@Override
-	public void addBlock(String resource, String entryType, int n, String origin, BlockException blockException,
-			Object... args) {
-		block += n;
-	}
+    @Override
+    public void addException(String resource, int n, Throwable throwable) {
+        // Do nothing because of using the enhanced one
+    }
 
-	@Override
-	public void addSuccess(String resource, String entryType, int n, Object... args) {
-		success += n;
-	}
+    @Override
+    public void addRt(String resource, long rt, Object... args) {
+        // Do nothing because of using the enhanced one
+    }
 
-	@Override
-	public void addException(String resource, String entryType, int n, Throwable throwable) {
-		exception += n;
-	}
+    @Override
+    public void increaseThreadNum(String resource, Object... args) {
+        // Do nothing because of using the enhanced one
+    }
 
-	@Override
-	public void addRt(String resource, String entryTypeTag, long rt, Object... args) {
-		this.rt += rt;
-	}
-
-	@Override
-	public void increaseThreadNum(String resource, String entryType, Object... args) {
-		thread ++;
-	}
-
-	@Override
-	public void decreaseThreadNum(String resource, String entryType, Object... args) {
-		thread --;
-	}
-
+    @Override
+    public void decreaseThreadNum(String resource, Object... args) {
+        // Do nothing because of using the enhanced one
+    }
 }

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/metric/extension/callback/MetricEntryCallbackTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/metric/extension/callback/MetricEntryCallbackTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.csp.sentinel.metric.extension.callback;
 
 import com.alibaba.csp.sentinel.EntryType;
@@ -35,7 +50,7 @@ public class MetricEntryCallbackTest {
         
         // assert advancedExtension
         Assert.assertEquals(advancedExtension.pass, count);
-        Assert.assertEquals(advancedExtension.thread, 1);
+        Assert.assertEquals(advancedExtension.concurrency, 1);
     }
 
     @Test

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/metric/extension/callback/MetricExitCallbackTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/metric/extension/callback/MetricExitCallbackTest.java
@@ -77,8 +77,8 @@ public class MetricExitCallbackTest extends AbstractTimeBasedTest {
         Object[] args = {"args1", "args2"};
         long prevRt = 20;
         extension.rt = prevRt;
-        extension.success = 6;
-        extension.thread = 10;
+        extension.complete = 6;
+        extension.concurrency = 10;
         Context context = mock(Context.class);
         Entry entry = mock(Entry.class);
 
@@ -92,7 +92,7 @@ public class MetricExitCallbackTest extends AbstractTimeBasedTest {
         when(context.getCurEntry()).thenReturn(entry);
         exitCallback.onExit(context, resourceWrapper, count, args);
         Assert.assertEquals(prevRt + deltaMs, extension.rt);
-        Assert.assertEquals(extension.success, 6 + count);
-        Assert.assertEquals(extension.thread, 10 - 1);
+        Assert.assertEquals(extension.complete, 6 + count);
+        Assert.assertEquals(extension.concurrency, 10 - 1);
     }
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it

Refactor the extended `AdvancedMetricExtension` interface (new added in #1665) to match fundamental events (pass, block, complete) in Sentinel.

### Does this pull request fix one issue?

Improvement for #1665 

### Describe how you did it

- Unify the extended interface as a few event handlers: onPass, onBlocked, onComplete and onError
- Polish related code

### Describe how to verify it

Run all test cases for regression.

### Special notes for reviews

NONE