### PR TITLE
[Fixes #1856] adjust decision logic when errRequestRatio equals 1.0

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/AbstractCircuitBreaker.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/AbstractCircuitBreaker.java
@@ -19,7 +19,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import com.alibaba.csp.sentinel.Entry;
 import com.alibaba.csp.sentinel.context.Context;
-import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
 import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRule;
 import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRuleManager;
 import com.alibaba.csp.sentinel.util.AssertUtil;
@@ -31,6 +30,8 @@ import com.alibaba.csp.sentinel.util.function.BiConsumer;
  * @since 1.8.0
  */
 public abstract class AbstractCircuitBreaker implements CircuitBreaker {
+
+    protected final double RATIO_MAX_VALUE = 1.0d;
 
     protected final DegradeRule rule;
     protected final int recoveryTimeoutMs;
@@ -122,7 +123,7 @@ public abstract class AbstractCircuitBreaker implements CircuitBreaker {
         }
         return false;
     }
-    
+
     private void notifyObservers(CircuitBreaker.State prevState, CircuitBreaker.State newState, Double snapshotValue) {
         for (CircuitBreakerStateChangeObserver observer : observerRegistry.getStateChangeObservers()) {
             observer.onStateChange(prevState, newState, rule, snapshotValue);

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ExceptionCircuitBreaker.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ExceptionCircuitBreaker.java
@@ -19,7 +19,6 @@ import java.util.List;
 
 import com.alibaba.csp.sentinel.Entry;
 import com.alibaba.csp.sentinel.context.Context;
-import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
 import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRule;
 import com.alibaba.csp.sentinel.slots.statistic.base.LeapArray;
 import com.alibaba.csp.sentinel.slots.statistic.base.LongAdder;
@@ -107,6 +106,11 @@ public class ExceptionCircuitBreaker extends AbstractCircuitBreaker {
         if (strategy == DEGRADE_GRADE_EXCEPTION_RATIO) {
             // Use errorRatio
             curCount = errCount * 1.0d / totalCount;
+            // special case when ratio equals 1.0
+            if (Double.compare(curCount, threshold) == 0 && Double.compare(threshold, RATIO_MAX_VALUE) == 0) {
+                transformToOpen(curCount);
+                return;
+            }
         }
         if (curCount > threshold) {
             transformToOpen(curCount);

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ResponseTimeCircuitBreaker.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ResponseTimeCircuitBreaker.java
@@ -33,8 +33,6 @@ import com.alibaba.csp.sentinel.util.TimeUtil;
  */
 public class ResponseTimeCircuitBreaker extends AbstractCircuitBreaker {
 
-    private static final double SLOW_REQUEST_RATIO_MAX_VALUE = 1.0d;
-
     private final long maxAllowedRt;
     private final double maxSlowRequestRatio;
     private final int minRequestAmount;
@@ -112,7 +110,7 @@ public class ResponseTimeCircuitBreaker extends AbstractCircuitBreaker {
             transformToOpen(currentRatio);
         }
         if (Double.compare(currentRatio, maxSlowRequestRatio) == 0 &&
-                Double.compare(maxSlowRequestRatio, SLOW_REQUEST_RATIO_MAX_VALUE) == 0) {
+                Double.compare(maxSlowRequestRatio, RATIO_MAX_VALUE) == 0) {
             transformToOpen(currentRatio);
         }
     }


### PR DESCRIPTION
when ratio == 1, requests will never be blocked. Fixed the judgment logic in this case.

Fixes #1856 


