### PR TITLE
fix the potential concurrence issue when rules updates

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManager.java
@@ -44,6 +44,7 @@ import com.alibaba.csp.sentinel.property.SentinelProperty;
  *
  * @author jialiang.linjl
  * @author Eric Zhao
+ * @author Weihua
  */
 public class FlowRuleManager {
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManager.java
@@ -16,6 +16,7 @@
 package com.alibaba.csp.sentinel.slots.block.flow;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -58,6 +59,7 @@ public class FlowRuleManager {
         new NamedThreadFactory("sentinel-metrics-record-task", true));
 
     static {
+        flowRules.set(Collections.<String, List<FlowRule>>emptyMap());
         currentProperty.addListener(LISTENER);
         SCHEDULER.scheduleAtFixedRate(new MetricTimerListener(), 0, 1, TimeUnit.SECONDS);
     }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManager.java
@@ -133,14 +133,14 @@ public class FlowRuleManager {
             //the rules was always not null, it's no need to check nullable
             //remove checking to avoid IDE warning
             flowRules.set(rules);
-            RecordLog.info("[FlowRuleManager] Flow rules received: {}", flowRules);
+            RecordLog.info("[FlowRuleManager] Flow rules received: {}", flowRules.get());
         }
 
         @Override
         public void configLoad(List<FlowRule> conf) {
             Map<String, List<FlowRule>> rules = FlowRuleUtil.buildFlowRuleMap(conf);
             flowRules.set(rules);
-            RecordLog.info("[FlowRuleManager] Flow rules loaded: {}", flowRules);
+            RecordLog.info("[FlowRuleManager] Flow rules loaded: {}", flowRules.get());
         }
     }
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManager.java
@@ -134,14 +134,14 @@ public class FlowRuleManager {
             //the rules was always not null, it's no need to check nullable
             //remove checking to avoid IDE warning
             flowRules.set(rules);
-            RecordLog.info("[FlowRuleManager] Flow rules received: {}", flowRules.get());
+            RecordLog.info("[FlowRuleManager] Flow rules received: {}", rules);
         }
 
         @Override
         public void configLoad(List<FlowRule> conf) {
             Map<String, List<FlowRule>> rules = FlowRuleUtil.buildFlowRuleMap(conf);
             flowRules.set(rules);
-            RecordLog.info("[FlowRuleManager] Flow rules loaded: {}", flowRules.get());
+            RecordLog.info("[FlowRuleManager] Flow rules loaded: {}", rules);
         }
     }
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManager.java
@@ -48,7 +48,7 @@ import com.alibaba.csp.sentinel.property.SentinelProperty;
  */
 public class FlowRuleManager {
 
-    private static final AtomicReference<Map<String, List<FlowRule>>> flowRules = new AtomicReference<>();
+    private static final AtomicReference<Map<String, List<FlowRule>>> flowRules = new AtomicReference<Map<String, List<FlowRule>>>();
 
     private static final FlowPropertyListener LISTENER = new FlowPropertyListener();
     private static SentinelProperty<List<FlowRule>> currentProperty = new DynamicSentinelProperty<List<FlowRule>>();

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManagerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManagerTest.java
@@ -1,0 +1,59 @@
+package com.alibaba.csp.sentinel.slots.block.flow;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Weihua
+ * @since 1.0.0
+ */
+public class FlowRuleManagerTest {
+
+    public static final List<FlowRule> STATIC_RULES_1 = new ArrayList<>();
+    public static final List<FlowRule> STATIC_RULES_2 = new ArrayList<>();
+
+    static {
+        FlowRule first = new FlowRule();
+        first.setResource("/a/b/c");
+        first.setCount(100);
+        STATIC_RULES_1.add(first);
+
+        FlowRule second = new FlowRule();
+        second.setResource("/a/b/c");
+        second.setCount(200);
+        STATIC_RULES_2.add(second);
+
+    }
+
+    @Test
+    public void testLoadAndGetRules(){
+        FlowRuleManager.loadRules(STATIC_RULES_1);
+        assertEquals(1, FlowRuleManager.getRules().size()); // the initial size
+        new Thread(loader, "Loader").start();
+
+        for(int i = 0; i < 10000; i++){
+            System.out.println("main:" + i);
+            //The initial size is 1, and the size after updating should also be 1,
+            //if the actual size is 0, that must be called after clear(),
+            // but before putAll() in FlowPropertyListener.configUpdate
+            assertEquals(1, FlowRuleManager.getRules().size());
+        }
+
+    }
+
+    public Runnable loader = new Runnable() {
+        @Override
+        public void run() {
+            for(int i = 0; i < 10000; i++){
+                //to guarantee that they're different and change happens
+                System.out.println("loader:" + i);
+                FlowRuleManager.loadRules(i%2 == 0 ? STATIC_RULES_2 : STATIC_RULES_1);
+            }
+        }
+    };
+
+}

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManagerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManagerTest.java
@@ -27,8 +27,8 @@ import static org.junit.Assert.assertEquals;
  */
 public class FlowRuleManagerTest {
 
-    public static final List<FlowRule> STATIC_RULES_1 = new ArrayList<>();
-    public static final List<FlowRule> STATIC_RULES_2 = new ArrayList<>();
+    public static final List<FlowRule> STATIC_RULES_1 = new ArrayList<FlowRule>();
+    public static final List<FlowRule> STATIC_RULES_2 = new ArrayList<FlowRule>();
 
     static {
         FlowRule first = new FlowRule();

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManagerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManagerTest.java
@@ -50,13 +50,11 @@ public class FlowRuleManagerTest {
         new Thread(loader, "Loader").start();
 
         for(int i = 0; i < 10000; i++){
-            System.out.println("main:" + i);
             //The initial size is 1, and the size after updating should also be 1,
             //if the actual size is 0, that must be called after clear(),
             // but before putAll() in FlowPropertyListener.configUpdate
             assertEquals(1, FlowRuleManager.getRules().size());
         }
-
     }
 
     public Runnable loader = new Runnable() {
@@ -64,8 +62,7 @@ public class FlowRuleManagerTest {
         public void run() {
             for(int i = 0; i < 10000; i++){
                 //to guarantee that they're different and change happens
-                System.out.println("loader:" + i);
-                FlowRuleManager.loadRules(i%2 == 0 ? STATIC_RULES_2 : STATIC_RULES_1);
+                FlowRuleManager.loadRules(i % 2 == 0 ? STATIC_RULES_2 : STATIC_RULES_1);
             }
         }
     };

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManagerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManagerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.csp.sentinel.slots.block.flow;
 
 import org.junit.Test;
@@ -9,7 +24,6 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * @author Weihua
- * @since 1.0.0
  */
 public class FlowRuleManagerTest {
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
fix the potential concurrence issue when rules updates

### Does this pull request fix one issue?
Fixes #1782.

### Describe how you did it
make the map wrapped in AtomicReference

### Describe how to verify it
Run the new-added UT 

### Special notes for reviews
If this pr can be acceptable, I plan to fix the same issue in other rule managers. 
Code seems to be strange in DegradeRuleManager because the same piece of code uses synchronized keyword. It seems to be realized, but in the wrong way to fix it.