### PR TITLE
More resources can be added.Adjust the resource limit by csp.sentinel.context.max.size

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/config/SentinelConfig.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/config/SentinelConfig.java
@@ -61,6 +61,7 @@ public final class SentinelConfig {
     public static final String STATISTIC_MAX_RT = "csp.sentinel.statistic.max.rt";
     public static final String SPI_CLASSLOADER = "csp.sentinel.spi.classloader";
     public static final String METRIC_FLUSH_INTERVAL = "csp.sentinel.metric.flush.interval";
+    public static final String MAX_CONTEXT_NAME_SIZE = "csp.sentinel.context.max.size";
 
     public static final String DEFAULT_CHARSET = "UTF-8";
     public static final long DEFAULT_SINGLE_METRIC_FILE_SIZE = 1024 * 1024 * 50;
@@ -68,6 +69,9 @@ public final class SentinelConfig {
     public static final int DEFAULT_COLD_FACTOR = 3;
     public static final int DEFAULT_STATISTIC_MAX_RT = 5000;
     public static final long DEFAULT_METRIC_FLUSH_INTERVAL = 1L;
+    public static final int DEFAULT_MAX_CONTEXT_NAME_SIZE = 2000;
+
+    private static int maxContextNameSize = DEFAULT_MAX_CONTEXT_NAME_SIZE;
 
     static {
         try {
@@ -75,6 +79,7 @@ public final class SentinelConfig {
             loadProps();
             resolveAppName();
             resolveAppType();
+            resolveMaxContextNameSize();
             RecordLog.info("[SentinelConfig] Application type resolved: {}", appType);
         } catch (Throwable ex) {
             RecordLog.warn("[SentinelConfig] Failed to initialize", ex);
@@ -98,6 +103,21 @@ public final class SentinelConfig {
         }
     }
 
+    private static void resolveMaxContextNameSize() {
+        try {
+            String size = getConfig(MAX_CONTEXT_NAME_SIZE);
+            if (size == null) {
+                return;
+            }
+            maxContextNameSize = Integer.parseInt(size);
+            if (maxContextNameSize < 0) {
+                maxContextNameSize = DEFAULT_MAX_CONTEXT_NAME_SIZE;
+            }
+        } catch (Exception ex) {
+            maxContextNameSize = DEFAULT_MAX_CONTEXT_NAME_SIZE;
+        }
+    }
+
     private static void initialize() {
         // Init default properties.
         setConfig(CHARSET, DEFAULT_CHARSET);
@@ -106,6 +126,7 @@ public final class SentinelConfig {
         setConfig(COLD_FACTOR, String.valueOf(DEFAULT_COLD_FACTOR));
         setConfig(STATISTIC_MAX_RT, String.valueOf(DEFAULT_STATISTIC_MAX_RT));
         setConfig(METRIC_FLUSH_INTERVAL, String.valueOf(DEFAULT_METRIC_FLUSH_INTERVAL));
+        setConfig(MAX_CONTEXT_NAME_SIZE, String.valueOf(DEFAULT_MAX_CONTEXT_NAME_SIZE));
     }
 
     private static void loadProps() {
@@ -163,10 +184,15 @@ public final class SentinelConfig {
     public static String charset() {
         return props.get(CHARSET);
     }
-    
+
+    public static int getMaxContextNameSize() {
+        return maxContextNameSize;
+    }
+
     /**
      * Get the metric log flush interval in second
-     * @return  the metric log flush interval in second
+     *
+     * @return the metric log flush interval in second
      * @since 1.8.1
      */
     public static long metricLogFlushIntervalSec() {

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/context/NullContext.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/context/NullContext.java
@@ -15,10 +15,10 @@
  */
 package com.alibaba.csp.sentinel.context;
 
-import com.alibaba.csp.sentinel.Constants;
+import com.alibaba.csp.sentinel.config.SentinelConfig;
 
 /**
- * If total {@link Context} exceed {@link Constants#MAX_CONTEXT_NAME_SIZE}, a
+ * If total {@link Context} exceed {@link SentinelConfig#getMaxContextNameSize()}, a
  * {@link NullContext} will get when invoke {@link ContextUtil}.enter(), means
  * no rules checking will do.
  *

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/CtSphTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/CtSphTest.java
@@ -1,24 +1,17 @@
 package com.alibaba.csp.sentinel;
 
+import com.alibaba.csp.sentinel.config.SentinelConfig;
 import com.alibaba.csp.sentinel.context.Context;
 import com.alibaba.csp.sentinel.context.ContextTestUtil;
 import com.alibaba.csp.sentinel.context.ContextUtil;
 import com.alibaba.csp.sentinel.node.DefaultNode;
-import com.alibaba.csp.sentinel.slotchain.AbstractLinkedProcessorSlot;
-import com.alibaba.csp.sentinel.slotchain.DefaultProcessorSlotChain;
-import com.alibaba.csp.sentinel.slotchain.ProcessorSlot;
-import com.alibaba.csp.sentinel.slotchain.ProcessorSlotChain;
-import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
-import com.alibaba.csp.sentinel.slotchain.SlotChainProvider;
-import com.alibaba.csp.sentinel.slotchain.StringResourceWrapper;
+import com.alibaba.csp.sentinel.slotchain.*;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
 
 /**
  * Test cases for Sentinel internal {@link CtSph}.
@@ -53,12 +46,6 @@ public class CtSphTest {
             }
             ContextUtil.exit();
         }
-    }
-
-    @Test
-    public void testCustomContextSyncEntryWithFullContextSize() {
-        String resourceName = "testCustomContextSyncEntryWithFullContextSize";
-        testCustomContextEntryWithFullContextSize(resourceName, false);
     }
 
     @Test
@@ -270,7 +257,7 @@ public class CtSphTest {
     }
 
     private void fillFullContext() {
-        for (int i = 0; i < Constants.MAX_CONTEXT_NAME_SIZE; i++) {
+        for (int i = 0; i < SentinelConfig.getMaxContextNameSize(); i++) {
             ContextUtil.enter("test-context-" + i);
             ContextUtil.exit();
         }


### PR DESCRIPTION

### Describe what this PR does / why we need it

当资源数大于2000时限流不可用

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixed #2108

### Describe how you did it

1. 当资源数目大于限制数量时，清理空闲资源
2. 提供csp.sentinel.context.max.size用于资源数量上线

### Describe how to verify it

编写相关测试

### Special notes for reviews

@sczyh30