### PR TITLE
Improve: 优化LeapArray getIntervalInSecond

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/base/LeapArray.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/base/LeapArray.java
@@ -43,6 +43,7 @@ public abstract class LeapArray<T> {
     protected int windowLengthInMs;
     protected int sampleCount;
     protected int intervalInMs;
+    private double intervalInSecond;
 
     protected final AtomicReferenceArray<WindowWrap<T>> array;
 
@@ -64,6 +65,7 @@ public abstract class LeapArray<T> {
 
         this.windowLengthInMs = intervalInMs / sampleCount;
         this.intervalInMs = intervalInMs;
+        this.intervalInSecond = intervalInMs / 1000.0;
         this.sampleCount = sampleCount;
 
         this.array = new AtomicReferenceArray<>(sampleCount);
@@ -393,7 +395,7 @@ public abstract class LeapArray<T> {
      * @return interval in second
      */
     public double getIntervalInSecond() {
-        return intervalInMs / 1000.0;
+        return intervalInSecond;
     }
 
     public void debug(long time) {


### PR DESCRIPTION
Describe what this PR does / why we need it

优化LeapArray的getIntervalInSecond,在构造的时候计算一次就够了,不需要每次都计算