### PR TITLE
Fix incorrect parameter names in VersionUtils javadoc and used more appropriate names

### DIFF
--- a/sentinel-dashboard/README.md
+++ b/sentinel-dashboard/README.md
@@ -33,7 +33,7 @@ java -Dserver.port=8080 \
 
 | 参数 | 作用 |
 |--------|--------|
-|`Dcsp.sentinel.dashboard.server=localhost:8080`|向 Sentinel 接入端指定控制台的地址|
+|`-Dcsp.sentinel.dashboard.server=localhost:8080`|向 Sentinel 接入端指定控制台的地址|
 |`-Dproject.name=sentinel-dashboard`|向 Sentinel 指定应用名称，比如上面对应的应用名称就为 `sentinel-dashboard`|
 
 全部的配置项可以参考 [启动配置项文档](https://github.com/alibaba/Sentinel/wiki/%E5%90%AF%E5%8A%A8%E9%85%8D%E7%BD%AE%E9%A1%B9)。

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/util/VersionUtils.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/util/VersionUtils.java
@@ -32,16 +32,16 @@ public final class VersionUtils {
     /**
      * Parse version of Sentinel from raw string.
      *
-     * @param versionFull version string
+     * @param verStr version string
      * @return parsed {@link SentinelVersion} if the version is valid; empty if
      * there is something wrong with the format
      */
-    public static Optional<SentinelVersion> parseVersion(String s) {
-        if (StringUtil.isBlank(s)) {
+    public static Optional<SentinelVersion> parseVersion(String verStr) {
+        if (StringUtil.isBlank(verStr)) {
             return Optional.empty();
         }
         try {
-            String versionFull = s;
+            String versionFull = verStr;
             SentinelVersion version = new SentinelVersion();
             
             // postfix


### PR DESCRIPTION
Fix incorrect parameter names in VersionUtils#parseVersion of sentinel-dashboard, and use 'verStr'(version string) instead.