### PR TITLE
FIX NPE when update ParamFlowRule before the resource has been requested once

### DIFF
--- a/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowRuleManager.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowRuleManager.java
@@ -138,7 +138,10 @@ public final class ParamFlowRuleManager {
                 List<ParamFlowRule> oldRuleList = new ArrayList<>(entry.getValue());
                 oldRuleList.removeAll(newRuleList);
                 for (ParamFlowRule rule : oldRuleList) {
-                    ParameterMetricStorage.getParamMetricForResource(resource).clearForRule(rule);
+                    ParameterMetric parameterMetric = ParameterMetricStorage.getParamMetricForResource(resource);
+                    if (parameterMetric != null) {
+                        parameterMetric.clearForRule(rule);
+                    }
                 }
             }
 

--- a/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowRuleManagerTest.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowRuleManagerTest.java
@@ -138,4 +138,18 @@ public class ParamFlowRuleManagerTest {
         assertTrue(allRules.contains(ruleC));
         assertTrue(allRules.contains(ruleD));
     }
+
+    @Test
+    public void testLoadParamRulesWithNoMetric() {
+        String resource = "test";
+        ParamFlowRule paramFlowRule = new ParamFlowRule(resource)
+                .setDurationInSec(1).setParamIdx(1);
+        ParamFlowRuleManager.loadRules(Collections.singletonList(paramFlowRule));
+        ParamFlowRule newParamFlowRule = new ParamFlowRule(resource)
+                .setDurationInSec(2).setParamIdx(1);
+        ParamFlowRuleManager.loadRules(Collections.singletonList(newParamFlowRule));
+        List<ParamFlowRule> result = ParamFlowRuleManager.getRulesOfResource(resource);
+        assertEquals(1, result.size());
+        assertEquals(2, result.get(0).getDurationInSec());
+    }
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it
fix issue: [#1895]( https://github.com/alibaba/Sentinel/issues/1895)
### Does this pull request fix one issue?
fix [#1895](https://github.com/alibaba/Sentinel/issues/1895)
### Describe how you did it
just add a judge to if the ParameterMetric is null before clear the ParamFlowRule
### Describe how to verify it
run com.alibaba.csp.sentinel.slots.block.flow.param.ParamFlowRuleManagerTest#testLoadParamRulesWithNoMetric to check whether the new value is set
### Special notes for reviews