### PR TITLE
[Fixes #1769] adjust decision logic when slowRequestRatio equals 1.0

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ResponseTimeCircuitBreaker.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ResponseTimeCircuitBreaker.java
@@ -19,7 +19,6 @@ import java.util.List;
 
 import com.alibaba.csp.sentinel.Entry;
 import com.alibaba.csp.sentinel.context.Context;
-import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
 import com.alibaba.csp.sentinel.slots.block.RuleConstant;
 import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRule;
 import com.alibaba.csp.sentinel.slots.statistic.base.LeapArray;
@@ -33,6 +32,8 @@ import com.alibaba.csp.sentinel.util.TimeUtil;
  * @since 1.8.0
  */
 public class ResponseTimeCircuitBreaker extends AbstractCircuitBreaker {
+
+    private static final double SLOW_REQUEST_RATIO_MAX_VALUE = 1.0d;
 
     private final long maxAllowedRt;
     private final double maxSlowRequestRatio;
@@ -108,6 +109,10 @@ public class ResponseTimeCircuitBreaker extends AbstractCircuitBreaker {
         }
         double currentRatio = slowCount * 1.0d / totalCount;
         if (currentRatio > maxSlowRequestRatio) {
+            transformToOpen(currentRatio);
+        }
+        if (Double.compare(currentRatio, maxSlowRequestRatio) == 0 &&
+                Double.compare(maxSlowRequestRatio, SLOW_REQUEST_RATIO_MAX_VALUE) == 0) {
             transformToOpen(currentRatio);
         }
     }

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ResponseTimeCircuitBreakerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ResponseTimeCircuitBreakerTest.java
@@ -1,0 +1,58 @@
+package com.alibaba.csp.sentinel.slots.block.degrade.circuitbreaker;
+
+import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRule;
+import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRuleManager;
+import com.alibaba.csp.sentinel.test.AbstractTimeBasedTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author xierz
+ * @date 2020/10/4
+ */
+public class ResponseTimeCircuitBreakerTest extends AbstractTimeBasedTest {
+    @Before
+    public void setUp() {
+        DegradeRuleManager.loadRules(new ArrayList<DegradeRule>());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        DegradeRuleManager.loadRules(new ArrayList<DegradeRule>());
+    }
+
+    @Test
+    public void testMaxSlowRatioThreshold() {
+        String resource = "testMaxSlowRatioThreshold";
+        DegradeRule rule = new DegradeRule("resource")
+                .setCount(10)
+                .setGrade(RuleConstant.DEGRADE_GRADE_RT)
+                .setMinRequestAmount(3)
+                .setSlowRatioThreshold(1)
+                .setStatIntervalMs(5000)
+                .setTimeWindow(5);
+        rule.setResource(resource);
+        DegradeRuleManager.loadRules(Collections.singletonList(rule));
+
+        assertTrue(entryAndSleepFor(resource, 20));
+        assertTrue(entryAndSleepFor(resource, 20));
+        assertTrue(entryAndSleepFor(resource, 20));
+
+        // should be blocked, cause 3/3 requests' rt is bigger than max rt.
+        assertFalse(entryAndSleepFor(resource,20));
+        sleep(1000);
+        assertFalse(entryAndSleepFor(resource,20));
+        sleep(4000);
+
+        assertTrue(entryAndSleepFor(resource, 20));
+    }
+
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->#1769

### Describe what this PR does / why we need it
when slowRequestRatio equals 1.0d, requests will never be blocked. Because the former decision logic is use '>' to block the request, but the max ratio is 100%, so the currentRatio will never be bigger than slowRequestRatio.

### Does this pull request fix one issue?
Fixes #1769 
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
If maxSlowRequestRatio equals currentRatio && maxSlowRequestRatio equals 1.0d, call this method 'transformToOpen'.

### Describe how to verify it
In the Test Class which called ResponseTimeCircuitBreakerTest.

### Special notes for reviews
