### PR TITLE
fix(dashboard): ${user.home} is resolved when maven package

### DIFF
--- a/sentinel-dashboard/pom.xml
+++ b/sentinel-dashboard/pom.xml
@@ -13,6 +13,7 @@
     <packaging>jar</packaging>
 
     <properties>
+        <resource.delimiter>@</resource.delimiter>
         <spring.boot.version>2.0.5.RELEASE</spring.boot.version>
         <curator.version>4.0.1</curator.version>
     </properties>
@@ -138,6 +139,20 @@
 
     <build>
         <finalName>sentinel-dashboard</finalName>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <configuration>
+                        <delimiters>
+                            <delimiter>${resource.delimiter}</delimiter>
+                        </delimiters>
+                        <useDefaultDelimiters>false</useDefaultDelimiters>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>

--- a/sentinel-dashboard/src/main/resources/application.properties
+++ b/sentinel-dashboard/src/main/resources/application.properties
@@ -21,4 +21,4 @@ auth.password=sentinel
 
 # Inject the dashboard version. It's required to enable
 # filtering in pom.xml for this resource file.
-sentinel.dashboard.version=${project.version}
+sentinel.dashboard.version=@project.version@


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

${user.home} in `application.properties` should be resolved in dashboard runtime, not after maven package.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Fixes #2045 

### Describe how you did it

Change maven-resources-plugin's behavior by use delimiter `@`

### Describe how to verify it

Run `mvn clean package -DskipTests` on project, then check `BOOT-INF/classes/application.properties` in file `sentinel-dashboard/target/sentinel-dashboard.jar`

`application.properties`'s content is changed.

Only 
```properties
sentinel.dashboard.version=@project.version@
```
is changed to
```properties
sentinel.dashboard.version=1.8.2-SNAPSHOT
```

And
```properties
logging.file=${user.home}/logs/csp/sentinel-dashboard.log
```
keep same as source code.

### Special notes for reviews
