### PR TITLE
Support setting flush interval of the metric log via SentinelConfig property

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/config/SentinelConfig.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/config/SentinelConfig.java
@@ -158,6 +158,24 @@ public final class SentinelConfig {
     public static String charset() {
         return props.get(CHARSET);
     }
+    
+    /**
+     * Get the metric log flush interval in second
+     * @return  the metric log flush interval in second
+     */
+    public static long metricLogFlushIntervalSec() {
+        String flushIntervalStr = SentinelConfig.getConfig(SentinelConfig.METRIC_FLUSH_INTERVAL);
+        if (flushIntervalStr == null) {
+            return DEFAULT_METRIC_FLUSH_INTERVAL;
+        }
+        try {
+            return Long.parseLong(flushIntervalStr);
+        } catch (Throwable throwable) {
+            RecordLog.warn("[SentinelConfig] Parse the metricLogFlushInterval fail, use default value: "
+                    + DEFAULT_METRIC_FLUSH_INTERVAL, throwable);
+            return DEFAULT_METRIC_FLUSH_INTERVAL;
+        }
+    }
 
     public static long singleMetricFileSize() {
         try {

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/config/SentinelConfig.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/config/SentinelConfig.java
@@ -55,12 +55,14 @@ public final class SentinelConfig {
     public static final String COLD_FACTOR = "csp.sentinel.flow.cold.factor";
     public static final String STATISTIC_MAX_RT = "csp.sentinel.statistic.max.rt";
     public static final String SPI_CLASSLOADER = "csp.sentinel.spi.classloader";
+    public static final String METRIC_FLUSH_INTERVAL = "csp.sentinel.metric.flush.interval";
 
     public static final String DEFAULT_CHARSET = "UTF-8";
     public static final long DEFAULT_SINGLE_METRIC_FILE_SIZE = 1024 * 1024 * 50;
     public static final int DEFAULT_TOTAL_METRIC_FILE_COUNT = 6;
     public static final int DEFAULT_COLD_FACTOR = 3;
     public static final int DEFAULT_STATISTIC_MAX_RT = 5000;
+    public static final long DEFAULT_METRIC_FLUSH_INTERVAL = 1L;
 
     static {
         try {
@@ -98,6 +100,7 @@ public final class SentinelConfig {
         setConfig(TOTAL_METRIC_FILE_COUNT, String.valueOf(DEFAULT_TOTAL_METRIC_FILE_COUNT));
         setConfig(COLD_FACTOR, String.valueOf(DEFAULT_COLD_FACTOR));
         setConfig(STATISTIC_MAX_RT, String.valueOf(DEFAULT_STATISTIC_MAX_RT));
+        setConfig(METRIC_FLUSH_INTERVAL, String.valueOf(DEFAULT_METRIC_FLUSH_INTERVAL));
     }
 
     private static void loadProps() {

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/config/SentinelConfig.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/config/SentinelConfig.java
@@ -164,7 +164,7 @@ public final class SentinelConfig {
      * @return  the metric log flush interval in second
      */
     public static long metricLogFlushIntervalSec() {
-        String flushIntervalStr = SentinelConfig.getConfig(SentinelConfig.METRIC_FLUSH_INTERVAL);
+        String flushIntervalStr = SentinelConfig.getConfig(METRIC_FLUSH_INTERVAL);
         if (flushIntervalStr == null) {
             return DEFAULT_METRIC_FLUSH_INTERVAL;
         }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManager.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.alibaba.csp.sentinel.concurrent.NamedThreadFactory;
+import com.alibaba.csp.sentinel.config.SentinelConfig;
 import com.alibaba.csp.sentinel.log.RecordLog;
 import com.alibaba.csp.sentinel.util.AssertUtil;
 import com.alibaba.csp.sentinel.util.StringUtil;
@@ -61,9 +62,42 @@ public class FlowRuleManager {
     static {
         flowRules.set(Collections.<String, List<FlowRule>>emptyMap());
         currentProperty.addListener(LISTENER);
-        SCHEDULER.scheduleAtFixedRate(new MetricTimerListener(), 0, 1, TimeUnit.SECONDS);
+        startMetricTimerListener();
     }
-
+    
+    /**
+     * <p> Start the MetricTimerListener
+     * <ol>
+     *     <li>if the {@link SentinelConfig#METRIC_FLUSH_INTERVAL} more than 0,
+     * the timer will run with the {@link SentinelConfig#METRIC_FLUSH_INTERVAL} as the rate </li>.
+     *      <li>if the {@link SentinelConfig#METRIC_FLUSH_INTERVAL} less than 0(include) or value is not valid,
+     * then means the timer will not be started </li>
+     * <ol></p>
+     */
+    private static void startMetricTimerListener() {
+        long flushInterval;
+        String flushIntervalStr = SentinelConfig.getConfig(SentinelConfig.METRIC_FLUSH_INTERVAL);
+        if (flushIntervalStr == null) {
+            flushInterval = SentinelConfig.DEFAULT_METRIC_FLUSH_INTERVAL;
+        } else {
+            try {
+                flushInterval = Long.parseLong(flushIntervalStr);
+            } catch (Exception e) {
+                RecordLog.warn("[FlowRuleManager] The custom config({}) is not a valid Long value, "
+                        + "the value({}) will be replaced with system default value({}).", SentinelConfig.METRIC_FLUSH_INTERVAL,
+                        flushIntervalStr, SentinelConfig.DEFAULT_METRIC_FLUSH_INTERVAL);
+                flushInterval = SentinelConfig.DEFAULT_METRIC_FLUSH_INTERVAL;
+            }
+        }
+        if (flushInterval <= 0) {
+            RecordLog.info("[FlowRuleManager] The MetricTimerListener is'n started. If you want to start it, "
+                    + "please change the value(current: {}) of config({}) more than 0 to start it.", flushInterval,
+                    SentinelConfig.METRIC_FLUSH_INTERVAL);
+            return;
+        }
+        SCHEDULER.scheduleAtFixedRate(new MetricTimerListener(), 0, flushInterval, TimeUnit.SECONDS);
+    }
+    
     /**
      * Listen to the {@link SentinelProperty} for {@link FlowRule}s. The property is the source of {@link FlowRule}s.
      * Flow rules can also be set by {@link #loadRules(List)} directly.

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManager.java
@@ -68,27 +68,14 @@ public class FlowRuleManager {
     /**
      * <p> Start the MetricTimerListener
      * <ol>
-     *     <li>if the {@link SentinelConfig#METRIC_FLUSH_INTERVAL} more than 0,
-     * the timer will run with the {@link SentinelConfig#METRIC_FLUSH_INTERVAL} as the rate </li>.
-     *      <li>if the {@link SentinelConfig#METRIC_FLUSH_INTERVAL} less than 0(include) or value is not valid,
+     *     <li>If the flushInterval more than 0,
+     * the timer will run with the flushInterval as the rate </li>.
+     *      <li>If the flushInterval less than 0(include) or value is not valid,
      * then means the timer will not be started </li>
      * <ol></p>
      */
     private static void startMetricTimerListener() {
-        long flushInterval;
-        String flushIntervalStr = SentinelConfig.getConfig(SentinelConfig.METRIC_FLUSH_INTERVAL);
-        if (flushIntervalStr == null) {
-            flushInterval = SentinelConfig.DEFAULT_METRIC_FLUSH_INTERVAL;
-        } else {
-            try {
-                flushInterval = Long.parseLong(flushIntervalStr);
-            } catch (Exception e) {
-                RecordLog.warn("[FlowRuleManager] The custom config({}) is not a valid Long value, "
-                        + "the value({}) will be replaced with system default value({}).", SentinelConfig.METRIC_FLUSH_INTERVAL,
-                        flushIntervalStr, SentinelConfig.DEFAULT_METRIC_FLUSH_INTERVAL);
-                flushInterval = SentinelConfig.DEFAULT_METRIC_FLUSH_INTERVAL;
-            }
-        }
+        long flushInterval = SentinelConfig.metricLogFlushIntervalSec();
         if (flushInterval <= 0) {
             RecordLog.info("[FlowRuleManager] The MetricTimerListener is'n started. If you want to start it, "
                     + "please change the value(current: {}) of config({}) more than 0 to start it.", flushInterval,


### PR DESCRIPTION
…roperty

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
add a new feature to support control the flush interval of metric via sentinel config: `csp.sentinel.metric.flush.interval`

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixs [1867](https://github.com/alibaba/Sentinel/issues/1867)
### Describe how you did it
add a new property in sentinel config(`csp.sentinel.metric.flush.interval`). control the metic timer start via this config.
1. if the SentinelConfig#METRIC_FLUSH_INTERVAL more than 0, the timer will run with the SentinelConfig#METRIC_FLUSH_INTERVAL as the rate.
2. if the SentinelConfig#METRIC_FLUSH_INTERVAL less than 0(include) or value is not valid, then means the timer will not be started.

### Describe how to verify it
change the config value,  see the metric log file output and use jvm tool to see if the timer thread is started.

### Special notes for reviews
