### PR TITLE
Fix the dependency conflict issue

### DIFF
--- a/sentinel-transport/sentinel-transport-netty-http/pom.xml
+++ b/sentinel-transport/sentinel-transport-netty-http/pom.xml
@@ -37,11 +37,6 @@
             <version>4.5.3</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-            <version>4.4.5</version>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Fix the dependency conflict issue #1730 by Remove the conflicting Jar **org.apache.httpcomponents:httpcore:4.4.5** in pom file.
This fix will not affect other libraries or class, except the above duplicate class.