### PR TITLE
[feature] 熔断器状态变换事件通知到对应resource 

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/AbstractCircuitBreaker.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/AbstractCircuitBreaker.java
@@ -124,7 +124,7 @@ public abstract class AbstractCircuitBreaker implements CircuitBreaker {
     }
     
     private void notifyObservers(CircuitBreaker.State prevState, CircuitBreaker.State newState, Double snapshotValue) {
-        for (CircuitBreakerStateChangeObserver observer : observerRegistry.getStateChangeObservers()) {
+        for (CircuitBreakerStateChangeObserver observer : observerRegistry.getStateChangeObservers(rule.getResource())) {
             observer.onStateChange(prevState, newState, rule, snapshotValue);
         }
     }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/EventObserverRegistry.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/EventObserverRegistry.java
@@ -16,7 +16,9 @@
 package com.alibaba.csp.sentinel.slots.block.degrade.circuitbreaker;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -30,18 +32,30 @@ import com.alibaba.csp.sentinel.util.AssertUtil;
  */
 public class EventObserverRegistry {
 
-    private final Map<String, CircuitBreakerStateChangeObserver> stateChangeObserverMap = new HashMap<>();
+    private final Map<String, ObserverEntity> stateChangeObserverMap = new HashMap<>();
 
     /**
      * Register a circuit breaker state change observer.
-     *
+     * <p> Notes. the observer will all the state change</p>
      * @param name observer name
      * @param observer a valid observer
      */
     public void addStateChangeObserver(String name, CircuitBreakerStateChangeObserver observer) {
+        addStateChangeObserver(name, null, observer);
+    }
+    
+    /**
+     * Register a circuit breaker state change observer which observe the resource.
+     *
+     * @param name observer name
+     * @param resource  resource name
+     * @param observer a valid observer
+     */
+    public void addStateChangeObserver(String name, String resource, CircuitBreakerStateChangeObserver observer) {
         AssertUtil.notNull(name, "name cannot be null");
         AssertUtil.notNull(observer, "observer cannot be null");
-        stateChangeObserverMap.put(name, observer);
+        ObserverEntity observerEntity = new ObserverEntity(name, resource, observer);
+        stateChangeObserverMap.put(name, observerEntity);
     }
 
     public boolean removeStateChangeObserver(String name) {
@@ -50,12 +64,24 @@ public class EventObserverRegistry {
     }
 
     /**
-     * Get all registered state chane observers.
+     * Get all registered state chane observers which observe the resource.
      *
-     * @return all registered state chane observers
+     * @return all registered state chane observers which observe the resource
      */
-    public List<CircuitBreakerStateChangeObserver> getStateChangeObservers() {
-        return new ArrayList<>(stateChangeObserverMap.values());
+    public List<CircuitBreakerStateChangeObserver> getStateChangeObservers(String resource) {
+        Collection<ObserverEntity> observerEntities = stateChangeObserverMap.values();
+        if (observerEntities.isEmpty()) {
+            return new ArrayList<>();
+        }
+        List<CircuitBreakerStateChangeObserver> observers = new ArrayList<>();
+        Iterator<ObserverEntity> iterator = observerEntities.iterator();
+        while (iterator.hasNext()) {
+            ObserverEntity observerEntity = iterator.next();
+            if (observerEntity.isObserve(resource)) {
+                observers.add(observerEntity.observer);
+            }
+        }
+        return observers;
     }
 
     public static EventObserverRegistry getInstance() {
@@ -67,4 +93,41 @@ public class EventObserverRegistry {
     }
 
     EventObserverRegistry() {}
+    
+    /**
+     * the entity of {@link CircuitBreakerStateChangeObserver}
+     */
+    private final class ObserverEntity {
+    
+        /**
+         * observer name
+         */
+        final private String name;
+    
+        /**
+         * the resource name which the observer focus on
+         */
+        final private String resource;
+    
+        /**
+         * the observer
+         */
+        final private CircuitBreakerStateChangeObserver observer;
+    
+        public ObserverEntity(String name, String resource, CircuitBreakerStateChangeObserver observer) {
+            this.name = name;
+            this.resource = resource;
+            this.observer = observer;
+        }
+    
+        /**
+         * check if the observer entity is observe the resource.
+         * if the entity's resource is null, mean it will observe all the changes.
+         * @param resource the resource
+         * @return the observe result
+         */
+        public boolean isObserve(String resource) {
+            return this.resource == null || resource.equals(this.resource);
+        }
+    }
 }


### PR DESCRIPTION
… If the value of the resource is null, then it will observe all the state change.

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
 熔断器状态变换事件通知到对应resource 

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixs #1940 

### Describe how you did it
I add the resource when register the observer. then when the changes coming, it will choose the obsever by resource.

### Describe how to verify it
verify it in SlowRatioCircuitBreakerDemo.class by change the register type of observer.

### Special notes for reviews
