### PR TITLE
fix flaky test in TracerTest.java

### DIFF
--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/TracerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/TracerTest.java
@@ -17,12 +17,14 @@ public class TracerTest extends Tracer {
     public void setUp() {
         ContextTestUtil.cleanUpContext();
         ContextTestUtil.resetContextMap();
+        Tracer.exceptionPredicate = null;
     }
 
     @After
     public void tearDown() {
         ContextTestUtil.cleanUpContext();
         ContextTestUtil.resetContextMap();
+        Tracer.exceptionPredicate = null;
     }
 
     @Test
@@ -45,7 +47,6 @@ public class TracerTest extends Tracer {
 
     @Test
     public void setExceptionsToTrace() {
-        Tracer.exceptionPredicate = null;
         Tracer.ignoreClasses = null;
         Tracer.traceClasses = null;
         Tracer.setExceptionsToTrace(TraceException.class, TraceException2.class);
@@ -75,7 +76,6 @@ public class TracerTest extends Tracer {
 
     @Test
     public void setExceptionsToIgnore() {
-        Tracer.exceptionPredicate = null;
         Tracer.ignoreClasses = null;
         Tracer.traceClasses = null;
         Tracer.setExceptionsToIgnore(IgnoreException.class, IgnoreException2.class);

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/TracerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/TracerTest.java
@@ -45,6 +45,7 @@ public class TracerTest extends Tracer {
 
     @Test
     public void setExceptionsToTrace() {
+        Tracer.exceptionPredicate = null;
         Tracer.ignoreClasses = null;
         Tracer.traceClasses = null;
         Tracer.setExceptionsToTrace(TraceException.class, TraceException2.class);
@@ -74,6 +75,7 @@ public class TracerTest extends Tracer {
 
     @Test
     public void setExceptionsToIgnore() {
+        Tracer.exceptionPredicate = null;
         Tracer.ignoreClasses = null;
         Tracer.traceClasses = null;
         Tracer.setExceptionsToIgnore(IgnoreException.class, IgnoreException2.class);

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/config/SentinelConfigTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/config/SentinelConfigTest.java
@@ -21,12 +21,17 @@ public class SentinelConfigTest {
 
     @Test
     public void testDefaultConfig() {
+       
+        SentinelConfig.setConfig(SentinelConfig.COLD_FACTOR, String.valueOf(DEFAULT_COLD_FACTOR));
+        
         assertEquals(SentinelConfig.DEFAULT_CHARSET, SentinelConfig.charset());
         assertEquals(SentinelConfig.DEFAULT_SINGLE_METRIC_FILE_SIZE, SentinelConfig.singleMetricFileSize());
         assertEquals(SentinelConfig.DEFAULT_TOTAL_METRIC_FILE_COUNT, SentinelConfig.totalMetricFileCount());
         assertEquals(SentinelConfig.DEFAULT_COLD_FACTOR, SentinelConfig.coldFactor());
         assertEquals(SentinelConfig.DEFAULT_STATISTIC_MAX_RT, SentinelConfig.statisticMaxRt());
     }
+
+  
 
     //    add JVM parameter
 //    -Dcsp.sentinel.charset=gbk

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/config/SentinelConfigTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/config/SentinelConfigTest.java
@@ -21,17 +21,12 @@ public class SentinelConfigTest {
 
     @Test
     public void testDefaultConfig() {
-       
-        SentinelConfig.setConfig(SentinelConfig.COLD_FACTOR, String.valueOf(DEFAULT_COLD_FACTOR));
-        
         assertEquals(SentinelConfig.DEFAULT_CHARSET, SentinelConfig.charset());
         assertEquals(SentinelConfig.DEFAULT_SINGLE_METRIC_FILE_SIZE, SentinelConfig.singleMetricFileSize());
         assertEquals(SentinelConfig.DEFAULT_TOTAL_METRIC_FILE_COUNT, SentinelConfig.totalMetricFileCount());
         assertEquals(SentinelConfig.DEFAULT_COLD_FACTOR, SentinelConfig.coldFactor());
         assertEquals(SentinelConfig.DEFAULT_STATISTIC_MAX_RT, SentinelConfig.statisticMaxRt());
     }
-
-  
 
     //    add JVM parameter
 //    -Dcsp.sentinel.charset=gbk


### PR DESCRIPTION
Fixed flaky test that caused by setExceptionPredicate.

For setExceptionsToTrace and setExceptionsToIgnore, if we called setExceptionPredicate first,  it will assigned value to Tracer.exceptionPredicate.

To avoid this case, we would better to reset exceptionPredicate to null first 


The flaky tests are found by running https://github.com/idflakies/iDFlakies