### PR TITLE
Fix bugs and improve default fallback logic of Apache Dubbo adapter

### DIFF
--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/README.md
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/README.md
@@ -1,4 +1,4 @@
-# Sentinel Apache Dubbo Adapter
+# Sentinel Apache Dubbo Adapter (for 2.7.x+)
 
 > Note: 中文文档请见[此处](https://github.com/alibaba/Sentinel/wiki/主流框架的适配#dubbo)。
 
@@ -21,7 +21,7 @@ To use Sentinel Dubbo Adapter, you can simply add the following dependency to yo
 The Sentinel filters are **enabled by default**. Once you add the dependency,
 the Dubbo services and methods will become protected resources in Sentinel,
 which can leverage Sentinel's flow control and guard ability when rules are configured.
-Demos can be found in [sentinel-demo-dubbo](https://github.com/alibaba/Sentinel/tree/master/sentinel-demo/sentinel-demo-dubbo).
+Demos can be found in [sentinel-demo-apache-dubbo](https://github.com/alibaba/Sentinel/tree/master/sentinel-demo/sentinel-demo-apache-dubbo).
 
 If you don't want the filters enabled, you can manually disable them. For example:
 
@@ -37,8 +37,8 @@ For more details of Dubbo filter, see [here](http://dubbo.apache.org/en-us/docs/
 
 The resource for Dubbo services has two granularities: service interface and service method.
 
-- Service interface：resourceName format is `interfaceName`，e.g. `com.alibaba.csp.sentinel.demo.dubbo.FooService`
-- Service method：resourceName format is `interfaceName:methodSignature`，e.g. `com.alibaba.csp.sentinel.demo.dubbo.FooService:sayHello(java.lang.String)`
+- Service interface: resourceName format is `interfaceName`, e.g. `com.alibaba.csp.sentinel.demo.dubbo.FooService`
+- Service method: resourceName format is `interfaceName:methodSignature`, e.g. `com.alibaba.csp.sentinel.demo.dubbo.FooService:sayHello(java.lang.String)`
 
 ## Flow control based on caller
 

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/BaseSentinelDubboFilter.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/BaseSentinelDubboFilter.java
@@ -21,11 +21,10 @@ import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 
 /**
- * Base Class of the {@link SentinelDubboProviderFilter} and {@link SentinelDubboConsumerFilter}.
+ * Base class of the {@link SentinelDubboProviderFilter} and {@link SentinelDubboConsumerFilter}.
  *
  * @author Zechao Zheng
  */
-
 public abstract class BaseSentinelDubboFilter implements Filter {
 
 

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboProviderFilter.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboProviderFilter.java
@@ -20,6 +20,7 @@ import com.alibaba.csp.sentinel.adapter.dubbo.config.DubboAdapterGlobalConfig;
 import com.alibaba.csp.sentinel.context.ContextUtil;
 import com.alibaba.csp.sentinel.log.RecordLog;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
+
 import org.apache.dubbo.common.extension.Activate;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
@@ -74,7 +75,8 @@ public class SentinelDubboProviderFilter extends BaseSentinelDubboFilter {
             // at entrance of invocation chain only (for inbound traffic).
             ContextUtil.enter(methodResourceName, origin);
             interfaceEntry = SphU.entry(interfaceResourceName, ResourceTypeConstants.COMMON_RPC, EntryType.IN);
-            methodEntry = SphU.entry(methodResourceName, ResourceTypeConstants.COMMON_RPC, EntryType.IN, invocation.getArguments());
+            methodEntry = SphU.entry(methodResourceName, ResourceTypeConstants.COMMON_RPC, EntryType.IN,
+                invocation.getArguments());
             Result result = invoker.invoke(invocation);
             if (result.hasException()) {
                 Tracer.traceEntry(result.getException(), interfaceEntry);
@@ -97,7 +99,6 @@ public class SentinelDubboProviderFilter extends BaseSentinelDubboFilter {
             ContextUtil.exit();
         }
     }
-
 
 }
 

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/config/DubboAdapterGlobalConfig.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/config/DubboAdapterGlobalConfig.java
@@ -43,12 +43,10 @@ public final class DubboAdapterGlobalConfig {
     private static final String DEFAULT_DUBBO_CONSUMER_PREFIX = "dubbo:consumer:";
 
     public static final String DUBBO_INTERFACE_GROUP_VERSION_ENABLED = "csp.sentinel.dubbo.interface.group.version.enabled";
-    public static final String TRACE_BIZ_EXCEPTION_ENABLED = "csp.sentinel.dubbo.trace.biz.exception.enabled";
 
     private static volatile DubboFallback consumerFallback = new DefaultDubboFallback();
     private static volatile DubboFallback providerFallback = new DefaultDubboFallback();
     private static volatile DubboOriginParser originParser = new DefaultDubboOriginParser();
-
 
     public static boolean isUsePrefix() {
         return TRUE_STR.equalsIgnoreCase(SentinelConfig.getConfig(DUBBO_RES_NAME_WITH_PREFIX_KEY));
@@ -73,16 +71,6 @@ public final class DubboAdapterGlobalConfig {
     public static Boolean getDubboInterfaceGroupAndVersionEnabled() {
         return TRUE_STR.equalsIgnoreCase(SentinelConfig.getConfig(DUBBO_INTERFACE_GROUP_VERSION_ENABLED));
     }
-
-    public static Boolean getDubboBizExceptionTraceEnabled() {
-        String traceBizExceptionEnabled = SentinelConfig.getConfig(TRACE_BIZ_EXCEPTION_ENABLED);
-        if (StringUtil.isNotBlank(traceBizExceptionEnabled)) {
-            return TRUE_STR.equalsIgnoreCase(traceBizExceptionEnabled);
-        }
-        return true;
-    }
-
-
 
     public static DubboFallback getConsumerFallback() {
         return consumerFallback;

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/fallback/DefaultDubboFallback.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/fallback/DefaultDubboFallback.java
@@ -16,7 +16,7 @@
 package com.alibaba.csp.sentinel.adapter.dubbo.fallback;
 
 import com.alibaba.csp.sentinel.slots.block.BlockException;
-import com.alibaba.csp.sentinel.slots.block.SentinelRpcException;
+
 import org.apache.dubbo.rpc.AsyncRpcResult;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
@@ -30,6 +30,6 @@ public class DefaultDubboFallback implements DubboFallback {
     @Override
     public Result handle(Invoker<?> invoker, Invocation invocation, BlockException ex) {
         // Just wrap the exception.
-        return AsyncRpcResult.newDefaultAsyncResult(null, new SentinelRpcException(ex), invocation);
+        return AsyncRpcResult.newDefaultAsyncResult(ex.toRuntimeException(), invocation);
     }
 }

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/fallback/DubboFallbackRegistry.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/fallback/DubboFallbackRegistry.java
@@ -16,18 +16,14 @@
 package com.alibaba.csp.sentinel.adapter.dubbo.fallback;
 
 import com.alibaba.csp.sentinel.adapter.dubbo.config.DubboAdapterGlobalConfig;
-import com.alibaba.csp.sentinel.util.AssertUtil;
 
 /**
  * <p>Global fallback registry for Dubbo.</p>
  *
- * <p>
- * Note: Circuit breaking is mainly designed for consumer. The provider should not
- * give fallback result in most circumstances.
- * </p>
- *
  * @author Eric Zhao
+ * @deprecated use {@link DubboAdapterGlobalConfig} instead since 1.8.0.
  */
+@Deprecated
 public final class DubboFallbackRegistry {
 
     public static DubboFallback getConsumerFallback() {
@@ -35,7 +31,6 @@ public final class DubboFallbackRegistry {
     }
 
     public static void setConsumerFallback(DubboFallback consumerFallback) {
-        AssertUtil.notNull(consumerFallback, "consumerFallback cannot be null");
         DubboAdapterGlobalConfig.setConsumerFallback(consumerFallback);
     }
 
@@ -44,7 +39,6 @@ public final class DubboFallbackRegistry {
     }
 
     public static void setProviderFallback(DubboFallback providerFallback) {
-        AssertUtil.notNull(providerFallback, "providerFallback cannot be null");
         DubboAdapterGlobalConfig.setProviderFallback(providerFallback);
     }
 

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboConsumerFilterTest.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboConsumerFilterTest.java
@@ -19,6 +19,7 @@ import com.alibaba.csp.sentinel.BaseTest;
 import com.alibaba.csp.sentinel.DubboTestUtil;
 import com.alibaba.csp.sentinel.Entry;
 import com.alibaba.csp.sentinel.EntryType;
+import com.alibaba.csp.sentinel.adapter.dubbo.config.DubboAdapterGlobalConfig;
 import com.alibaba.csp.sentinel.adapter.dubbo.fallback.DubboFallback;
 import com.alibaba.csp.sentinel.adapter.dubbo.fallback.DubboFallbackRegistry;
 import com.alibaba.csp.sentinel.context.Context;
@@ -34,6 +35,7 @@ import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRule;
 import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRuleManager;
 import com.alibaba.csp.sentinel.slots.block.flow.FlowRule;
 import com.alibaba.csp.sentinel.slots.block.flow.FlowRuleManager;
+
 import org.apache.dubbo.rpc.*;
 import org.apache.dubbo.rpc.support.RpcUtils;
 import org.junit.After;
@@ -53,8 +55,7 @@ import static org.mockito.Mockito.*;
  */
 public class SentinelDubboConsumerFilterTest extends BaseTest {
 
-    private SentinelDubboConsumerFilter consumerFilter = new SentinelDubboConsumerFilter();
-
+    private final SentinelDubboConsumerFilter consumerFilter = new SentinelDubboConsumerFilter();
 
     @Before
     public void setUp() {
@@ -66,7 +67,6 @@ public class SentinelDubboConsumerFilterTest extends BaseTest {
     public void destroy() {
         cleanUpAll();
     }
-
 
     @Test
     public void testInterfaceLevelFollowControlAsync() throws InterruptedException {
@@ -104,7 +104,6 @@ public class SentinelDubboConsumerFilterTest extends BaseTest {
         Result result = invokeDubboRpc(false, invoker, invocation);
         verifyInvocationStructureForCallFinish(invoker, invocation);
         assertEquals("normal", result.getValue());
-
 
         // inc the clusterNode's exception to trigger the fallback
         for (int i = 0; i < 5; i++) {
@@ -153,7 +152,6 @@ public class SentinelDubboConsumerFilterTest extends BaseTest {
         assertNull(context);
     }
 
-
     @Test
     public void testMethodFlowControlAsync() {
 
@@ -175,9 +173,7 @@ public class SentinelDubboConsumerFilterTest extends BaseTest {
         assertEquals("fallback", fallback.getValue());
         verifyInvocationStructureForCallFinish(invoker, invocation);
 
-
     }
-
 
     @Test
     public void testInvokeAsync() {
@@ -190,7 +186,7 @@ public class SentinelDubboConsumerFilterTest extends BaseTest {
         when(result.hasException()).thenReturn(false);
         when(invoker.invoke(invocation)).thenAnswer(invocationOnMock -> {
             verifyInvocationStructureForAsyncCall(invoker, invocation);
-             return result;
+            return result;
         });
         consumerFilter.invoke(invoker, invocation);
         verify(invoker).invoke(invocation);
@@ -220,7 +216,6 @@ public class SentinelDubboConsumerFilterTest extends BaseTest {
         assertNull(context);
     }
 
-
     /**
      * Simply verify invocation structure in memory:
      * EntranceNode(defaultContextName)
@@ -231,7 +226,8 @@ public class SentinelDubboConsumerFilterTest extends BaseTest {
         Context context = ContextUtil.getContext();
         assertNotNull(context);
         // As not call ContextUtil.enter(resourceName, application) in SentinelDubboConsumerFilter, use default context
-        // In actual project, a consumer is usually also a provider, the context will be created by SentinelDubboProviderFilter
+        // In actual project, a consumer is usually also a provider, the context will be created by
+        //SentinelDubboProviderFilter
         // If consumer is on the top of Dubbo RPC invocation chain, use default context
         String resourceName = consumerFilter.getMethodName(invoker, invocation, null);
         assertEquals(com.alibaba.csp.sentinel.Constants.CONTEXT_DEFAULT_NAME, context.getName());
@@ -269,7 +265,8 @@ public class SentinelDubboConsumerFilterTest extends BaseTest {
         // Verify clusterNode
         ClusterNode methodClusterNode = methodNode.getClusterNode();
         ClusterNode interfaceClusterNode = interfaceNode.getClusterNode();
-        assertNotSame(methodClusterNode, interfaceClusterNode);// Different resource->Different ProcessorSlot->Different ClusterNode
+        assertNotSame(methodClusterNode,
+            interfaceClusterNode);// Different resource->Different ProcessorSlot->Different ClusterNode
 
         // As context origin is "", the StatisticNode should not be created in originCountMap of ClusterNode
         Map<String, StatisticNode> methodOriginCountMap = methodClusterNode.getOriginCountMap();
@@ -284,7 +281,8 @@ public class SentinelDubboConsumerFilterTest extends BaseTest {
         assertNotNull(context);
 
         // As not call ContextUtil.enter(resourceName, application) in SentinelDubboConsumerFilter, use default context
-        // In actual project, a consumer is usually also a provider, the context will be created by SentinelDubboProviderFilter
+        // In actual project, a consumer is usually also a provider, the context will be created by
+        //SentinelDubboProviderFilter
         // If consumer is on the top of Dubbo RPC invocation chain, use default context
         String resourceName = consumerFilter.getMethodName(invoker, invocation, null);
         assertEquals(com.alibaba.csp.sentinel.Constants.CONTEXT_DEFAULT_NAME, context.getName());
@@ -319,7 +317,8 @@ public class SentinelDubboConsumerFilterTest extends BaseTest {
         // Verify clusterNode
         ClusterNode methodClusterNode = methodNode.getClusterNode();
         ClusterNode interfaceClusterNode = interfaceNode.getClusterNode();
-        assertNotSame(methodClusterNode, interfaceClusterNode);// Different resource->Different ProcessorSlot->Different ClusterNode
+        assertNotSame(methodClusterNode,
+            interfaceClusterNode);// Different resource->Different ProcessorSlot->Different ClusterNode
 
         // As context origin is "", the StatisticNode should not be created in originCountMap of ClusterNode
         Map<String, StatisticNode> methodOriginCountMap = methodClusterNode.getOriginCountMap();
@@ -329,7 +328,6 @@ public class SentinelDubboConsumerFilterTest extends BaseTest {
         assertEquals(0, interfaceOriginCountMap.size());
     }
 
-
     private void verifyInvocationStructureForCallFinish(Invoker invoker, Invocation invocation) {
         Context context = ContextUtil.getContext();
         assertNull(context);
@@ -337,7 +335,6 @@ public class SentinelDubboConsumerFilterTest extends BaseTest {
         Entry[] entries = (Entry[]) RpcContext.getContext().get(methodResourceName);
         assertNull(entries);
     }
-
 
     private DefaultNode getNode(String resourceName, DefaultNode root) {
 
@@ -355,7 +352,6 @@ public class SentinelDubboConsumerFilterTest extends BaseTest {
         return null;
     }
 
-
     private void initFlowRule(String resource) {
         FlowRule flowRule = new FlowRule(resource);
         flowRule.setCount(1);
@@ -367,24 +363,18 @@ public class SentinelDubboConsumerFilterTest extends BaseTest {
 
     private void initDegradeRule(String resource) {
         DegradeRule degradeRule = new DegradeRule(resource)
-                .setCount(0.5)
-                .setGrade(DEGRADE_GRADE_EXCEPTION_RATIO);
+            .setCount(0.5)
+            .setGrade(DEGRADE_GRADE_EXCEPTION_RATIO);
         List<DegradeRule> degradeRules = new ArrayList<>();
         degradeRules.add(degradeRule);
         degradeRule.setTimeWindow(1);
         DegradeRuleManager.loadRules(degradeRules);
     }
 
-
     private void initFallback() {
-        DubboFallbackRegistry.setConsumerFallback(new DubboFallback() {
-            @Override
-            public Result handle(Invoker<?> invoker, Invocation invocation, BlockException ex) {
-                boolean async = RpcUtils.isAsync(invoker.getUrl(), invocation);
-                Result fallbackResult = null;
-                fallbackResult = AsyncRpcResult.newDefaultAsyncResult("fallback", invocation);
-                return fallbackResult;
-            }
+        DubboAdapterGlobalConfig.setConsumerFallback((invoker, invocation, ex) -> {
+            // boolean async = RpcUtils.isAsync(invoker.getUrl(), invocation);
+            return AsyncRpcResult.newDefaultAsyncResult("fallback", invocation);
         });
     }
 
@@ -394,13 +384,11 @@ public class SentinelDubboConsumerFilterTest extends BaseTest {
         if (InvokeMode.SYNC == invokeMode) {
             result = exception ? new AppResponse(new Exception("error")) : new AppResponse("normal");
         } else {
-            result = exception ? AsyncRpcResult.newDefaultAsyncResult(new Exception("error"), invocation) : AsyncRpcResult.newDefaultAsyncResult("normal", invocation);
+            result = exception ? AsyncRpcResult.newDefaultAsyncResult(new Exception("error"), invocation)
+                : AsyncRpcResult.newDefaultAsyncResult("normal", invocation);
         }
         when(invoker.invoke(invocation)).thenReturn(result);
         return consumerFilter.invoke(invoker, invocation);
     }
-
-
-
 
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/BlockException.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/BlockException.java
@@ -23,7 +23,11 @@ package com.alibaba.csp.sentinel.slots.block;
  */
 public abstract class BlockException extends Exception {
 
+    private static final int MAX_SEARCH_DEPTH = 10;
+
     public static final String BLOCK_EXCEPTION_FLAG = "SentinelBlockException";
+    public static final String BLOCK_EXCEPTION_MSG_PREFIX = "SentinelBlockException: ";
+
     /**
      * <p>this constant RuntimeException has no stack trace, just has a message
      * {@link #BLOCK_EXCEPTION_FLAG} that marks its name.
@@ -85,12 +89,18 @@ public abstract class BlockException extends Exception {
         this.ruleLimitApp = ruleLimitApp;
     }
 
+    public RuntimeException toRuntimeException() {
+        RuntimeException t = new RuntimeException(BLOCK_EXCEPTION_MSG_PREFIX + getClass().getSimpleName());
+        t.setStackTrace(sentinelStackTrace);
+        return t;
+    }
+
     /**
      * Check whether the exception is sentinel blocked exception. One exception is sentinel blocked
      * exception only when:
      * <ul>
      * <li>the exception or its (sub-)cause is {@link BlockException}, or</li>
-     * <li>the exception's message is or any of its sub-cause's message equals to {@link #BLOCK_EXCEPTION_FLAG}</li>
+     * <li>the exception's message or any of its sub-cause's message is prefixed by {@link #BLOCK_EXCEPTION_FLAG}</li>
      * </ul>
      *
      * @param t the exception.
@@ -103,8 +113,11 @@ public abstract class BlockException extends Exception {
 
         int counter = 0;
         Throwable cause = t;
-        while (cause != null && counter++ < 50) {
-            if ((cause instanceof BlockException) || (BLOCK_EXCEPTION_FLAG.equals(cause.getMessage()))) {
+        while (cause != null && counter++ < MAX_SEARCH_DEPTH) {
+            if (cause instanceof BlockException) {
+                return true;
+            }
+            if (cause.getMessage() != null && cause.getMessage().startsWith(BLOCK_EXCEPTION_FLAG)) {
                 return true;
             }
             cause = cause.getCause();


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

There are some problems in Apache Dubbo adapter (since 1.8.0-SNAPSHOT):

- Unexpected behavior will occur when there are non-biz errors (e.g. Dubbo RPC timeout), which is caused by NPE in whenComplete hook in consumer filter.
- The default fallback logic (wrap an error result with SentinelRpcException, which wraps a BlockException) may cause error when deserialization.

This PR fixes the bug and improves the default fallback of Apache Dubbo 2.7.x adapter.

### Does this pull request fix one issue?

NONE

### Describe how you did it

- Add RuntimeException converting method (`toRuntimeException`) in BlockException and polish logic for `BlockException` validation
- Fix NPE bug in consumer filter (when non-biz error occurred)
- Improve default fallback in Dubbo 2.7.x adapter: convert the BlockException to a simple RuntimeException (with necessary message)
- Polish code and comments

### Describe how to verify it

Run the test cases.

### Special notes for reviews

NONE