### PR TITLE
When the sentinel core is added to obtain IP, the configuration support ignores part of the network card interface name, and supports the priority to obtain the specified network segment

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/NetUtil.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/NetUtil.java
@@ -1,0 +1,158 @@
+package com.alibaba.csp.sentinel.util;
+
+import java.io.Serializable;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.util.*;
+
+/**
+ * network tools
+ *
+ * @author imlzw
+ */
+public class NetUtil {
+
+    public static String getLocalInetAddress() {
+        List<String[]> localIPs = getLocalIPs(null);
+        if (localIPs.size() > 0) {
+            return localIPs.get(0)[1];
+        }
+        return null;
+    }
+
+    public static String getLocalInetAddress(NetConfig config) {
+        List<String[]> localIPs = getLocalIPs(config);
+        if (localIPs.size() > 0) {
+            return localIPs.get(0)[1];
+        }
+        return null;
+    }
+
+    /**
+     * get local ips
+     *
+     * @param config
+     * @return
+     */
+    public static List<String[]> getLocalIPs(NetConfig config) {
+        LinkedHashMap<String, InetAddress> localIps = getLocalHostAddresses(new ConfigInetAddressFilter(config));
+        List<String[]> list = new ArrayList<>();
+        if (localIps != null && !localIps.isEmpty()) {
+            for (String key : localIps.keySet()) {
+                list.add(new String[]{key, localIps.get(key).getHostAddress()});
+            }
+        }
+        if (config != null) {
+            String preferredNetworks = config.getPreferredNetworks();
+            if (preferredNetworks != null && preferredNetworks.trim().length() > 0) {
+                final String[] ipSorts = preferredNetworks.split(",");
+                Collections.sort(list, new Comparator<String[]>() {
+                    @Override
+                    public int compare(String[] interfacess1, String[] interfacess2) {
+                        int sort1 = -1;
+                        int sort2 = -1;
+                        for (int i = 0; i < ipSorts.length; i++) {
+                            if (interfacess1[1].indexOf(ipSorts[i]) == 0) {
+                                sort1 = ipSorts.length - i;
+                                break;
+                            }
+                        }
+                        for (int i = 0; i < ipSorts.length; i++) {
+                            if (interfacess2[1].indexOf(ipSorts[i]) == 0) {
+                                sort2 = ipSorts.length - i;
+                                break;
+                            }
+                        }
+                        return sort2 - sort1;
+                    }
+                });
+            }
+        }
+        return list;
+    }
+
+    public static LinkedHashMap<String, InetAddress> getLocalHostAddresses(NameFilter nameFilter) {
+        LinkedHashMap<String, InetAddress> map = new LinkedHashMap<>();
+        Enumeration<NetworkInterface> netInterfaces;
+        try {
+            netInterfaces = NetworkInterface.getNetworkInterfaces();
+            InetAddress ip;
+            while (netInterfaces.hasMoreElements()) {
+                NetworkInterface ni = netInterfaces.nextElement();
+                if (nameFilter.filter(ni.getDisplayName())) {
+                    Enumeration<InetAddress> addresses = ni.getInetAddresses();
+                    while (addresses.hasMoreElements()) {
+                        ip = addresses.nextElement();
+                        if (!ip.isLoopbackAddress() && ip.getHostAddress().indexOf(':') == -1) {
+                            map.put(ni.getName() + ":" + ni.getDisplayName(), ip);
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return map;
+    }
+
+//    public static void main(String[] args) {
+//        NetConfig config = new NetConfig();
+//        config.setPreferredNetworks("192.168.2");
+//        System.out.println(getLocalIPs(config).get(0)[1]);
+//    }
+
+    public static interface NameFilter {
+        public boolean filter(String name);
+    }
+
+    /**
+     * config inet address filter
+     */
+    public static class ConfigInetAddressFilter implements NameFilter {
+
+        private NetConfig config;
+
+        public ConfigInetAddressFilter(NetConfig config) {
+            this.config = config;
+        }
+
+        @Override
+        public boolean filter(String name) {
+            String lowerCase = name.toLowerCase();
+            if (config != null) {
+                String ignoredInterfaces = config.getIgnoredInterfaces();
+                if (ignoredInterfaces != null && ignoredInterfaces.trim().length() > 0) {
+                    String[] splitInterfacess = ignoredInterfaces.split(",");
+                    for (String netInterfacess : splitInterfacess) {
+                        if (netInterfacess != null && lowerCase.indexOf(netInterfacess.trim().toLowerCase()) >= 0) {
+                            return false;
+                        }
+                    }
+                }
+            }
+            return true;
+        }
+    }
+
+    public static class NetConfig implements Serializable {
+        private String ignoredInterfaces;
+        private String preferredNetworks;
+
+        public String getIgnoredInterfaces() {
+            return ignoredInterfaces;
+        }
+
+        public void setIgnoredInterfaces(String ignoredInterfaces) {
+            this.ignoredInterfaces = ignoredInterfaces;
+        }
+
+        public String getPreferredNetworks() {
+            return preferredNetworks;
+        }
+
+        public void setPreferredNetworks(String preferredNetworks) {
+            this.preferredNetworks = preferredNetworks;
+        }
+    }
+}

--- a/sentinel-dashboard/pom.xml
+++ b/sentinel-dashboard/pom.xml
@@ -102,7 +102,6 @@
         <dependency>
             <groupId>com.alibaba.csp</groupId>
             <artifactId>sentinel-datasource-nacos</artifactId>
-            <scope>test</scope>
         </dependency>
         <!-- for Apollo rule publisher sample -->
         <dependency>

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/v2/FlowControllerV2.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/v2/FlowControllerV2.java
@@ -59,10 +59,10 @@ public class FlowControllerV2 {
     private InMemoryRuleRepositoryAdapter<FlowRuleEntity> repository;
 
     @Autowired
-    @Qualifier("flowRuleDefaultProvider")
+    @Qualifier("flowRuleNacosProvider")
     private DynamicRuleProvider<List<FlowRuleEntity>> ruleProvider;
     @Autowired
-    @Qualifier("flowRuleDefaultPublisher")
+    @Qualifier("flowRuleNacosPublisher")
     private DynamicRulePublisher<List<FlowRuleEntity>> rulePublisher;
 
     @GetMapping("/rules")

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/rule/nacos/FlowRuleNacosProvider.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/rule/nacos/FlowRuleNacosProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dashboard.rule.nacos;
+
+import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.FlowRuleEntity;
+import com.alibaba.csp.sentinel.dashboard.rule.DynamicRuleProvider;
+import com.alibaba.csp.sentinel.datasource.Converter;
+import com.alibaba.csp.sentinel.util.StringUtil;
+import com.alibaba.nacos.api.config.ConfigService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Eric Zhao
+ * @since 1.4.0
+ */
+@Component("flowRuleNacosProvider")
+public class FlowRuleNacosProvider implements DynamicRuleProvider<List<FlowRuleEntity>> {
+
+    @Autowired
+    private ConfigService configService;
+    @Autowired
+    private Converter<String, List<FlowRuleEntity>> converter;
+
+    @Override
+    public List<FlowRuleEntity> getRules(String appName) throws Exception {
+        String rules = configService.getConfig(appName + NacosConfigUtil.FLOW_DATA_ID_POSTFIX,
+            NacosConfigUtil.GROUP_ID, 3000);
+        if (StringUtil.isEmpty(rules)) {
+            return new ArrayList<>();
+        }
+        return converter.convert(rules);
+    }
+}

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/rule/nacos/FlowRuleNacosPublisher.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/rule/nacos/FlowRuleNacosPublisher.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dashboard.rule.nacos;
+
+import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.FlowRuleEntity;
+import com.alibaba.csp.sentinel.dashboard.rule.DynamicRulePublisher;
+import com.alibaba.csp.sentinel.datasource.Converter;
+import com.alibaba.csp.sentinel.util.AssertUtil;
+import com.alibaba.nacos.api.config.ConfigService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * @author Eric Zhao
+ * @since 1.4.0
+ */
+@Component("flowRuleNacosPublisher")
+public class FlowRuleNacosPublisher implements DynamicRulePublisher<List<FlowRuleEntity>> {
+
+    @Autowired
+    private ConfigService configService;
+    @Autowired
+    private Converter<List<FlowRuleEntity>, String> converter;
+
+    @Override
+    public void publish(String app, List<FlowRuleEntity> rules) throws Exception {
+        AssertUtil.notEmpty(app, "app name cannot be empty");
+        if (rules == null) {
+            return;
+        }
+        configService.publishConfig(app + NacosConfigUtil.FLOW_DATA_ID_POSTFIX,
+            NacosConfigUtil.GROUP_ID, converter.convert(rules));
+    }
+}

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/rule/nacos/NacosConfig.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/rule/nacos/NacosConfig.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dashboard.rule.nacos;
+
+import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.FlowRuleEntity;
+import com.alibaba.csp.sentinel.datasource.Converter;
+import com.alibaba.fastjson.JSON;
+import com.alibaba.nacos.api.config.ConfigFactory;
+import com.alibaba.nacos.api.config.ConfigService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+/**
+ * @author Eric Zhao
+ * @since 1.4.0
+ */
+@Configuration
+public class NacosConfig {
+
+    @Bean
+    public Converter<List<FlowRuleEntity>, String> flowRuleEntityEncoder() {
+        return JSON::toJSONString;
+    }
+
+    @Bean
+    public Converter<String, List<FlowRuleEntity>> flowRuleEntityDecoder() {
+        return s -> JSON.parseArray(s, FlowRuleEntity.class);
+    }
+
+    @Bean
+    public ConfigService nacosConfigService() throws Exception {
+        return ConfigFactory.createConfigService("localhost:8848");
+    }
+}

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/rule/nacos/NacosConfigUtil.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/rule/nacos/NacosConfigUtil.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dashboard.rule.nacos;
+
+/**
+ * @author Eric Zhao
+ * @since 1.4.0
+ */
+public final class NacosConfigUtil {
+
+    public static final String GROUP_ID = "SENTINEL_GROUP";
+    
+    public static final String FLOW_DATA_ID_POSTFIX = "-flow-rules";
+    public static final String PARAM_FLOW_DATA_ID_POSTFIX = "-param-rules";
+    public static final String CLUSTER_MAP_DATA_ID_POSTFIX = "-cluster-map";
+
+    /**
+     * cc for `cluster-client`
+     */
+    public static final String CLIENT_CONFIG_DATA_ID_POSTFIX = "-cc-config";
+    /**
+     * cs for `cluster-server`
+     */
+    public static final String SERVER_TRANSPORT_CONFIG_DATA_ID_POSTFIX = "-cs-transport-config";
+    public static final String SERVER_FLOW_CONFIG_DATA_ID_POSTFIX = "-cs-flow-config";
+    public static final String SERVER_NAMESPACE_SET_DATA_ID_POSTFIX = "-cs-namespace-set";
+
+    private NacosConfigUtil() {}
+}

--- a/sentinel-dashboard/src/main/webapp/resources/app/scripts/directives/sidebar/sidebar.html
+++ b/sentinel-dashboard/src/main/webapp/resources/app/scripts/directives/sidebar/sidebar.html
@@ -54,7 +54,7 @@
           </li>
 
           <li ui-sref-active="active" ng-if="!entry.isGateway">
-            <a ui-sref="dashboard.flowV1({app: entry.app})">
+            <a ui-sref="dashboard.flow({app: entry.app})">
               <i class="glyphicon glyphicon-filter"></i>&nbsp;&nbsp;流控规则</a>
           </li>
 


### PR DESCRIPTION
When the sentinel core is added to obtain IP, the configuration support ignores part of the network card interface name, and supports the priority to obtain the specified network segment.
The configuration is as follows:
`
#Specifies the network port key ignored when acquiring local IP in heartbeat packet (case ignored)
csp.sentinel.heartbeat.client.net.ignoredInterfaces=veth,docker,virtual

#Specify the priority network segment configuration when acquiring the local IP in the heartbeat packet
csp.sentinel.heartbeat.client.net.preferredNetworks=192.168.2,192.168,172.27
`