### PR TITLE
Perfect the simple webserver in transport-simple-http 

### DIFF
--- a/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/command/SimpleHttpCommandCenter.java
+++ b/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/command/SimpleHttpCommandCenter.java
@@ -181,7 +181,7 @@ public class SimpleHttpCommandCenter implements CommandCenter {
                     socket = this.serverSocket.accept();
                     setSocketSoTimeout(socket);
                     HttpEventTask eventTask = new HttpEventTask(socket);
-                    //add server initiative timeout，prevent bizThreadPool full
+                    //add server initiative timeout，prevent bizThreadPool full normal requests may be affected
                    Future<String> future = bizExecutor.submit(eventTask,"ok");
                    try {
                        future.get(DEFAULT_SERVER_SO_TIMEOUT, TimeUnit.MILLISECONDS);

--- a/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/command/SimpleHttpCommandCenter.java
+++ b/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/command/SimpleHttpCommandCenter.java
@@ -184,7 +184,7 @@ public class SimpleHttpCommandCenter implements CommandCenter {
                     //add server initiative timeout，prevent bizThreadPool full
                    Future<String> future = bizExecutor.submit(eventTask,"ok");
                    try {
-                       future.get(3000, TimeUnit.MILLISECONDS);
+                       future.get(DEFAULT_SERVER_SO_TIMEOUT, TimeUnit.MILLISECONDS);
                    }catch (TimeoutException | InterruptedException | ExecutionException  ex){
                        CommandCenterLog.error("httpEventTask request timeout");
                        future.cancel(true);

--- a/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/command/SimpleHttpCommandCenter.java
+++ b/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/command/SimpleHttpCommandCenter.java
@@ -175,11 +175,13 @@ public class SimpleHttpCommandCenter implements CommandCenter {
 
         @Override
         public void run() {
+            //loop accept ,receive request and
             while (true) {
                 Socket socket = null;
                 try {
                     socket = this.serverSocket.accept();
                     setSocketSoTimeout(socket);
+                    //Give it to the biz threadPool for processing
                     HttpEventTask eventTask = new HttpEventTask(socket);
                     //add server initiative timeout，prevent bizThreadPool full normal requests may be affected
                    Future<String> future = bizExecutor.submit(eventTask,"ok");

--- a/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/command/SimpleHttpCommandCenter.java
+++ b/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/command/SimpleHttpCommandCenter.java
@@ -185,7 +185,7 @@ public class SimpleHttpCommandCenter implements CommandCenter {
                    Future<String> future = bizExecutor.submit(eventTask,"ok");
                    try {
                        future.get(DEFAULT_SERVER_SO_TIMEOUT, TimeUnit.MILLISECONDS);
-                   }catch (TimeoutException | InterruptedException | ExecutionException  ex){
+                   }catch (TimeoutException | InterruptedException | ExecutionException ex){
                        CommandCenterLog.error("httpEventTask request timeout");
                        //http eventTask timeout,call cancel (interrupt this thread)
                        future.cancel(true);

--- a/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/command/SimpleHttpCommandCenter.java
+++ b/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/command/SimpleHttpCommandCenter.java
@@ -187,6 +187,7 @@ public class SimpleHttpCommandCenter implements CommandCenter {
                        future.get(DEFAULT_SERVER_SO_TIMEOUT, TimeUnit.MILLISECONDS);
                    }catch (TimeoutException | InterruptedException | ExecutionException  ex){
                        CommandCenterLog.error("httpEventTask request timeout");
+                       //http eventTask timeout,call cancel (interrupt this thread)
                        future.cancel(true);
                    }
                 } catch (Exception e) {

--- a/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/command/SimpleHttpCommandCenter.java
+++ b/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/command/SimpleHttpCommandCenter.java
@@ -186,7 +186,7 @@ public class SimpleHttpCommandCenter implements CommandCenter {
                    try {
                        future.get(DEFAULT_SERVER_SO_TIMEOUT, TimeUnit.MILLISECONDS);
                    }catch (TimeoutException | InterruptedException | ExecutionException ex){
-                       CommandCenterLog.error("httpEventTask request timeout");
+                       CommandCenterLog.error("httpEventTask handle request timeout");
                        //http eventTask timeout,call cancel (interrupt this thread)
                        future.cancel(true);
                    }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
The simple webserver in transport-simple-http ,add server initiative timeout，prevent bizThreadPool full。
Although there are already has setSocketSoTimeout，but the eventTask thread will not be released。
When some requests are slow，the bizThreadPool will full，then many normal requests may be affected

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

use the juc future timeout

### Describe how to verify it


### Special notes for reviews
