### PR TITLE
Customize fallback config

### DIFF
--- a/sentinel-adapter/sentinel-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/fallback/DefaultDubboFallback.java
+++ b/sentinel-adapter/sentinel-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/fallback/DefaultDubboFallback.java
@@ -15,8 +15,14 @@
  */
 package com.alibaba.csp.sentinel.adapter.dubbo.fallback;
 
+import com.alibaba.csp.sentinel.Constants;
+import com.alibaba.csp.sentinel.fallback.FallbackRule;
+import com.alibaba.csp.sentinel.fallback.FallbackRuleManager;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
 import com.alibaba.csp.sentinel.slots.block.SentinelRpcException;
+import com.alibaba.csp.sentinel.util.StringUtil;
+import com.alibaba.dubbo.common.json.JSON;
+import com.alibaba.dubbo.common.json.ParseException;
 import com.alibaba.dubbo.rpc.Invocation;
 import com.alibaba.dubbo.rpc.Invoker;
 import com.alibaba.dubbo.rpc.Result;
@@ -29,6 +35,40 @@ public class DefaultDubboFallback implements DubboFallback {
 
     @Override
     public Result handle(Invoker<?> invoker, Invocation invocation, BlockException ex) {
+        return defaultFallback(ex);
+    }
+
+    @Override
+    public Result handle(Invoker<?> invoker, Invocation invocation, BlockException ex, String resourceName) {
+        FallbackRule fallbackRule = FallbackRuleManager.getFallbackRule(resourceName);
+        if (StringUtil.isNotEmpty(fallbackRule.getFallback())) {
+            // return null
+            if (Constants.NULL_FALLBACK.equals(fallbackRule.getFallback())) {
+                return null;
+            // throw exception
+            } else if (Constants.EXCEPTION_FALLBACK.equals(fallbackRule.getFallback())) {
+                throw new SentinelRpcException(ex.toRuntimeException());
+            // return fallback object
+            } else {
+                if (StringUtil.isNotEmpty(fallbackRule.getClazzReference())) {
+                        RpcResult result = new RpcResult();
+                        try {
+                            result.setValue(JSON.parse(fallbackRule.getFallback(), fallbackRule.getClass()));
+                        } catch (ParseException e) {
+                            e.printStackTrace();
+                            result.setException(new SentinelRpcException(ex.toRuntimeException()));
+                        }
+                        return result;
+                } else {
+                    return defaultFallback(ex);
+                }
+            }
+        } else {
+            return defaultFallback(ex);
+        }
+    }
+
+    private Result defaultFallback(BlockException ex) {
         // Just wrap the exception. edit by wzg923 2020/9/23
         RpcResult result = new RpcResult();
         result.setException(new SentinelRpcException(ex.toRuntimeException()));

--- a/sentinel-adapter/sentinel-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/fallback/DubboFallback.java
+++ b/sentinel-adapter/sentinel-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/fallback/DubboFallback.java
@@ -36,4 +36,14 @@ public interface DubboFallback {
      * @return fallback result
      */
     Result handle(Invoker<?> invoker, Invocation invocation, BlockException ex);
+
+    /**
+     * Handle the block exception and provide fallback result customize.
+     * @param invoker
+     * @param invocation
+     * @param ex
+     * @param resourceName
+     * @return
+     */
+    Result handle(Invoker<?> invoker, Invocation invocation, BlockException ex, String resourceName);
 }

--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/callback/BlockExceptionHandler.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/callback/BlockExceptionHandler.java
@@ -37,4 +37,16 @@ public interface BlockExceptionHandler {
      */
     void handle(HttpServletRequest request, HttpServletResponse response, BlockException e) throws Exception;
 
+    /**
+     * handle the request when blocked
+     *
+     * @param request
+     * @param response
+     * @param e
+     * @param resourceName
+     * @throws Exception
+     */
+    void handle(HttpServletRequest request, HttpServletResponse response, BlockException e, String resourceName) throws Exception;
+
+
 }

--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/callback/DefaultBlockExceptionHandler.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/callback/DefaultBlockExceptionHandler.java
@@ -15,11 +15,15 @@
  */
 package com.alibaba.csp.sentinel.adapter.spring.webmvc.callback;
 
+import com.alibaba.csp.sentinel.Constants;
+import com.alibaba.csp.sentinel.fallback.FallbackRule;
+import com.alibaba.csp.sentinel.fallback.FallbackRuleManager;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
 import com.alibaba.csp.sentinel.util.StringUtil;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.io.PrintWriter;
 
 /**
@@ -28,6 +32,8 @@ import java.io.PrintWriter;
  * @author kaizi2009
  */
 public class DefaultBlockExceptionHandler implements BlockExceptionHandler {
+
+    public static final String DEFAULT_FALLBACK = "Blocked by Sentinel (flow limiting)";
 
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, BlockException e) throws Exception {
@@ -40,8 +46,38 @@ public class DefaultBlockExceptionHandler implements BlockExceptionHandler {
             url.append("?").append(request.getQueryString());
         }
 
+        doFallback(response, DEFAULT_FALLBACK);
+    }
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, BlockException e, String resourceName) throws Exception {
+        // Return 200, can use fallback config instead.
+        response.setStatus(200);
+        StringBuffer url = request.getRequestURL();
+        if ("GET".equals(request.getMethod()) && StringUtil.isNotBlank(request.getQueryString())) {
+            url.append("?").append(request.getQueryString());
+        }
+        FallbackRule fallbackRule = FallbackRuleManager.getFallbackRule(resourceName);
+        if (StringUtil.isNotEmpty(fallbackRule.getFallback())) {
+            if (Constants.NULL_FALLBACK.equals(fallbackRule.getFallback())) {
+                doFallback(response, null);
+            } else {
+                doFallback(response, fallbackRule.getFallback());
+            }
+        } else {
+            doFallback(response, DEFAULT_FALLBACK);
+        }
+    }
+
+    /**
+     * default fallback
+     *
+     * @param response
+     * @throws IOException
+     */
+    private void doFallback(HttpServletResponse response, String fallback) throws IOException {
         PrintWriter out = response.getWriter();
-        out.print("Blocked by Sentinel (flow limiting)");
+        out.print(fallback);
         out.flush();
         out.close();
     }

--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/controller/TestController.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/controller/TestController.java
@@ -31,6 +31,11 @@ public class TestController {
         return "Hello!";
     }
 
+    @GetMapping("/fallbackConfig")
+    public String fallbackConfig() {
+        return "fallbackConfig";
+    }
+
     @GetMapping("/err")
     public String apiError() {
         return "Oops...";

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Constants.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/Constants.java
@@ -69,6 +69,14 @@ public final class Constants {
      * The global switch for Sentinel.
      */
     public static volatile boolean ON = true;
+    /**
+     * fallback type throw exception
+     */
+    public final static String EXCEPTION_FALLBACK = "__exception__";
+    /**
+     * fallback type null value
+     */
+    public final static String NULL_FALLBACK = "__null__";
 
     private Constants() {}
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/fallback/FallbackRule.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/fallback/FallbackRule.java
@@ -1,0 +1,110 @@
+package com.alibaba.csp.sentinel.fallback;
+
+import com.alibaba.csp.sentinel.log.RecordLog;
+import com.alibaba.csp.sentinel.slots.block.AbstractRule;
+import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+import com.alibaba.csp.sentinel.util.ClassUtils;
+
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @ClassName: FallbackRule
+ * @Author Mason.MA
+ * @Package com.alibaba.csp.sentinel.fallback
+ * @Date 2021/3/10 14:22
+ * @Version 1.0
+ */
+public class FallbackRule extends AbstractRule {
+
+    private static ConcurrentHashMap<String, Class<?>> referenceClassMap = new ConcurrentHashMap<>(64);
+
+    public FallbackRule() {
+        super();
+        setLimitApp(RuleConstant.LIMIT_APP_DEFAULT);
+    }
+
+    public FallbackRule(String resourceName) {
+        super();
+        setResource(resourceName);
+        setLimitApp(RuleConstant.LIMIT_APP_DEFAULT);
+    }
+
+    /**
+     * fallback string, json for good
+     */
+    private String fallback;
+    /**
+     * class of fallback string, if configured , use this class serialize json string
+     */
+    private String clazzReference = "";
+
+    @Override
+    public String toString() {
+        return "FallbackRule{" +
+                "resource='" + getResource() + '\'' +
+                ", fallback='" + fallback + '\'' +
+                ", clazzReference='" + clazzReference + '\'' +
+                '}';
+    }
+
+    public String getFallback() {
+        return fallback;
+    }
+
+    public FallbackRule setFallback(String fallback) {
+        this.fallback = fallback;
+        return this;
+    }
+
+    public String getClazzReference() {
+        return clazzReference;
+    }
+
+    public FallbackRule setClazzReference(String clazzReference) {
+        this.clazzReference = clazzReference;
+        return this;
+    }
+
+
+    /**
+     * get Class by name
+     *
+     * @param clazzReference example java.lang.String
+     * @return Class
+     */
+    public static Class<?> getClass(String clazzReference) {
+        try {
+            if (null != referenceClassMap.get(clazzReference)) {
+                return referenceClassMap.get(clazzReference);
+            } else {
+                Class<?> clazz = ClassUtils.getClass(clazzReference, true);
+                referenceClassMap.put(clazzReference, clazz);
+                return clazz;
+            }
+        } catch (ClassNotFoundException e) {
+            RecordLog.warn(clazzReference + " ClassNotFoundException in current Classloader");
+        }
+        return null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        FallbackRule that = (FallbackRule) o;
+        return Objects.equals(fallback, that.fallback) && Objects.equals(clazzReference, that.clazzReference);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), fallback, clazzReference);
+    }
+}

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/fallback/FallbackRuleManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/fallback/FallbackRuleManager.java
@@ -1,0 +1,95 @@
+package com.alibaba.csp.sentinel.fallback;
+
+import com.alibaba.csp.sentinel.log.RecordLog;
+import com.alibaba.csp.sentinel.property.DynamicSentinelProperty;
+import com.alibaba.csp.sentinel.property.PropertyListener;
+import com.alibaba.csp.sentinel.property.SentinelProperty;
+import com.alibaba.csp.sentinel.util.AssertUtil;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * <p>
+ * Return fallback config when blocked:
+ * <ol>
+ * <li>requests from specified caller</li>
+ * <li>no specified caller</li>
+ * </ol>
+ * </p>
+ *
+ * @ClassName: FallbackRuleManager
+ * @Author Mason.MA
+ * @Package com.alibaba.csp.sentinel.fallback
+ * @Date 2021/3/10 14:21
+ * @Version 1.0
+ */
+public class FallbackRuleManager {
+
+    FallbackRuleManager(){}
+    /**
+     * No matter what type of block(flow/degrade/param/authority) it is.It is block.
+     * So for a single resource,has only one customized fallback config.
+     */
+    private static final Map<String, FallbackRule> BLOCK_FALLBACK = new ConcurrentHashMap<String, FallbackRule>();
+    private static final FallbackPropertyListener FALLBACK_PROPERTY_LISTENER = new FallbackPropertyListener();
+    private static SentinelProperty<List<FallbackRule>> currentProperty = new DynamicSentinelProperty<List<FallbackRule>>();
+
+
+    static {
+        currentProperty.addListener(FALLBACK_PROPERTY_LISTENER);
+    }
+
+    public static void register2Property(SentinelProperty<List<FallbackRule>> property) {
+        AssertUtil.notNull(property, "property can't be null");
+        synchronized (FALLBACK_PROPERTY_LISTENER) {
+            currentProperty.removeListener(FALLBACK_PROPERTY_LISTENER);
+            property.addListener(FALLBACK_PROPERTY_LISTENER);
+            currentProperty = property;
+        }
+    }
+
+    public static FallbackRule getFallbackRule(String resource) {
+        return BLOCK_FALLBACK.get(resource);
+    }
+
+    /**
+     * manually load
+     * @param fallbacks
+     */
+    public static void loadFallbacks(List<FallbackRule> fallbacks) {
+        currentProperty.updateValue(fallbacks);
+    }
+
+
+    private static class FallbackPropertyListener implements PropertyListener<List<FallbackRule>> {
+
+        @Override
+        public void configUpdate(List<FallbackRule> fallbackRules) {
+            Map<String, FallbackRule> fallbacks = buildFallbackMap(fallbackRules);
+            BLOCK_FALLBACK.clear();
+            BLOCK_FALLBACK.putAll(fallbacks);
+            RecordLog.info("[FallbackManager] fallbacks received: " + fallbacks);
+        }
+
+        @Override
+        public void configLoad(List<FallbackRule> value) {
+            Map<String, FallbackRule> fallbacks = buildFallbackMap(value);
+            BLOCK_FALLBACK.clear();
+            BLOCK_FALLBACK.putAll(fallbacks);
+            RecordLog.info("[FallbackManager] fallbacks loaded: " + fallbacks);
+        }
+    }
+
+    private static Map<String, FallbackRule> buildFallbackMap(List<FallbackRule> fallbackRules) {
+        Map<String, FallbackRule> newMap = new ConcurrentHashMap<>();
+        if (null == fallbackRules || fallbackRules.isEmpty()) {
+            return newMap;
+        }
+        for (FallbackRule fallbackRule : fallbackRules) {
+            newMap.put(fallbackRule.getResource(), fallbackRule);
+        }
+        return newMap;
+    }
+}

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/ClassUtils.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/ClassUtils.java
@@ -1,0 +1,135 @@
+package com.alibaba.csp.sentinel.util;
+
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Operates on classes without using reflection.
+ * This class handles invalid null inputs as best it can. Each method documents its behavior in more detail.
+ * The notion of a canonical name includes the human readable name for the type, for example int[]. The non-canonical method variants work with the JVM names, such as [I.
+ * Since:
+ * 2.0
+ *
+ * @author masonma
+ */
+public class ClassUtils {
+    ClassUtils() {
+    }
+
+    public static final char PACKAGE_SEPARATOR_CHAR = '.';
+
+    /**
+     * The inner class separator character: <code>'$' == {@value}</code>.
+     */
+    public static final char INNER_CLASS_SEPARATOR_CHAR = '$';
+
+    private static final Map<String, Class<?>> namePrimitiveMap = new HashMap<>();
+
+    static {
+        namePrimitiveMap.put("boolean", Boolean.TYPE);
+        namePrimitiveMap.put("byte", Byte.TYPE);
+        namePrimitiveMap.put("char", Character.TYPE);
+        namePrimitiveMap.put("short", Short.TYPE);
+        namePrimitiveMap.put("int", Integer.TYPE);
+        namePrimitiveMap.put("long", Long.TYPE);
+        namePrimitiveMap.put("double", Double.TYPE);
+        namePrimitiveMap.put("float", Float.TYPE);
+        namePrimitiveMap.put("void", Void.TYPE);
+    }
+
+    private static final Map<String, String> abbreviationMap;
+
+    /**
+     * Feed abbreviation maps
+     */
+    static {
+        final Map<String, String> m = new HashMap<>();
+        m.put("int", "I");
+        m.put("boolean", "Z");
+        m.put("float", "F");
+        m.put("long", "J");
+        m.put("short", "S");
+        m.put("byte", "B");
+        m.put("double", "D");
+        m.put("char", "C");
+        abbreviationMap = Collections.unmodifiableMap(m);
+    }
+
+    public static Class<?> getClass(final String className) throws ClassNotFoundException {
+        return getClass(className, true);
+    }
+
+    public static Class<?> getClass(final String className, final boolean initialize) throws ClassNotFoundException {
+        final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        final ClassLoader loader = contextClassLoader == null ? ClassUtils.class.getClassLoader() : contextClassLoader;
+        return getClass(loader, className, initialize);
+    }
+
+    public static Class<?> getClass(
+            final ClassLoader classLoader, final String className, final boolean initialize) throws ClassNotFoundException {
+        try {
+            Class<?> clazz;
+            if (namePrimitiveMap.containsKey(className)) {
+                clazz = namePrimitiveMap.get(className);
+            } else {
+                clazz = Class.forName(toCanonicalName(className), initialize, classLoader);
+            }
+            return clazz;
+        } catch (final ClassNotFoundException ex) {
+            // allow path separators (.) as inner class name separators
+            final int lastDotIndex = className.lastIndexOf(PACKAGE_SEPARATOR_CHAR);
+
+            if (lastDotIndex != -1) {
+                try {
+                    return getClass(classLoader, className.substring(0, lastDotIndex) +
+                                    INNER_CLASS_SEPARATOR_CHAR + className.substring(lastDotIndex + 1),
+                            initialize);
+                } catch (final ClassNotFoundException ex2) { // NOPMD
+                    // ignore exception
+                }
+            }
+
+            throw ex;
+        }
+    }
+
+    private static String toCanonicalName(String className) {
+        className = deleteWhitespace(className);
+        AssertUtil.notNull(className, "className must not be null.");
+        if (className.endsWith("[]")) {
+            final StringBuilder classNameBuffer = new StringBuilder();
+            while (className.endsWith("[]")) {
+                className = className.substring(0, className.length() - 2);
+                classNameBuffer.append("[");
+            }
+            final String abbreviation = abbreviationMap.get(className);
+            if (abbreviation != null) {
+                classNameBuffer.append(abbreviation);
+            } else {
+                classNameBuffer.append("L").append(className).append(";");
+            }
+            className = classNameBuffer.toString();
+        }
+        return className;
+    }
+
+    public static String deleteWhitespace(final String str) {
+        if (StringUtil.isEmpty(str)) {
+            return str;
+        }
+        final int sz = str.length();
+        final char[] chs = new char[sz];
+        int count = 0;
+        for (int i = 0; i < sz; i++) {
+            if (!Character.isWhitespace(str.charAt(i))) {
+                chs[count++] = str.charAt(i);
+            }
+        }
+        if (count == sz) {
+            return str;
+        }
+        return new String(chs, 0, count);
+    }
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it
Sentinel's users can define the Fallback rule, load manually or by data source, when a block happened, return the customize Fallback data to the resource caller.
fallback string usually is a JSON string, If you want to return an Object when blocked(such as Dubbo RPC fallback), you can define your class Reference of this JSON string and serialize it by any serialize framework such as Fastjson/Gson/Jackson.


### Does this pull request fix one issue?

Fixes: https://github.com/alibaba/Sentinel/issues/2074

### Describe how you did it
The same as the flow rule

### Describe how to verify it
Test unit

### Special notes for reviews
Commit Dubbo and HTTP Web MVC adapter as an example
