### PR TITLE
fix flaky test in SentinelConfigTest

### DIFF
--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/config/SentinelConfigTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/config/SentinelConfigTest.java
@@ -2,6 +2,8 @@ package com.alibaba.csp.sentinel.config;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.Before;
+import org.junit.After;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -18,6 +20,16 @@ import static org.junit.Assert.assertEquals;
  * @author cdfive
  */
 public class SentinelConfigTest {
+
+    @Before
+    public void setUp() {
+        SentinelConfig.setConfig(SentinelConfig.COLD_FACTOR, SentinelConfig.DEFAULT_CHARSET);
+    }
+
+    @After
+    public void tearDown() {
+        SentinelConfig.setConfig(SentinelConfig.COLD_FACTOR, SentinelConfig.DEFAULT_CHARSET);
+    }
 
     @Test
     public void testDefaultConfig() {


### PR DESCRIPTION
Fixed flaky test testDefaultConfig that caused by testColdFactoryLargerThanOne in SentinelConfigTest

If we run testColdFactoryLargerThanOne first, it will modify SentinelConfig.COLD_FACTOR.
Then when we run testDefaultConfig, the code assertEquals(SentinelConfig.DEFAULT_CHARSET, SentinelConfig.charset()) will have issue.

The flaky tests are found by running https://github.com/idflakies/iDFlakies


**Describe how you did it:**

Set a before and after method to set the variables to the default value.

