### PR TITLE
add server initiative timeout，prevent bizThreadPool full

### DIFF
--- a/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/command/SimpleHttpCommandCenter.java
+++ b/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/command/SimpleHttpCommandCenter.java
@@ -184,7 +184,7 @@ public class SimpleHttpCommandCenter implements CommandCenter {
                     //add server initiative timeout，prevent bizThreadPool full
                    Future<String> future = bizExecutor.submit(eventTask,"ok");
                    try {
-                       future.get(3000, TimeUnit.MILLISECONDS);
+                       future.get(DEFAULT_SERVER_SO_TIMEOUT, TimeUnit.MILLISECONDS);
                    }catch (TimeoutException | InterruptedException | ExecutionException  ex){
                        CommandCenterLog.error("httpEventTask request timeout");
                        future.cancel(true);


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

The simple webserver in transport-simple-http ,add server initiative timeout，prevent bizThreadPool full。
Although there are already has setSocketSoTimeout，but the eventTask thread will not be released。
When some requests are slow，the bizThreadPool will full，then many normal requests may be affected 

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
