### PR TITLE
refactor(dashboard): use MetricsRepositoryConfiguration to config bean of MetricsRepository's implementation

### DIFF
--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/config/MetricsRepositoryConfiguration.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/config/MetricsRepositoryConfiguration.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.csp.sentinel.dashboard.config;
 
 import com.alibaba.csp.sentinel.dashboard.datasource.entity.MetricEntity;

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/config/MetricsRepositoryConfiguration.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/config/MetricsRepositoryConfiguration.java
@@ -1,0 +1,24 @@
+package com.alibaba.csp.sentinel.dashboard.config;
+
+import com.alibaba.csp.sentinel.dashboard.datasource.entity.MetricEntity;
+import com.alibaba.csp.sentinel.dashboard.repository.metric.InMemoryMetricsRepository;
+import com.alibaba.csp.sentinel.dashboard.repository.metric.MetricsRepository;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * {@link MetricsRepository}'s implementation bean configuration.
+ *
+ * @author wxq
+ */
+@Configuration
+public class MetricsRepositoryConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public MetricsRepository<MetricEntity> metricEntityMetricsRepository() {
+        return new InMemoryMetricsRepository();
+    }
+
+}

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/repository/metric/InMemoryMetricsRepository.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/repository/metric/InMemoryMetricsRepository.java
@@ -18,7 +18,6 @@ package com.alibaba.csp.sentinel.dashboard.repository.metric;
 import com.alibaba.csp.sentinel.dashboard.datasource.entity.MetricEntity;
 import com.alibaba.csp.sentinel.util.StringUtil;
 import com.alibaba.csp.sentinel.util.TimeUtil;
-import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -36,7 +35,6 @@ import java.util.stream.Collectors;
  * @author Carpenter Lee
  * @author Eric Zhao
  */
-@Component
 public class InMemoryMetricsRepository implements MetricsRepository<MetricEntity> {
 
     private static final long MAX_METRIC_LIVE_TIME_MS = 1000 * 60 * 5;
@@ -44,7 +42,7 @@ public class InMemoryMetricsRepository implements MetricsRepository<MetricEntity
     /**
      * {@code app -> resource -> timestamp -> metric}
      */
-    private Map<String, Map<String, LinkedHashMap<Long, MetricEntity>>> allMetrics = new ConcurrentHashMap<>();
+    private final Map<String, Map<String, LinkedHashMap<Long, MetricEntity>>> allMetrics = new ConcurrentHashMap<>();
 
     private final ReentrantReadWriteLock readWriteLock = new ReentrantReadWriteLock();
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Make people custom their own MetricsRepository more easier.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

#2053 

### Describe how you did it

Use MetricsRepositoryConfiguration to config bean of MetricsRepository's implementation.

Conbine with `@ConditionalOnMissingBean`, then people can custom their own MetricsRepository without change the source code, just add their own MetricsRepositoryConfiguration.

### Describe how to verify it

Annotation `@Component` above class `InMemoryMetricsRepository` has been delete, it is created by method

```java
    @Bean
    @ConditionalOnMissingBean
    public MetricsRepository<MetricEntity> metricEntityMetricsRepository() {
        return new InMemoryMetricsRepository();
    }
```

and not break the old test.

### Special notes for reviews
