### PR TITLE
[Fixes #1065]modified sentinel-dubbo-adapter module DefaultDubboFallback.java class,resolve the issue #1065 [Serialized class com.alibaba.csp.sentinel.slots.block.flow.FlowRule must implement java.io.Serializable]

### DIFF
--- a/sentinel-adapter/sentinel-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/fallback/DefaultDubboFallback.java
+++ b/sentinel-adapter/sentinel-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/fallback/DefaultDubboFallback.java
@@ -16,7 +16,6 @@
 package com.alibaba.csp.sentinel.adapter.dubbo.fallback;
 
 import com.alibaba.csp.sentinel.slots.block.BlockException;
-import com.alibaba.csp.sentinel.slots.block.SentinelRpcException;
 import com.alibaba.dubbo.rpc.Invocation;
 import com.alibaba.dubbo.rpc.Invoker;
 import com.alibaba.dubbo.rpc.Result;
@@ -29,7 +28,9 @@ public class DefaultDubboFallback implements DubboFallback {
 
     @Override
     public Result handle(Invoker<?> invoker, Invocation invocation, BlockException ex) {
-        // Just wrap the exception.
-        return new RpcResult(new SentinelRpcException(ex));
+        // Just wrap the exception. edit by wzg923 2020/9/23
+		RpcResult result = new RpcResult();
+        result.setException(ex.toRuntimeException());
+        return result;
     }
 }

--- a/sentinel-adapter/sentinel-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/fallback/DefaultDubboFallback.java
+++ b/sentinel-adapter/sentinel-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/fallback/DefaultDubboFallback.java
@@ -16,6 +16,7 @@
 package com.alibaba.csp.sentinel.adapter.dubbo.fallback;
 
 import com.alibaba.csp.sentinel.slots.block.BlockException;
+import com.alibaba.csp.sentinel.slots.block.SentinelRpcException;
 import com.alibaba.dubbo.rpc.Invocation;
 import com.alibaba.dubbo.rpc.Invoker;
 import com.alibaba.dubbo.rpc.Result;
@@ -30,7 +31,7 @@ public class DefaultDubboFallback implements DubboFallback {
     public Result handle(Invoker<?> invoker, Invocation invocation, BlockException ex) {
         // Just wrap the exception. edit by wzg923 2020/9/23
 		RpcResult result = new RpcResult();
-        result.setException(ex.toRuntimeException());
+        result.setException(new SentinelRpcException(ex.toRuntimeException()));
         return result;
     }
 }

--- a/sentinel-adapter/sentinel-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/fallback/DubboFallbackRegistryTest.java
+++ b/sentinel-adapter/sentinel-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/fallback/DubboFallbackRegistryTest.java
@@ -38,7 +38,7 @@ public class DubboFallbackRegistryTest {
         BlockException ex = new FlowException("xxx");
         Result result = new DefaultDubboFallback().handle(null, null, ex);
         Assert.assertTrue(result.hasException());
-        Assert.assertEquals(RuntimeException.class, result.getException().getClass());
+        Assert.assertEquals(SentinelRpcException.class, result.getException().getClass());
     }
 
     @Test

--- a/sentinel-adapter/sentinel-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/fallback/DubboFallbackRegistryTest.java
+++ b/sentinel-adapter/sentinel-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/fallback/DubboFallbackRegistryTest.java
@@ -38,7 +38,7 @@ public class DubboFallbackRegistryTest {
         BlockException ex = new FlowException("xxx");
         Result result = new DefaultDubboFallback().handle(null, null, ex);
         Assert.assertTrue(result.hasException());
-        Assert.assertEquals(SentinelRpcException.class, result.getException().getClass());
+        Assert.assertEquals(RuntimeException.class, result.getException().getClass());
     }
 
     @Test


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

fixed the bug of sentinel-dubbo-adapter [Caused by: java.lang.RuntimeException: Serialized class com.alibaba.csp.sentinel.slots.block.flow.FlowRule must implement java.io.Serializable]

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #1065

### Describe how you did it

Just wrap the BlockException to a custom RuntimeException,so the result do not contains the BlockException.

### Describe how to verify it

Verify it by run the example project of sentinel-demo-dubbo .

### Special notes for reviews
