### PR TITLE
Improve degradation mechanism of RT-based circuit breaking

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/context/ContextUtil.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/context/ContextUtil.java
@@ -252,7 +252,7 @@ public class ContextUtil {
      * @return old context
      * @since 0.2.0
      */
-    static Context replaceContext(Context newContext) {
+    public static Context replaceContext(Context newContext) {
         Context backupContext = contextHolder.get();
         if (newContext == null) {
             contextHolder.remove();

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ResponseTimeCircuitBreaker.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ResponseTimeCircuitBreaker.java
@@ -15,7 +15,10 @@
  */
 package com.alibaba.csp.sentinel.slots.block.degrade.circuitbreaker;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
 
 import com.alibaba.csp.sentinel.Entry;
@@ -39,33 +42,98 @@ public class ResponseTimeCircuitBreaker extends AbstractCircuitBreaker {
     private final double maxSlowRequestRatio;
     private final int minRequestAmount;
 
-    private final LeapArray<SlowRequestCounter> slidingCounter;
+    private final SlowRequestLeapArray slidingCounter;
 
     public ResponseTimeCircuitBreaker(DegradeRule rule) {
-        this(rule, new SlowRequestLeapArray(1, rule.getStatIntervalMs()));
-    }
-
-    ResponseTimeCircuitBreaker(DegradeRule rule, LeapArray<SlowRequestCounter> stat) {
         super(rule);
         AssertUtil.isTrue(rule.getGrade() == RuleConstant.DEGRADE_GRADE_RT, "rule metric type should be RT");
-        AssertUtil.notNull(stat, "stat cannot be null");
         this.maxAllowedRt = Math.round(rule.getCount());
         this.maxSlowRequestRatio = rule.getSlowRatioThreshold();
         this.minRequestAmount = rule.getMinRequestAmount();
-        this.slidingCounter = stat;
+        /*
+         * Init slidingCounter based on the value of statIntervalMs and maxAllowedRt
+         * 1. If maxAllowedRt is greater than or equal to statIntervalMs,
+         *    then sampleCnt = (maxAllowedRt / statIntervalMs()) + 1
+         * 2. If maxAllowedRt is lesser than or equal to half of statIntervalMs, then sampleCnt = 1
+         * 3. Else sampleCnt = 1
+         * In all the above cases, the windowLengthInMs of slidingCounter is equal to statIntervalMs,
+         * and intervalInMs is just happen to greater than maxAllowedRt.
+         */
+        long sampleCntLong = maxAllowedRt / rule.getStatIntervalMs();
+        AssertUtil.isTrue((int) sampleCntLong == sampleCntLong, "count of the max allowed rt is too large");
+        if (sampleCntLong == 0L) {
+            long mutiple = rule.getStatIntervalMs() / maxAllowedRt;
+            if (mutiple >= 2L) {
+                this.slidingCounter = new SlowRequestLeapArray(1, rule.getStatIntervalMs());
+            } else {
+                this.slidingCounter = new SlowRequestLeapArray(2, 2 * rule.getStatIntervalMs());
+            }
+        } else {
+            int sampleCnt = (int) sampleCntLong + 1;
+            int intervalInMs = sampleCnt * rule.getStatIntervalMs();
+            this.slidingCounter = new SlowRequestLeapArray(sampleCnt, intervalInMs);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @implSpec
+     * This implementation will try to check previous deprecated buckets when the state equal to {@code State.CLOSED}.
+     */
+    @Override
+    public boolean tryPass(Context context) {
+        boolean superTryPass = super.tryPass(context);
+        if (!superTryPass) {
+            return superTryPass;
+        }
+        long createTime = context.getCurEntry().getCreateTimestamp();
+        SlowRequestCounter curCounter = slidingCounter.currentWindow(createTime).value();
+        long curWindowTime = createTime - createTime % slidingCounter.getWindowLengthInMs();
+        // Just check prev inflight request once.
+        if (currentState.get() != State.HALF_OPEN
+                && curCounter.getStatus() != SlowRequestCounter.CHECKED_BY_ENTRY
+                && curCounter.casOnlyStatus(curWindowTime, SlowRequestCounter.UNCHECKED, SlowRequestCounter.CHECKED_BY_ENTRY)) {
+            long prevTotalCount = curCounter.getPrevTotalCount();
+            if (prevTotalCount >= minRequestAmount && openIfNecessary(prevTotalCount, curCounter.getPrevSlowCount())) {
+                return false;
+            }
+            // Check inflight request in deprecated buckets.
+            List<SlowRequestCounter> deprecatedCounterList = slidingCounter.listAllDeprecated(curWindowTime);
+            for (SlowRequestCounter prevCounter : deprecatedCounterList) {
+                long prevWindowTime = prevCounter.getTimestamp();
+                if (curWindowTime - prevWindowTime < slidingCounter.getIntervalInMs()
+                        || !prevCounter.casOnlyStatus(prevWindowTime, SlowRequestCounter.CHECKED_BY_ENTRY,
+                        SlowRequestCounter.CHECKED_BY_SLOW)) {
+                    break;
+                }
+                prevTotalCount = prevCounter.getTotalCount();
+                if (prevTotalCount >= minRequestAmount && openIfNecessary(prevTotalCount, prevCounter.getInflightCount())) {
+                    return false;
+                }
+            }
+        }
+        curCounter.slowCount.add(1L);
+        curCounter.inflightCount.add(1L);
+        curCounter.totalCount.add(1L);
+        return true;
     }
 
     @Override
     public void resetStat() {
-        // Reset current bucket (bucket count = 1).
-        slidingCounter.currentWindow().value().reset();
+        // Reset all bucket completely.
+        slidingCounter.resetCompletely();
     }
 
     @Override
     public void onRequestComplete(Context context) {
-        SlowRequestCounter counter = slidingCounter.currentWindow().value();
         Entry entry = context.getCurEntry();
         if (entry == null) {
+            return;
+        }
+        SlowRequestCounter entryCounter = slidingCounter.getWindowValue(entry.getCreateTimestamp());
+        // the original bucket is deprecated, it had been checked by successor.
+        if (entryCounter == null) {
             return;
         }
         long completeTime = entry.getCompleteTimestamp();
@@ -73,19 +141,38 @@ public class ResponseTimeCircuitBreaker extends AbstractCircuitBreaker {
             completeTime = TimeUtil.currentTimeMillis();
         }
         long rt = completeTime - entry.getCreateTimestamp();
-        if (rt > maxAllowedRt) {
-            counter.slowCount.add(1);
+        // decrement the inflight count and slow count optionally.
+        entryCounter.inflightCount.add(-1);
+        if (rt <= maxAllowedRt) {
+            entryCounter.slowCount.add(-1);
         }
-        counter.totalCount.add(1);
-
-        handleStateChangeWhenThresholdExceeded(rt);
+        handleStateChangeWhenThresholdExceeded(rt, entry, entryCounter);
     }
 
-    private void handleStateChangeWhenThresholdExceeded(long rt) {
+    /**
+     * calculate and transfer state to open.
+     *
+     * @return whether transfer to open.
+     */
+    private boolean openIfNecessary(long totalCount, long slowCount) {
+        double currentRatio = slowCount * 1.0d / totalCount;
+        if (currentRatio > maxSlowRequestRatio) {
+            transformToOpen(currentRatio);
+            return true;
+        }
+        if (Double.compare(currentRatio, maxSlowRequestRatio) == 0 &&
+                Double.compare(maxSlowRequestRatio, SLOW_REQUEST_RATIO_MAX_VALUE) == 0) {
+            transformToOpen(currentRatio);
+            return true;
+        }
+        return false;
+    }
+
+    private void handleStateChangeWhenThresholdExceeded(long rt, Entry entry, SlowRequestCounter curCounter) {
         if (currentState.get() == State.OPEN) {
             return;
         }
-        
+
         if (currentState.get() == State.HALF_OPEN) {
             // In detecting request
             // TODO: improve logic for half-open recovery
@@ -97,55 +184,150 @@ public class ResponseTimeCircuitBreaker extends AbstractCircuitBreaker {
             return;
         }
 
-        List<SlowRequestCounter> counters = slidingCounter.values();
-        long slowCount = 0;
-        long totalCount = 0;
-        for (SlowRequestCounter counter : counters) {
-            slowCount += counter.slowCount.sum();
-            totalCount += counter.totalCount.sum();
-        }
-        if (totalCount < minRequestAmount) {
+        if (rt <= maxAllowedRt) {
             return;
         }
-        double currentRatio = slowCount * 1.0d / totalCount;
-        if (currentRatio > maxSlowRequestRatio) {
-            transformToOpen(currentRatio);
+        long curTotalCount = curCounter.getTotalCount();
+        if (curTotalCount < minRequestAmount || curCounter.getStatus() != SlowRequestCounter.CHECKED_BY_ENTRY) {
+            return;
         }
-        if (Double.compare(currentRatio, maxSlowRequestRatio) == 0 &&
-                Double.compare(maxSlowRequestRatio, SLOW_REQUEST_RATIO_MAX_VALUE) == 0) {
-            transformToOpen(currentRatio);
+        long curInflightCount = curCounter.getInflightCount();
+        long curSlowCount = curCounter.getSlowCount();
+        long leftTimeInWindow = slidingCounter.getWindowLengthInMs() -
+                entry.getCreateTimestamp() % slidingCounter.getWindowLengthInMs();
+        if (rt - maxAllowedRt > leftTimeInWindow || curInflightCount <= 0L) {
+            // We can ensure the slow count will not change.
+            long windowTime = curCounter.getTimestamp();
+            if (windowTime <= entry.getCreateTimestamp() &&
+                    curCounter.casOnlyStatus(windowTime, SlowRequestCounter.CHECKED_BY_ENTRY,
+                            SlowRequestCounter.CHECKED_BY_SLOW)) {
+                openIfNecessary(curTotalCount, curSlowCount);
+            }
+        } else {
+            double currentRatio = (curSlowCount - curInflightCount) * 1.0d / curTotalCount;
+            boolean isEqualToMaxRatio = Double.compare(currentRatio, maxSlowRequestRatio) == 0 &&
+                    Double.compare(maxSlowRequestRatio, SLOW_REQUEST_RATIO_MAX_VALUE) == 0;
+            if (currentRatio > maxSlowRequestRatio || isEqualToMaxRatio) {
+                long windowTime = curCounter.getTimestamp();
+                if (windowTime <= entry.getCreateTimestamp() &&
+                        curCounter.casOnlyStatus(windowTime, SlowRequestCounter.CHECKED_BY_ENTRY,
+                                SlowRequestCounter.CHECKED_BY_SLOW)) {
+                    transformToOpen(currentRatio);
+                }
+            }
         }
     }
 
     static class SlowRequestCounter {
         private LongAdder slowCount;
+        private LongAdder inflightCount;
         private LongAdder totalCount;
+        private LongAdder prevSlowCount;
+        private LongAdder prevTotalCount;
 
-        public SlowRequestCounter() {
+        static final int TIMESTAMP_SHIFT = 2;
+        static final int STATUS_MASK = (1 << TIMESTAMP_SHIFT) - 1;
+        /** status value to indicate previous count has not been checked */
+        static final int UNCHECKED = 0x00;
+        /** status value to indicate previous count had been checked by a successor entry */
+        static final int CHECKED_BY_ENTRY = 0x01;
+        /** status value to indicate current count had been checked by a slow exit or a skip entry */
+        static final int CHECKED_BY_SLOW = 0x02;
+        /*
+         * state is logically divided into two parts:
+         * The lower one representing counter status,
+         * and the upper the timestamp the counter belonged to.
+         *
+         * NOTE: We must ensure the timestamp of a counter equal to
+         * start time of the window that the counter belonged to.
+         */
+        private AtomicLong state;
+
+        public SlowRequestCounter(long timeMillis) {
             this.slowCount = new LongAdder();
+            this.inflightCount = new LongAdder();
             this.totalCount = new LongAdder();
+            this.prevSlowCount = new LongAdder();
+            this.prevTotalCount = new LongAdder();
+            this.state = new AtomicLong(timeMillis << 2 | UNCHECKED);
         }
 
-        public LongAdder getSlowCount() {
-            return slowCount;
+        public long getSlowCount() {
+            return slowCount.sum();
         }
 
-        public LongAdder getTotalCount() {
-            return totalCount;
+        public long getInflightCount() {
+            return inflightCount.sum();
         }
 
-        public SlowRequestCounter reset() {
+        public long getTotalCount() {
+            return totalCount.sum();
+        }
+
+        public long getPrevSlowCount() {
+            return prevSlowCount.sum();
+        }
+
+        public long getPrevTotalCount() {
+            return prevTotalCount.sum();
+        }
+
+        public int getStatus() {
+            return (int) state.get() & STATUS_MASK;
+        }
+
+        public long getTimestamp() {
+            return state.get() >>> TIMESTAMP_SHIFT;
+        }
+
+        static long toState(long timeMillis, int status) {
+            return timeMillis << TIMESTAMP_SHIFT | status;
+        }
+
+        public boolean casOnlyStatus(long oldTimeMillis, int oldStatus, int status) {
+            return state.compareAndSet(toState(oldTimeMillis, oldStatus), toState(oldTimeMillis, status));
+        }
+
+        public boolean casAllState(long oldTimeMillis, int oldStatus, long timeMillis, int status) {
+            return state.compareAndSet(toState(oldTimeMillis, oldStatus), toState(timeMillis, status));
+        }
+
+        /**
+         * Track the previous deprecated bucket.
+         */
+        public SlowRequestCounter reset(long oldTimeMillis, long timeMillis) {
+            prevSlowCount.reset();
+            prevSlowCount.add(slowCount.sumThenReset());
+            inflightCount.reset();
+            prevTotalCount.reset();
+            prevTotalCount.add(totalCount.sumThenReset());
+            casAllState(oldTimeMillis, CHECKED_BY_ENTRY, timeMillis, UNCHECKED);
+            return this;
+        }
+
+        /**
+         * Reset all counts and status.
+         */
+        public SlowRequestCounter resetCompletely(long timeMillis) {
+            prevSlowCount.reset();
+            prevTotalCount.reset();
+            inflightCount.reset();
             slowCount.reset();
             totalCount.reset();
+            state.set(toState(timeMillis, CHECKED_BY_ENTRY));
             return this;
         }
 
         @Override
         public String toString() {
             return "SlowRequestCounter{" +
-                "slowCount=" + slowCount +
-                ", totalCount=" + totalCount +
-                '}';
+                    "slowCount=" + slowCount +
+                    ", inflightCount=" + inflightCount +
+                    ", totalCount=" + totalCount +
+                    ", prevSlowCount=" + prevSlowCount +
+                    ", prevTotalCount=" + prevTotalCount +
+                    ", state=" + state +
+                    '}';
         }
     }
 
@@ -157,14 +339,75 @@ public class ResponseTimeCircuitBreaker extends AbstractCircuitBreaker {
 
         @Override
         public SlowRequestCounter newEmptyBucket(long timeMillis) {
-            return new SlowRequestCounter();
+            long windowStartTime = calculateWindowStart(timeMillis);
+            return new SlowRequestCounter(windowStartTime);
         }
 
         @Override
         protected WindowWrap<SlowRequestCounter> resetWindowTo(WindowWrap<SlowRequestCounter> w, long startTime) {
+            long oldStartTime = w.windowStart();
             w.resetTo(startTime);
-            w.value().reset();
+            w.value().reset(oldStartTime, startTime);
             return w;
+        }
+
+        public int getWindowLengthInMs() {
+            return windowLengthInMs;
+        }
+
+        /**
+         * Get all deprecated buckets for entire sliding window.
+         *
+         * @param timeMillis a valid timestamp in milliseconds
+         * @return deprecated bucket list for entire sliding window.
+         */
+        @SuppressWarnings("unchecked")
+        public List<SlowRequestCounter> listAllDeprecated(long timeMillis) {
+            int size = array.length();
+            if (size == 1) {
+                return Collections.EMPTY_LIST;
+            }
+            int idx = (int) ((timeMillis / windowLengthInMs) % size);
+            timeMillis -= timeMillis % windowLengthInMs;
+            idx = (--idx) < 0 ? idx + size : idx;
+            WindowWrap<SlowRequestCounter> prevWindow = array.get(idx);
+            if (prevWindow != null && !isWindowDeprecated(timeMillis, prevWindow)) {
+                // There exist a valid prev window, return empty list.
+                return Collections.EMPTY_LIST;
+            }
+            if (prevWindow == null && size == 2) {
+                return Collections.EMPTY_LIST;
+            }
+            List<SlowRequestCounter> counterList = new ArrayList<>(size - 1);
+            if (prevWindow != null) {
+                counterList.add(prevWindow.value());
+            }
+            for (int i = 0; i < size - 2; i++) {
+                idx = (--idx) < 0 ? idx + size : idx;
+                WindowWrap<SlowRequestCounter> windowWrap = array.get(i);
+                if (windowWrap == null || !isWindowDeprecated(timeMillis, windowWrap)) {
+                    continue;
+                }
+                counterList.add(windowWrap.value());
+            }
+            return counterList;
+        }
+
+        /**
+         * Reset all counts and status in all bucket, and reset window start time.
+         */
+        public void resetCompletely() {
+            int size = array.length();
+            long resetTimeMillis = 0L;
+            for (int i = 0; i < size; i++, resetTimeMillis += windowLengthInMs) {
+                WindowWrap<SlowRequestCounter> windowWrap = array.get(i);
+                if (windowWrap == null) {
+                    continue;
+                }
+                SlowRequestCounter counter = windowWrap.value();
+                counter.resetCompletely(resetTimeMillis);
+                windowWrap.resetTo(resetTimeMillis);
+            }
         }
     }
 }

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ResponseTimeCircuitBreakerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ResponseTimeCircuitBreakerTest.java
@@ -69,8 +69,8 @@ public class ResponseTimeCircuitBreakerTest extends AbstractTimeBasedTest {
     }
 
     /**
-     * If maxAllowedRT=5000, and a entry created at 980 exits at 6050,
-     * then we can judge that all inflight request can be treated as slow request.
+     * If maxAllowedRT=5000, and a entry created at 970 exits at 6050,
+     * then we can judge that all inflight requests can be treated as slow request.
      */
     @Test
     public void testDegradeByOneSlowRT() {
@@ -104,7 +104,7 @@ public class ResponseTimeCircuitBreakerTest extends AbstractTimeBasedTest {
         assertTrue(entryAndSleepFor(resource, 0));
         sleep(800);
         // Entry: 0 --- 800,810,820...990  Exited: 0
-        batchEntryEvenly(resource, 20, 10, entryList);
+        batchEntryPeriodically(resource, 20, 10, entryList);
         assertTrue(noOneBlocked(entryList));
         assertTrue(entryAndSleepFor(resource, 0));
 
@@ -118,14 +118,14 @@ public class ResponseTimeCircuitBreakerTest extends AbstractTimeBasedTest {
 
         sleep(850);
         assertTrue(entryAndSleepFor(resource, 0));
-        // Entry 810 slow exits at 5850, that`s timeout but will not trigger breaker.
+        // Entry created at 810 exits at 5850, that`s timeout but will not trigger breaker.
         safeExit(entryList.get(1));
         assertTrue(entryAndSleepFor(resource, 0));
-        // Entry 980 exits at 5850, that`s not timeout and will not trigger breaker.
+        // Entry created at 980 exits at 5850, that`s not timeout and will not trigger breaker.
         safeExit(entryList.get(18));
         assertTrue(entryAndSleepFor(resource, 0));
         sleep(200);
-        // Entry 970 slow exits at 6050, will trigger breaker.
+        // Entry created at 970 exits at 6050, will trigger breaker.
         safeExit(entryList.get(17));
         assertSame(prevStateRef.get(), State.CLOSED);
         assertSame(newStateRef.get(), State.OPEN);
@@ -138,11 +138,11 @@ public class ResponseTimeCircuitBreakerTest extends AbstractTimeBasedTest {
 
     /**
      * If maxAllowedRT=5000, and entries created at range [0-1000) not exit at 6000,
-     * then we can judge that all entries can be treated as slow request.
+     * then we can judge that all inflight requests can be treated as slow request.
      */
     @Test
     public void testDegradeBySuccessorEntry() {
-        String resource = "testDegradeByEntry";
+        String resource = "testDegradeBySuccessorEntry";
         DegradeRule rule = new DegradeRule(resource)
                 .setCount(5000)
                 .setGrade(RuleConstant.DEGRADE_GRADE_RT)
@@ -170,21 +170,22 @@ public class ResponseTimeCircuitBreakerTest extends AbstractTimeBasedTest {
          * then we can judge that all entries can be treated as slow request.
          */
         // Entry: 0,50,100...900,950
-        batchEntryEvenly(resource, 20, 50, entryList);
+        batchEntryPeriodically(resource, 20, 50, entryList);
         assertTrue(noOneBlocked(entryList));
 
-        // Entry: 0,50,100...900,950 --- 4000,4100..5400  Exited: 5000,5100..5400
+        // Entry: 0,50,100...900,950 --- 4000,4100...5400  Exited: 4000,4100...5400
         sleep(3000);
         List<Entry> anotherEntryList = new ArrayList<>(15);
-        batchEntryEvenly(resource, 15, 100, anotherEntryList);
+        batchEntryPeriodically(resource, 15, 100, anotherEntryList);
         assertTrue(noOneBlocked(entryList));
         batchExitImmediately(anotherEntryList);
 
         // Entry: 0,50,100...900,950 --- 4000,4100..5400 --- 5500,5550...6500
         List<Entry> mayBlockedEntryList = new ArrayList<>(20);
-        batchEntryEvenly(resource, 20, 50, mayBlockedEntryList);
+        batchEntryPeriodically(resource, 20, 50, mayBlockedEntryList);
         assertFalse(noOneBlocked(mayBlockedEntryList));
-        // Entry is null means blocked. Entry 5950 will not blocked, while entry 6000 will blocked.
+        // Entry is null means blocked. Entry created at 5950 will not blocked
+        // while entry created at 6000 will blocked.
         assertNotNull(mayBlockedEntryList.get(9));
         assertNull(mayBlockedEntryList.get(10));
         assertSame(prevStateRef.get(), State.CLOSED);
@@ -198,11 +199,11 @@ public class ResponseTimeCircuitBreakerTest extends AbstractTimeBasedTest {
 
     /**
      * If maxAllowedRT=5000, and entries created at range [0-1000) not exit at 8000,
-     * then we can judge that all entries can be treated as slow request.
+     * then we can judge that all inflight requests can be treated as slow request.
      */
     @Test
     public void testDegradeBySkipEntry() {
-        String resource = "testDegradeByEntry";
+        String resource = "testDegradeBySkipEntry";
         DegradeRule rule = new DegradeRule(resource)
                 .setCount(5000)
                 .setGrade(RuleConstant.DEGRADE_GRADE_RT)
@@ -230,14 +231,64 @@ public class ResponseTimeCircuitBreakerTest extends AbstractTimeBasedTest {
          * then we can judge that all entries can be treated as slow request.
          */
         // Entry: 0,50,100...900,950
-        batchEntryEvenly(resource, 20, 50, entryList);
+        batchEntryPeriodically(resource, 20, 50, entryList);
         assertTrue(noOneBlocked(entryList));
 
         sleep(7000);
+        // Entry created at 8000 will check previous buckets
         assertFalse(entryAndSleepFor(resource, 0));
         assertSame(prevStateRef.get(), State.CLOSED);
         assertSame(newStateRef.get(), State.OPEN);
         assertEquals(0, Double.compare(snapshotValueRef.get(), 1.0d));
+
+        EventObserverRegistry.getInstance().removeStateChangeObserver(resource);
+        batchExitImmediately(entryList);
+    }
+
+    /**
+     * then we can judge that all inflight requests can be treated as slow request.
+     */
+    @Test
+    public void testDegradeBySimplyReachRatio() {
+        String resource = "testDegradeBySimplyReachRatio";
+        DegradeRule rule = new DegradeRule(resource)
+                .setCount(50)
+                .setGrade(RuleConstant.DEGRADE_GRADE_RT)
+                .setMinRequestAmount(3)
+                .setSlowRatioThreshold(0.5)
+                .setStatIntervalMs(1000)
+                .setTimeWindow(1);
+
+        AtomicReference<State> prevStateRef = new AtomicReference<>();
+        AtomicReference<State> newStateRef = new AtomicReference<>();
+        AtomicReference<Double> snapshotValueRef = new AtomicReference<>();
+        EventObserverRegistry.getInstance().addStateChangeObserver(resource, new CircuitBreakerStateChangeObserver() {
+            @Override
+            public void onStateChange(State prevState, State newState, DegradeRule rule, Double snapshotValue) {
+                prevStateRef.set(prevState);
+                newStateRef.set(newState);
+                snapshotValueRef.set(snapshotValue);
+            }
+        });
+        DegradeRuleManager.loadRules(Collections.singletonList(rule));
+
+        List<Entry> entryList = new ArrayList<>(20);
+        /*
+         * If maxAllowedRT=5000, and entries created at range [0-1000) not exit at 8000,
+         * then we can judge that all entries can be treated as slow request.
+         */
+        // Entry: 0,50,100...900,950
+        batchEntryPeriodically(resource, 20, 50, entryList);
+        assertTrue(noOneBlocked(entryList));
+
+        // Entry: 0,50,100...900,950  Exited: 0,50,100...450
+        batchExitImmediately(entryList.subList(0, 10));
+        assertNull(newStateRef.get());
+        // Entry created at 500 exits at 1000, slowRatio=11/20 which is bigger than maxSlowRequestRatio=0.5
+        safeExit(entryList.get(10));
+        assertSame(prevStateRef.get(), State.CLOSED);
+        assertSame(newStateRef.get(), State.OPEN);
+        assertEquals(0, Double.compare(snapshotValueRef.get(), 0.55d));
 
         EventObserverRegistry.getInstance().removeStateChangeObserver(resource);
         batchExitImmediately(entryList);

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ResponseTimeCircuitBreakerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ResponseTimeCircuitBreakerTest.java
@@ -1,8 +1,10 @@
 package com.alibaba.csp.sentinel.slots.block.degrade.circuitbreaker;
 
+import com.alibaba.csp.sentinel.Entry;
 import com.alibaba.csp.sentinel.slots.block.RuleConstant;
 import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRule;
 import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRuleManager;
+import com.alibaba.csp.sentinel.slots.block.degrade.circuitbreaker.CircuitBreaker.State;
 import com.alibaba.csp.sentinel.test.AbstractTimeBasedTest;
 import org.junit.After;
 import org.junit.Before;
@@ -10,8 +12,14 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -51,8 +59,187 @@ public class ResponseTimeCircuitBreakerTest extends AbstractTimeBasedTest {
         sleep(1000);
         assertFalse(entryAndSleepFor(resource,20));
         sleep(4000);
-
+        // HALF_OPEN to OPEN
         assertTrue(entryAndSleepFor(resource, 20));
+        assertFalse(entryAndSleepFor(resource, 20));
+        // HALF_OPEN to CLOSE
+        sleep(5000);
+        assertTrue(entryAndSleepFor(resource, 10));
+        assertTrue(entryAndSleepFor(resource, 10));
     }
 
+    /**
+     * If maxAllowedRT=5000, and a entry created at 980 exits at 6050,
+     * then we can judge that all inflight request can be treated as slow request.
+     */
+    @Test
+    public void testDegradeByOneSlowRT() {
+        String resource = "testDegradeByOneSlowRT";
+        DegradeRule rule = new DegradeRule(resource)
+                .setCount(5000)
+                .setGrade(RuleConstant.DEGRADE_GRADE_RT)
+                .setMinRequestAmount(3)
+                .setSlowRatioThreshold(0.5)
+                .setStatIntervalMs(1000)
+                .setTimeWindow(1);
+
+        AtomicReference<State> prevStateRef = new AtomicReference<>();
+        AtomicReference<State> newStateRef = new AtomicReference<>();
+        AtomicReference<Double> snapshotValueRef = new AtomicReference<>();
+        EventObserverRegistry.getInstance().addStateChangeObserver(resource, new CircuitBreakerStateChangeObserver() {
+            @Override
+            public void onStateChange(State prevState, State newState, DegradeRule rule, Double snapshotValue) {
+                prevStateRef.set(prevState);
+                newStateRef.set(newState);
+                snapshotValueRef.set(snapshotValue);
+            }
+        });
+        DegradeRuleManager.loadRules(Collections.singletonList(rule));
+
+        List<Entry> entryList = new ArrayList<>(20);
+        /*
+         * If maxAllowedRT=5000, and a entry created at 980 exits at 6050,
+         * then we can judge that all inflight request can be treated as slow request.
+         */
+        assertTrue(entryAndSleepFor(resource, 0));
+        sleep(800);
+        // Entry: 0 --- 800,810,820...990  Exited: 0
+        batchEntryEvenly(resource, 20, 10, entryList);
+        assertTrue(noOneBlocked(entryList));
+        assertTrue(entryAndSleepFor(resource, 0));
+
+        // Entry: 0 --- 800,810,820...990 2000,3000,4000  Exited: 0,800,990,2000,3000,4000
+        sleep(1000);
+        assertTrue(entryAndSleepFor(resource, 1000));
+        safeExit(entryList.get(0));
+        assertTrue(entryAndSleepFor(resource, 1000));
+        safeExit(entryList.get(19));
+        assertTrue(entryAndSleepFor(resource, 1000));
+
+        sleep(850);
+        assertTrue(entryAndSleepFor(resource, 0));
+        // Entry 810 slow exits at 5850, that`s timeout but will not trigger breaker.
+        safeExit(entryList.get(1));
+        assertTrue(entryAndSleepFor(resource, 0));
+        // Entry 980 exits at 5850, that`s not timeout and will not trigger breaker.
+        safeExit(entryList.get(18));
+        assertTrue(entryAndSleepFor(resource, 0));
+        sleep(200);
+        // Entry 970 slow exits at 6050, will trigger breaker.
+        safeExit(entryList.get(17));
+        assertSame(prevStateRef.get(), State.CLOSED);
+        assertSame(newStateRef.get(), State.OPEN);
+        // Entry 0,800,900,980 are not slow RT
+        assertEquals(0, Double.compare(snapshotValueRef.get(), 1.0d * 17 / 21));
+
+        EventObserverRegistry.getInstance().removeStateChangeObserver(resource);
+        batchExitImmediately(entryList);
+    }
+
+    /**
+     * If maxAllowedRT=5000, and entries created at range [0-1000) not exit at 6000,
+     * then we can judge that all entries can be treated as slow request.
+     */
+    @Test
+    public void testDegradeBySuccessorEntry() {
+        String resource = "testDegradeByEntry";
+        DegradeRule rule = new DegradeRule(resource)
+                .setCount(5000)
+                .setGrade(RuleConstant.DEGRADE_GRADE_RT)
+                .setMinRequestAmount(3)
+                .setSlowRatioThreshold(0.5)
+                .setStatIntervalMs(1000)
+                .setTimeWindow(1);
+
+        AtomicReference<State> prevStateRef = new AtomicReference<>();
+        AtomicReference<State> newStateRef = new AtomicReference<>();
+        AtomicReference<Double> snapshotValueRef = new AtomicReference<>();
+        EventObserverRegistry.getInstance().addStateChangeObserver(resource, new CircuitBreakerStateChangeObserver() {
+            @Override
+            public void onStateChange(State prevState, State newState, DegradeRule rule, Double snapshotValue) {
+                prevStateRef.set(prevState);
+                newStateRef.set(newState);
+                snapshotValueRef.set(snapshotValue);
+            }
+        });
+        DegradeRuleManager.loadRules(Collections.singletonList(rule));
+
+        List<Entry> entryList = new ArrayList<>(20);
+        /*
+         * If maxAllowedRT=5000, and entries created at range [0-1000) not exit at 6000,
+         * then we can judge that all entries can be treated as slow request.
+         */
+        // Entry: 0,50,100...900,950
+        batchEntryEvenly(resource, 20, 50, entryList);
+        assertTrue(noOneBlocked(entryList));
+
+        // Entry: 0,50,100...900,950 --- 4000,4100..5400  Exited: 5000,5100..5400
+        sleep(3000);
+        List<Entry> anotherEntryList = new ArrayList<>(15);
+        batchEntryEvenly(resource, 15, 100, anotherEntryList);
+        assertTrue(noOneBlocked(entryList));
+        batchExitImmediately(anotherEntryList);
+
+        // Entry: 0,50,100...900,950 --- 4000,4100..5400 --- 5500,5550...6500
+        List<Entry> mayBlockedEntryList = new ArrayList<>(20);
+        batchEntryEvenly(resource, 20, 50, mayBlockedEntryList);
+        assertFalse(noOneBlocked(mayBlockedEntryList));
+        // Entry is null means blocked. Entry 5950 will not blocked, while entry 6000 will blocked.
+        assertNotNull(mayBlockedEntryList.get(9));
+        assertNull(mayBlockedEntryList.get(10));
+        assertSame(prevStateRef.get(), State.CLOSED);
+        assertSame(newStateRef.get(), State.OPEN);
+        assertEquals(0, Double.compare(snapshotValueRef.get(), 1.0d));
+
+        EventObserverRegistry.getInstance().removeStateChangeObserver(resource);
+        batchExitImmediately(entryList);
+        batchExitImmediately(mayBlockedEntryList);
+    }
+
+    /**
+     * If maxAllowedRT=5000, and entries created at range [0-1000) not exit at 8000,
+     * then we can judge that all entries can be treated as slow request.
+     */
+    @Test
+    public void testDegradeBySkipEntry() {
+        String resource = "testDegradeByEntry";
+        DegradeRule rule = new DegradeRule(resource)
+                .setCount(5000)
+                .setGrade(RuleConstant.DEGRADE_GRADE_RT)
+                .setMinRequestAmount(3)
+                .setSlowRatioThreshold(0.5)
+                .setStatIntervalMs(1000)
+                .setTimeWindow(1);
+
+        AtomicReference<State> prevStateRef = new AtomicReference<>();
+        AtomicReference<State> newStateRef = new AtomicReference<>();
+        AtomicReference<Double> snapshotValueRef = new AtomicReference<>();
+        EventObserverRegistry.getInstance().addStateChangeObserver(resource, new CircuitBreakerStateChangeObserver() {
+            @Override
+            public void onStateChange(State prevState, State newState, DegradeRule rule, Double snapshotValue) {
+                prevStateRef.set(prevState);
+                newStateRef.set(newState);
+                snapshotValueRef.set(snapshotValue);
+            }
+        });
+        DegradeRuleManager.loadRules(Collections.singletonList(rule));
+
+        List<Entry> entryList = new ArrayList<>(20);
+        /*
+         * If maxAllowedRT=5000, and entries created at range [0-1000) not exit at 8000,
+         * then we can judge that all entries can be treated as slow request.
+         */
+        // Entry: 0,50,100...900,950
+        batchEntryEvenly(resource, 20, 50, entryList);
+        assertTrue(noOneBlocked(entryList));
+
+        sleep(7000);
+        assertFalse(entryAndSleepFor(resource, 0));
+        assertSame(prevStateRef.get(), State.CLOSED);
+        assertSame(newStateRef.get(), State.OPEN);
+        assertEquals(0, Double.compare(snapshotValueRef.get(), 1.0d));
+
+        EventObserverRegistry.getInstance().removeStateChangeObserver(resource);
+        batchExitImmediately(entryList);
+    }
 }

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/test/AbstractTimeBasedTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/test/AbstractTimeBasedTest.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.csp.sentinel.test;
 
+import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 import org.junit.runner.RunWith;
@@ -25,6 +26,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import com.alibaba.csp.sentinel.Entry;
 import com.alibaba.csp.sentinel.SphU;
 import com.alibaba.csp.sentinel.Tracer;
+import com.alibaba.csp.sentinel.context.Context;
+import com.alibaba.csp.sentinel.context.ContextUtil;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
 import com.alibaba.csp.sentinel.util.TimeUtil;
 
@@ -92,6 +95,52 @@ public abstract class AbstractTimeBasedTest {
         } finally {
             if (entry != null) {
                 entry.exit();
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Init entries one by one with a fix interval.
+     *
+     * @param entryList filled with entries, set null if blocked.
+     */
+    protected final void batchEntryEvenly(String resource, int size, int intervalMs, List<Entry> entryList) {
+        for (int i = 0; i < size; i++) {
+            Entry entry = null;
+            try {
+                entry = SphU.entry(resource);
+            } catch (BlockException ex) {
+                // do nothing
+            } catch (Exception ex) {
+                Tracer.traceEntry(ex, entry);
+            }
+            entryList.add(entry);
+            sleep(intervalMs);
+        }
+    }
+
+    protected final void batchExitImmediately(List<Entry> entryList) {
+        for (Entry entry : entryList) {
+            if (entry != null) {
+                safeExit(entry);
+            }
+        }
+    }
+
+    static protected final void safeExit(Entry entryToExit) {
+        Context context = ContextUtil.getContext();
+        Entry curEntry = context.getCurEntry();
+        context.setCurEntry(entryToExit);
+        entryToExit.exit();
+        context.setCurEntry(curEntry);
+        ContextUtil.replaceContext(context);
+    }
+
+    static protected final boolean noOneBlocked(List<Entry> entryList) {
+        for (Entry entry : entryList) {
+            if (entry == null) {
+                return false;
             }
         }
         return true;

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/test/AbstractTimeBasedTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/test/AbstractTimeBasedTest.java
@@ -105,7 +105,7 @@ public abstract class AbstractTimeBasedTest {
      *
      * @param entryList filled with entries, set null if blocked.
      */
-    protected final void batchEntryEvenly(String resource, int size, int intervalMs, List<Entry> entryList) {
+    protected final void batchEntryPeriodically(String resource, int size, int intervalMs, List<Entry> entryList) {
         for (int i = 0; i < size; i++) {
             Entry entry = null;
             try {


### PR DESCRIPTION

### Describe what this PR does / why we need it

Improve degradation mechanism of RT-based circuit breaking, support more timely downgrades in some bad situations.

### Does this pull request fix one issue?

Fixes #1405

### Describe how you did it

1. Construct `SlowRequestLeapArray` , ensure `windowLengthInMs` is fixed to `statIntervalMs` and `intervalInMs` is just happen to greater than `maxAllowedRt`.
2. `SlowRequestCounter` in `SlowRequestLeapArray` should count inflight entries, increment counts when entries try pass and decrement counts when entries exit. Each `SlowRequestCounter` should track the predecessor deprecated bucket when it reset.
3. Get current window using create timestamp when entries try pass, then check previous `SlowRequestCounter`s in the deprecated buckets just once.
4. Get current window using create timestamp when entries exit, if that window is not deprecated and rt > `maxAllowedRt`, then check current `SlowRequestCounter`.

**Status of the `SlowRequestCounter`**

- UNCHECKED：indicate previous counts has not been checked. **status after new and reset**
- CHECKED_BY_ENTRY：indicate previous count has been checked by a successor entry.
- CHECKED_BY_SLOW：indicate current count has been checked by slowly exit or a no successor entry.

Normal status flow : UNCHECKED -> CHECKED_BY_ENTRY -> UNCHECKED -> CHECKED_BY_ENTRY
Slow RT status flow：UNCHECKED -> CHECKED_BY_ENTRY -> CHECKED_BY_SLOW

### Describe how to verify it

Run the test cases.

### Special notes for reviews

Should consider is it works well at some concurrency scenarios not considered.