### PR TITLE
fix Code comment documentation error

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/CtSph.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/CtSph.java
@@ -181,7 +181,7 @@ public class CtSph implements Sph {
      * be created if the resource doesn't relate one.
      *
      * <p>Same resource({@link ResourceWrapper#equals(Object)}) will share the same
-     * {@link ProcessorSlotChain} globally, no matter in witch {@link Context}.<p/>
+     * {@link ProcessorSlotChain} globally, no matter in which {@link Context}.<p/>
      *
      * <p>
      * Note that total {@link ProcessorSlot} count must not exceed {@link Constants#MAX_SLOT_CHAIN_SIZE},

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/clusterbuilder/ClusterBuilderSlot.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/clusterbuilder/ClusterBuilderSlot.java
@@ -51,7 +51,7 @@ public class ClusterBuilderSlot extends AbstractLinkedProcessorSlot<DefaultNode>
     /**
      * <p>
      * Remember that same resource({@link ResourceWrapper#equals(Object)}) will share
-     * the same {@link ProcessorSlotChain} globally, no matter in witch context. So if
+     * the same {@link ProcessorSlotChain} globally, no matter in which context. So if
      * code goes into {@link #entry(Context, ResourceWrapper, DefaultNode, int, boolean, Object...)},
      * the resource name must be same but context name may not.
      * </p>

--- a/sentinel-transport/sentinel-transport-netty-http/src/main/java/com/alibaba/csp/sentinel/transport/command/codec/Encoder.java
+++ b/sentinel-transport/sentinel-transport-netty-http/src/main/java/com/alibaba/csp/sentinel/transport/command/codec/Encoder.java
@@ -47,7 +47,7 @@ public interface Encoder<R> {
      * Encode the given object into a byte array with the default charset.
      *
      * @param r the object to encode
-     * @return the encoded byte buffer, witch is already flipped.
+     * @return the encoded byte buffer, which is already flipped.
      * @throws Exception error occurs when encoding the object (e.g. IO fails)
      */
     byte[] encode(R r) throws Exception;


### PR DESCRIPTION
#1720 
fix Code comment documentation error

I am looking up the document. The remark is that there are three ‘witch ’ adjectives?
Now I hope I can fix this word bug