### PR TITLE
Changed exception check by JUnit API usage

### DIFF
--- a/sentinel-adapter/sentinel-quarkus-adapter/sentinel-annotation-quarkus-adapter-deployment/src/test/java/com/alibaba/csp/sentinel/adapter/quarkus/annotation/deployment/SentinelAnnotationQuarkusAdapterTest.java
+++ b/sentinel-adapter/sentinel-quarkus-adapter/sentinel-annotation-quarkus-adapter-deployment/src/test/java/com/alibaba/csp/sentinel/adapter/quarkus/annotation/deployment/SentinelAnnotationQuarkusAdapterTest.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author sea
@@ -92,7 +93,7 @@ public class SentinelAnnotationQuarkusAdapterTest {
                 new FlowRule(resourceName).setCount(0)
         ));
 
-        Assertions.assertThrows(ArcUndeclaredThrowableException.class, () -> {
+        assertThrows(ArcUndeclaredThrowableException.class, () -> {
             fooService.baz("Sentinel");
         });
     }
@@ -104,13 +105,10 @@ public class SentinelAnnotationQuarkusAdapterTest {
         ClusterNode cn = ClusterBuilderSlot.getClusterNode(resourceName);
         assertThat(cn).isNotNull();
         assertThat(cn.passQps()).isPositive();
-
-        try {
+        assertThrows(IllegalMonitorStateException.class, () -> {
             fooService.baz("fail");
-            fail("should not reach here");
-        } catch (IllegalMonitorStateException ex) {
-            assertThat(cn.exceptionQps()).isZero();
-        }
+        });
+        assertThat(cn.exceptionQps()).isZero();
     }
 
     @Test


### PR DESCRIPTION
Problem:
The Exception Handling test smell occurs when the test outcome is manually determined through pass or fail method calls, dependent on the production method throwing an exception generally inside a try/catch block. This refactoring proposal aims to make the exception catching a responsibility of the test framework which is already provided by its API. Also, without using try/catch blocks, tests can be more straightforward and possibly more comprehensible and maintainable.

Solution:
We propose using JUnit's exception handling to automatically pass/fail the test instead of writing custom exception handling code. In this particular case, we added the possibly throwable object to test method signature and removed the redundant fail method call and message.

**Result:**
_Before:_
`try {
            fooService.baz("fail");
            fail("should not reach here");
        } catch (IllegalMonitorStateException ex) {
            assertThat(cn.exceptionQps()).isZero();
        }`

_After:_
`assertThrows(IllegalMonitorStateException.class, () -> {
            fooService.baz("fail");
        });
        assertThat(cn.exceptionQps()).isZero();`