### PR TITLE
remove statInterval check when adding degrade rules

### DIFF
--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/DegradeController.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/DegradeController.java
@@ -201,9 +201,9 @@ public class DegradeController {
         if (entity.getMinRequestAmount()  == null || entity.getMinRequestAmount() <= 0) {
             return Result.ofFail(-1, "Invalid minRequestAmount");
         }
-        if (entity.getStatIntervalMs() == null || entity.getStatIntervalMs() <= 0) {
-            return Result.ofFail(-1, "Invalid statInterval");
-        }
+        //if (entity.getStatIntervalMs() == null || entity.getStatIntervalMs() <= 0) {
+            //return Result.ofFail(-1, "Invalid statInterval");
+        //}
         if (strategy == RuleConstant.DEGRADE_GRADE_RT) {
             Double slowRatio = entity.getSlowRatioThreshold();
             if (slowRatio == null) {

--- a/sentinel-dashboard/src/main/webapp/resources/app/scripts/services/degrade_service.js
+++ b/sentinel-dashboard/src/main/webapp/resources/app/scripts/services/degrade_service.js
@@ -69,14 +69,15 @@ app.service('DegradeService', ['$http', function ($http) {
           alert('最小请求数目需大于 0');
           return false;
       }
-      if (rule.statIntervalMs == undefined || rule.statIntervalMs <= 0) {
-          alert('统计窗口时长需大于 0s');
-          return false;
-      }
-      if (rule.statIntervalMs !== undefined && rule.statIntervalMs > 60 * 1000 * 2) {
-          alert('统计窗口时长不能超过 120 分钟');
-          return false;
-      }
+      //if (rule.statIntervalMs == undefined || rule.statIntervalMs <= 0) {
+      //    alert('统计窗口时长需大于 0s');
+      //    return false;
+      //}
+      //if (rule.statIntervalMs !== undefined && rule.statIntervalMs > 60 * 1000 * 2) {
+      //    alert('统计窗口时长不能超过 120 分钟');
+      //    return false;
+      //}
+
       // 异常比率类型.
       if (rule.grade == 1 && rule.count > 1) {
           alert('异常比率超出范围：[0.0 - 1.0]');


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
[add_degrade_rule_error](https://xipfs.github.io/images/temp/add_degrade_rule_error.png)

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
when add a new degrade rule at sentinel-dashboard , the js and controller has checkRuleValid  at statIntervalMs ,but the attribute do not has this value, so remove statIntervalMs  validate

### Describe how to verify it

add new degrade rule success 

### Special notes for reviews
