### PR TITLE
Simplify enums: remove unnecessary code and reuse enum name

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/EntryType.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/EntryType.java
@@ -19,29 +19,16 @@ package com.alibaba.csp.sentinel;
  * An enum marks resource invocation direction.
  *
  * @author jialiang.linjl
+ * @author Yanming Zhou
  */
 public enum EntryType {
     /**
      * Inbound traffic
      */
-    IN("IN"),
+    IN,
     /**
      * Outbound traffic
      */
-    OUT("OUT");
+    OUT;
 
-    private final String name;
-
-    EntryType(String s) {
-        name = s;
-    }
-
-    public boolean equalsName(String otherName) {
-        return name.equals(otherName);
-    }
-
-    @Override
-    public String toString() {
-        return name;
-    }
 }

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/endpoint/Protocol.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/endpoint/Protocol.java
@@ -2,18 +2,13 @@ package com.alibaba.csp.sentinel.transport.endpoint;
 
 /**
  * @author Leo Li
+ * @author Yanming Zhou
  */
 public enum Protocol {
-    HTTP("http"),
-    HTTPS("https");
-
-    private String protocol;
-
-    Protocol(String protocol) {
-        this.protocol = protocol;
-    }
+    HTTP,
+    HTTPS;
 
     public String getProtocol() {
-        return protocol;
+        return name().toLowerCase();
     }
 }


### PR DESCRIPTION
Remove unnecessary code and reuse enum name.