### PR TITLE
Added ARM64 support to Sentinel and added ARM64 job to Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,17 @@ matrix:
     env: BUILD_JDK=ORACLE_JDK_8
   - jdk: oraclejdk11
     env: BUILD_JDK=ORACLE_JDK_11
+  - arch: arm64
   allow_failures:
   - env: BUILD_JDK=ORACLE_JDK_11
 
 # https://docs.travis-ci.com/user/languages/java/#maven-dependency-management
 install:
+  - if [ "${TRAVIS_CPU_ARCH}" == "arm64" ]; then
+      sudo apt-get install -y maven openjdk-11-jdk;
+      export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-arm64;
+      export PATH=$JAVA_HOME/bin:$PATH;
+    fi
   - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -DminimumPriority=1
 
 after_success:

--- a/sentinel-adapter/sentinel-grpc-adapter/pom.xml
+++ b/sentinel-adapter/sentinel-grpc-adapter/pom.xml
@@ -12,7 +12,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <grpc.version>1.13.1</grpc.version>
+        <grpc.version>1.30.2</grpc.version>
     </properties>
 
     <dependencies>

--- a/sentinel-cluster/sentinel-cluster-server-envoy-rls/pom.xml
+++ b/sentinel-cluster/sentinel-cluster-server-envoy-rls/pom.xml
@@ -16,7 +16,7 @@
         <java.target.version>1.8</java.target.version>
 
         <protobuf.version>3.10.0</protobuf.version>
-        <grpc.version>1.24.0</grpc.version>
+        <grpc.version>1.30.2</grpc.version>
 
         <maven.shade.version>3.2.1</maven.shade.version>
     </properties>

--- a/sentinel-extension/sentinel-datasource-consul/pom.xml
+++ b/sentinel-extension/sentinel-datasource-consul/pom.xml
@@ -15,11 +15,17 @@
     <properties>
         <java.source.version>1.8</java.source.version>
         <java.target.version>1.8</java.target.version>
-        <consul.version>1.4.2</consul.version>
-        <consul.process.version>2.0.0</consul.process.version>
+        <consul.version>1.4.5</consul.version>
+        <consul.process.version>2.2.0</consul.process.version>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-xml</artifactId>
+            <version>3.0.6</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>com.alibaba.csp</groupId>
             <artifactId>sentinel-datasource-extension</artifactId>


### PR DESCRIPTION
1. Added ARM64 architecture in .travis.yml
2. Updated 'embedded-consul' version to 2.2.0, 'consul-api' version to 1.4.5 and added groovy-all, slf4j-simple and slf4j-api dependencies for ARM64 support.
3. Updated grpc.version for 'io.grpc:protoc-gen-grpc-java' to 1.30.2, for ARM64 support.

Signed-off-by: odidev <odidev@puresoftware.com>