### PR TITLE
feat(sentinel-transport): user can custom heartbeat message

### DIFF
--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/heartbeat/HeartbeatMessageProvider.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/heartbeat/HeartbeatMessageProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.heartbeat;
+
+import com.alibaba.csp.sentinel.log.RecordLog;
+import com.alibaba.csp.sentinel.spi.SpiLoader;
+import com.alibaba.csp.sentinel.transport.message.HeartbeatMessage;
+
+/**
+ * @author wxq
+ * @since 1.8.2
+ */
+public final class HeartbeatMessageProvider {
+
+    private static final HeartbeatMessage heartbeatMessage = resolveInstance();
+
+    private HeartbeatMessageProvider() {
+    }
+
+    private static HeartbeatMessage resolveInstance() {
+        HeartbeatMessage heartbeatMessage = SpiLoader.of(HeartbeatMessage.class).loadHighestPriorityInstance();
+        if (heartbeatMessage == null) {
+            RecordLog.warn("[HeartbeatMessageProvider] WARN: No existing HeartbeatMessage found");
+        } else {
+            RecordLog.info("[HeartbeatMessageProvider] HeartbeatMessage activated: {}", heartbeatMessage.getClass()
+                    .getCanonicalName());
+        }
+        return heartbeatMessage;
+    }
+
+    /**
+     * @return resolved {@link HeartbeatMessage}.
+     */
+    public static HeartbeatMessage getHeartbeatMessage() {
+        return heartbeatMessage;
+    }
+
+}

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/AbstractHeartbeatMessage.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/AbstractHeartbeatMessage.java
@@ -25,58 +25,59 @@ import static com.alibaba.csp.sentinel.transport.message.HeartbeatMessageKeyCons
 import static com.alibaba.csp.sentinel.transport.message.HeartbeatMessageSuppliers.*;
 
 /**
- * If you want to custom {@link HeartbeatMessage}, recommend that inherit this abstract class.
+ * If you want to custom {@link HeartbeatMessage}, recommend that inherit this
+ * abstract class.
  *
  * @author wxq
  * @since 1.8.2
  */
 public abstract class AbstractHeartbeatMessage implements HeartbeatMessage {
 
-    private final Map<String, String> information = new HashMap<>();
+	private final Map<String, String> information = new HashMap<>();
 
-    /**
-     * wrapper {@link #information} to forbid user modify origin.
-     */
-    private final Map<String, String> unmodifiableInformation = Collections.unmodifiableMap(this.information);
-    
-    private final BiConsumer<String, Supplier<String>> informationUpdater = (key, valueSupplier) -> {
-    	String value = valueSupplier.get();
-    	this.information.put(key, value);
-    };
+	/**
+	 * wrapper {@link #information} to forbid user modify origin.
+	 */
+	private final Map<String, String> unmodifiableInformation = Collections.unmodifiableMap(this.information);
 
-    private final Map<String, Supplier<String>> dynamicInformationSuppliers = new HashMap<>();
+	private final BiConsumer<String, Supplier<String>> informationUpdater = (key, valueSupplier) -> {
+		String value = valueSupplier.get();
+		this.information.put(key, value);
+	};
 
-    public AbstractHeartbeatMessage() {
-        this.setInformation(PID, PID_SUPPLIER.get());
-        this.setInformation(APP_NAME, APP_NAME_SUPPLIER.get());
-        // application type (since 1.6.0).
-        this.setInformation(APP_TYPE, APP_TYPE_SUPPLIER.get());
-        // Version of Sentinel.
-        this.setInformation(SENTINEL_VERSION, SENTINEL_VERSION_SUPPLIER.get());
-        this.setInformation(HOST_NAME, HOST_NAME_SUPPLIER.get());
-        this.setInformation(HEARTBEAT_CLIENT_IP, HEARTBEAT_CLIENT_IP_SUPPLIER.get());
-        // sentinel client's port
-        this.setInformation(PORT, PORT_SUPPLIER.get());
-        
-        // Actually timestamp.
-        this.registerDynamicInformationSupplier(CURRENT_TIME_MILLIS, CURRENT_TIME_MILLIS_SUPPLIER);
-    }
+	private final Map<String, Supplier<String>> dynamicInformationSuppliers = new HashMap<>();
 
-    @Override
+	public AbstractHeartbeatMessage() {
+		this.setInformation(PID, PID_SUPPLIER.get());
+		this.setInformation(APP_NAME, APP_NAME_SUPPLIER.get());
+		// application type (since 1.6.0).
+		this.setInformation(APP_TYPE, APP_TYPE_SUPPLIER.get());
+		// Version of Sentinel.
+		this.setInformation(SENTINEL_VERSION, SENTINEL_VERSION_SUPPLIER.get());
+		this.setInformation(HOST_NAME, HOST_NAME_SUPPLIER.get());
+		this.setInformation(HEARTBEAT_CLIENT_IP, HEARTBEAT_CLIENT_IP_SUPPLIER.get());
+		// sentinel client's port
+		this.setInformation(PORT, PORT_SUPPLIER.get());
+
+		// Actually timestamp.
+		this.registerDynamicInformationSupplier(CURRENT_TIME_MILLIS, CURRENT_TIME_MILLIS_SUPPLIER);
+	}
+
+	@Override
 	public void setInformation(String key, String value) {
 		this.information.put(key, value);
 	}
 
 	@Override
-    public void registerDynamicInformationSupplier(String key, Supplier<String> valueSupplier) {
-        this.dynamicInformationSuppliers.put(key, valueSupplier);
-        this.information.put(key, valueSupplier.get());
-    }
+	public void registerDynamicInformationSupplier(String key, Supplier<String> valueSupplier) {
+		this.dynamicInformationSuppliers.put(key, valueSupplier);
+		this.information.put(key, valueSupplier.get());
+	}
 
-    @Override
-    public Map<String, String> get() {
-    	this.dynamicInformationSuppliers.forEach(this.informationUpdater);
-        return this.unmodifiableInformation;
-    }
+	@Override
+	public Map<String, String> get() {
+		this.dynamicInformationSuppliers.forEach(this.informationUpdater);
+		return this.unmodifiableInformation;
+	}
 
 }

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/AbstractHeartbeatMessage.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/AbstractHeartbeatMessage.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.transport.message;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import static com.alibaba.csp.sentinel.transport.message.HeartbeatMessageKeyConstants.*;
+import static com.alibaba.csp.sentinel.transport.message.HeartbeatMessageSuppliers.*;
+
+/**
+ * If you want to custom {@link HeartbeatMessage}, recommend that inherit this abstract class,
+ * <p>
+ * and use {@link #registerStaticInformation(String, String)} or {@link #registerDynamicInformation(String, Supplier)} to add the information you want.
+ *
+ * @author wxq
+ * @since 1.8.2
+ */
+public abstract class AbstractHeartbeatMessage implements HeartbeatMessage {
+
+    private final Map<String, String> staticMessage = new ConcurrentHashMap<>();
+
+    private final Map<String, Supplier<String>> dynamicMessage = new ConcurrentHashMap<>();
+
+    public AbstractHeartbeatMessage() {
+        // static information
+        this.registerStaticInformation(PID, PID_SUPPLIER);
+        this.registerStaticInformation(APP_NAME, APP_NAME_SUPPLIER);
+        // application type (since 1.6.0).
+        this.registerStaticInformation(APP_TYPE, APP_TYPE_SUPPLIER);
+        // Version of Sentinel.
+        this.registerStaticInformation(SENTINEL_VERSION, SENTINEL_VERSION_SUPPLIER);
+        this.registerStaticInformation(HOST_NAME, HOST_NAME_SUPPLIER);
+        this.registerStaticInformation(HEARTBEAT_CLIENT_IP, HEARTBEAT_CLIENT_IP_SUPPLIER);
+
+        // dynamic information
+        // sentinel client's port
+        this.registerDynamicInformation(PORT, PORT_SUPPLIER);
+        // Actually timestamp.
+        this.registerDynamicInformation(CURRENT_TIME_MILLIS, CURRENT_TIME_MILLIS_SUPPLIER);
+    }
+
+    protected void registerStaticInformation(String key, String value) {
+        this.staticMessage.put(key, value);
+    }
+
+    protected void registerStaticInformation(String key, Supplier<String> valueSupplier) {
+        this.registerStaticInformation(key, valueSupplier.get());
+    }
+
+    /**
+     * value will be resolved every time when user use method {@link #get()}.
+     */
+    protected void registerDynamicInformation(String key, Supplier<String> valueSupplier) {
+        this.dynamicMessage.put(key, valueSupplier);
+    }
+
+    @Override
+    public Map<String, String> get() {
+        Map<String, String> message = new HashMap<>(this.staticMessage.size() + this.dynamicMessage.size());
+        message.putAll(this.staticMessage);
+
+        for (Map.Entry<String, Supplier<String>> entry : this.dynamicMessage.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue().get();
+            message.put(key, value);
+        }
+
+        return message;
+    }
+}

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/AbstractHeartbeatMessage.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/AbstractHeartbeatMessage.java
@@ -34,6 +34,11 @@ public abstract class AbstractHeartbeatMessage implements HeartbeatMessage {
 
     private final Map<String, String> information = new HashMap<>();
 
+    /**
+     * wrapper {@link #information} to forbid user modify origin.
+     */
+    private final Map<String, String> unmodifiableInformation = Collections.unmodifiableMap(this.information);
+
     private final Map<String, Supplier<String>> informationSuppliers = new ConcurrentHashMap<>();
 
     public AbstractHeartbeatMessage() {
@@ -81,7 +86,7 @@ public abstract class AbstractHeartbeatMessage implements HeartbeatMessage {
     public Map<String, String> get() {
         this.beforeGet();
         this.refresh(CURRENT_TIME_MILLIS);
-        return Collections.unmodifiableMap(this.information);
+        return this.unmodifiableInformation;
     }
 
 }

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/AbstractHeartbeatMessage.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/AbstractHeartbeatMessage.java
@@ -18,7 +18,6 @@ package com.alibaba.csp.sentinel.transport.message;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 import static com.alibaba.csp.sentinel.transport.message.HeartbeatMessageKeyConstants.*;
@@ -39,7 +38,7 @@ public abstract class AbstractHeartbeatMessage implements HeartbeatMessage {
      */
     private final Map<String, String> unmodifiableInformation = Collections.unmodifiableMap(this.information);
 
-    private final Map<String, Supplier<String>> informationSuppliers = new ConcurrentHashMap<>();
+    private final Map<String, Supplier<String>> informationSuppliers = new HashMap<>();
 
     public AbstractHeartbeatMessage() {
         this.registerInformationSupplier(PID, PID_SUPPLIER);

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/AbstractHeartbeatMessage.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/AbstractHeartbeatMessage.java
@@ -65,10 +65,9 @@ public abstract class AbstractHeartbeatMessage implements HeartbeatMessage {
      *
      * @param key information's key
      */
-    protected AbstractHeartbeatMessage refresh(String key) {
+    protected void refresh(String key) {
         String newValue = this.informationSuppliers.get(key).get();
         this.information.put(key, newValue);
-        return this;
     }
 
     /**

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/AbstractHeartbeatMessage.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/AbstractHeartbeatMessage.java
@@ -48,23 +48,23 @@ public abstract class AbstractHeartbeatMessage implements HeartbeatMessage {
 	private final Map<String, Supplier<String>> dynamicInformationSuppliers = new HashMap<>();
 
 	public AbstractHeartbeatMessage() {
-		this.setInformation(PID, PID_SUPPLIER.get());
-		this.setInformation(APP_NAME, APP_NAME_SUPPLIER.get());
+		this.put(PID, PID_SUPPLIER.get());
+		this.put(APP_NAME, APP_NAME_SUPPLIER.get());
 		// application type (since 1.6.0).
-		this.setInformation(APP_TYPE, APP_TYPE_SUPPLIER.get());
+		this.put(APP_TYPE, APP_TYPE_SUPPLIER.get());
 		// Version of Sentinel.
-		this.setInformation(SENTINEL_VERSION, SENTINEL_VERSION_SUPPLIER.get());
-		this.setInformation(HOST_NAME, HOST_NAME_SUPPLIER.get());
-		this.setInformation(HEARTBEAT_CLIENT_IP, HEARTBEAT_CLIENT_IP_SUPPLIER.get());
+		this.put(SENTINEL_VERSION, SENTINEL_VERSION_SUPPLIER.get());
+		this.put(HOST_NAME, HOST_NAME_SUPPLIER.get());
+		this.put(HEARTBEAT_CLIENT_IP, HEARTBEAT_CLIENT_IP_SUPPLIER.get());
 		// sentinel client's port
-		this.setInformation(PORT, PORT_SUPPLIER.get());
+		this.put(PORT, PORT_SUPPLIER.get());
 
 		// Actually timestamp.
 		this.registerDynamicInformationSupplier(CURRENT_TIME_MILLIS, CURRENT_TIME_MILLIS_SUPPLIER);
 	}
 
 	@Override
-	public void setInformation(String key, String value) {
+	public void put(String key, String value) {
 		this.information.put(key, value);
 	}
 

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/AbstractHeartbeatMessage.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/AbstractHeartbeatMessage.java
@@ -71,7 +71,6 @@ public abstract class AbstractHeartbeatMessage implements HeartbeatMessage {
 	@Override
 	public void registerDynamicInformationSupplier(String key, Supplier<String> valueSupplier) {
 		this.dynamicInformationSuppliers.put(key, valueSupplier);
-		this.information.put(key, valueSupplier.get());
 	}
 
 	@Override

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/DefaultHeartbeatMessage.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/DefaultHeartbeatMessage.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.transport.message;
+
+import com.alibaba.csp.sentinel.spi.Spi;
+
+/**
+ * Default implementation of {@link HeartbeatMessage}.
+ *
+ * @author wxq
+ * @since 1.8.2
+ */
+@Spi(order = Spi.ORDER_LOWEST)
+public final class DefaultHeartbeatMessage extends AbstractHeartbeatMessage {
+
+}

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/HeartbeatMessage.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/HeartbeatMessage.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.transport.message;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * sentinel client will send message to dashboard when send heartbeat.
+ *
+ * @author wxq
+ * @since 1.8.2
+ */
+@FunctionalInterface
+public interface HeartbeatMessage extends Supplier<Map<String, String>> {
+
+}

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/HeartbeatMessage.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/HeartbeatMessage.java
@@ -18,13 +18,32 @@ package com.alibaba.csp.sentinel.transport.message;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import com.alibaba.csp.sentinel.transport.config.TransportConfig;
+
 /**
  * sentinel client will send message to dashboard when send heartbeat.
  *
  * @author wxq
  * @since 1.8.2
+ * @see HeartbeatMessageKeyConstants standard information's key
  */
-@FunctionalInterface
 public interface HeartbeatMessage extends Supplier<Map<String, String>> {
 
+	/**
+	 * Set the information to message. If your value will change in runtime,
+	 * recommend use {@link #registerDynamicInformationSupplier(String, Supplier)}.
+	 */
+	void setInformation(String key, String value);
+
+	/**
+	 * Will get a new value from value supplier in every calling of {@link #get()}.
+	 * If your value is static, recommend use
+	 * {@link #setInformation(String, String)}.
+	 * 
+	 * @param key           information's key
+	 * @param valueSupplier information's value supplier
+	 * @see TransportConfig#HEARTBEAT_INTERVAL_MS the value supplier's invoke
+	 *      frequency
+	 */
+	void registerDynamicInformationSupplier(String key, Supplier<String> valueSupplier);
 }

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/HeartbeatMessage.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/HeartbeatMessage.java
@@ -32,13 +32,14 @@ public interface HeartbeatMessage extends Supplier<Map<String, String>> {
 	/**
 	 * Set the information to message. If your value will change in runtime,
 	 * recommend use {@link #registerDynamicInformationSupplier(String, Supplier)}.
+	 * 
+	 * @see Map#put(String, String)
 	 */
-	void setInformation(String key, String value);
+	void put(String key, String value);
 
 	/**
 	 * Will get a new value from value supplier in every calling of {@link #get()}.
-	 * If your value is static, recommend use
-	 * {@link #setInformation(String, String)}.
+	 * If your value is static, recommend use {@link #put(String, String)}.
 	 * 
 	 * @param key           information's key
 	 * @param valueSupplier information's value supplier

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/HeartbeatMessageKeyConstants.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/HeartbeatMessageKeyConstants.java
@@ -31,46 +31,46 @@ public final class HeartbeatMessageKeyConstants {
     }
 
     /**
-     * @see HeartbeatMessageSuppliers#PID_SUPPLIER for value supplier
+     * @see HeartbeatMessageSuppliers#PID_SUPPLIER
      */
     public static final String PID = "pid";
 
     /**
-     * @see HeartbeatMessageSuppliers#APP_NAME_SUPPLIER for value supplier
+     * @see HeartbeatMessageSuppliers#APP_NAME_SUPPLIER
      */
     public static final String APP_NAME = "app";
 
     /**
-     * @see HeartbeatMessageSuppliers#APP_TYPE_SUPPLIER for value supplier
+     * @see HeartbeatMessageSuppliers#APP_TYPE_SUPPLIER
      */
     public static final String APP_TYPE = "app_type";
 
     /**
-     * @see HeartbeatMessageSuppliers#SENTINEL_VERSION_SUPPLIER for value supplier
+     * @see HeartbeatMessageSuppliers#SENTINEL_VERSION_SUPPLIER
      */
     public static final String SENTINEL_VERSION = "v";
 
     /**
-     * @see HeartbeatMessageSuppliers#HOST_NAME_SUPPLIER for value supplier
+     * @see HeartbeatMessageSuppliers#HOST_NAME_SUPPLIER
      */
     public static final String HOST_NAME = "hostname";
 
     /**
-     * @see HeartbeatMessageSuppliers#HEARTBEAT_CLIENT_IP_SUPPLIER for value supplier
+     * @see HeartbeatMessageSuppliers#HEARTBEAT_CLIENT_IP_SUPPLIER
      */
     public static final String HEARTBEAT_CLIENT_IP = "ip";
 
     /**
      * dynamic information.
      *
-     * @see HeartbeatMessageSuppliers#PORT_SUPPLIER for value supplier
+     * @see HeartbeatMessageSuppliers#PORT_SUPPLIER
      */
     public static final String PORT = "port";
 
     /**
      * dynamic information.
      *
-     * @see HeartbeatMessageSuppliers#CURRENT_TIME_MILLIS_SUPPLIER for value supplier
+     * @see HeartbeatMessageSuppliers#CURRENT_TIME_MILLIS_SUPPLIER
      */
     public static final String CURRENT_TIME_MILLIS = "version";
 

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/HeartbeatMessageKeyConstants.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/HeartbeatMessageKeyConstants.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.transport.message;
+
+/**
+ * When sentinel client send heartbeat to sentinel dashboard, those information should be send.
+ * <p>
+ * Store key in current class.
+ * <p>
+ * If you want to implement sentinel dashboard by self, you should handle those keys which send by sentinel client.
+ *
+ * @author wxq
+ * @since 1.8.2
+ */
+public final class HeartbeatMessageKeyConstants {
+
+    private HeartbeatMessageKeyConstants() {
+    }
+
+    /**
+     * @see HeartbeatMessageSuppliers#PID_SUPPLIER for value supplier
+     */
+    public static final String PID = "pid";
+
+    /**
+     * @see HeartbeatMessageSuppliers#APP_NAME_SUPPLIER for value supplier
+     */
+    public static final String APP_NAME = "app";
+
+    /**
+     * @see HeartbeatMessageSuppliers#APP_TYPE_SUPPLIER for value supplier
+     */
+    public static final String APP_TYPE = "app_type";
+
+    /**
+     * @see HeartbeatMessageSuppliers#SENTINEL_VERSION_SUPPLIER for value supplier
+     */
+    public static final String SENTINEL_VERSION = "v";
+
+    /**
+     * @see HeartbeatMessageSuppliers#HOST_NAME_SUPPLIER for value supplier
+     */
+    public static final String HOST_NAME = "hostname";
+
+    /**
+     * @see HeartbeatMessageSuppliers#HEARTBEAT_CLIENT_IP_SUPPLIER for value supplier
+     */
+    public static final String HEARTBEAT_CLIENT_IP = "ip";
+
+    /**
+     * dynamic information.
+     *
+     * @see HeartbeatMessageSuppliers#PORT_SUPPLIER for value supplier
+     */
+    public static final String PORT = "port";
+
+    /**
+     * dynamic information.
+     *
+     * @see HeartbeatMessageSuppliers#CURRENT_TIME_MILLIS_SUPPLIER for value supplier
+     */
+    public static final String CURRENT_TIME_MILLIS = "version";
+
+}

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/HeartbeatMessageSuppliers.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/HeartbeatMessageSuppliers.java
@@ -25,7 +25,7 @@ import com.alibaba.csp.sentinel.util.PidUtil;
 import java.util.function.Supplier;
 
 /**
- * Value supplier for key in {@link HeartbeatMessageKeyConstants}.
+ * Value supplier in {@link HeartbeatMessageKeyConstants}.
  *
  * @author wxq
  * @since 1.8.2
@@ -36,42 +36,42 @@ public final class HeartbeatMessageSuppliers {
     }
 
     /**
-     * @see HeartbeatMessageKeyConstants#PID for key
+     * @see HeartbeatMessageKeyConstants#PID
      */
     public static final Supplier<String> PID_SUPPLIER = () -> String.valueOf(PidUtil.getPid());
 
     /**
-     * @see HeartbeatMessageKeyConstants#APP_NAME for key
+     * @see HeartbeatMessageKeyConstants#APP_NAME
      */
     public static final Supplier<String> APP_NAME_SUPPLIER = AppNameUtil::getAppName;
 
     /**
-     * @see HeartbeatMessageKeyConstants#APP_TYPE for key
+     * @see HeartbeatMessageKeyConstants#APP_TYPE
      */
     public static final Supplier<String> APP_TYPE_SUPPLIER = () -> String.valueOf(SentinelConfig.getAppType());
 
     /**
-     * @see HeartbeatMessageKeyConstants#SENTINEL_VERSION for key
+     * @see HeartbeatMessageKeyConstants#SENTINEL_VERSION
      */
     public static final Supplier<String> SENTINEL_VERSION_SUPPLIER = () -> Constants.SENTINEL_VERSION;
 
     /**
-     * @see HeartbeatMessageKeyConstants#HOST_NAME for key
+     * @see HeartbeatMessageKeyConstants#HOST_NAME
      */
     public static final Supplier<String> HOST_NAME_SUPPLIER = HostNameUtil::getHostName;
 
     /**
-     * @see HeartbeatMessageKeyConstants#HEARTBEAT_CLIENT_IP for key
+     * @see HeartbeatMessageKeyConstants#HEARTBEAT_CLIENT_IP
      */
     public static final Supplier<String> HEARTBEAT_CLIENT_IP_SUPPLIER = TransportConfig::getHeartbeatClientIp;
 
     /**
-     * @see HeartbeatMessageKeyConstants#PORT for key
+     * @see HeartbeatMessageKeyConstants#PORT
      */
     public static final Supplier<String> PORT_SUPPLIER = TransportConfig::getPort;
 
     /**
-     * @see HeartbeatMessageKeyConstants#CURRENT_TIME_MILLIS for key
+     * @see HeartbeatMessageKeyConstants#CURRENT_TIME_MILLIS
      */
     public static final Supplier<String> CURRENT_TIME_MILLIS_SUPPLIER = () -> String.valueOf(System.currentTimeMillis());
 }

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/HeartbeatMessageSuppliers.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/message/HeartbeatMessageSuppliers.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.transport.message;
+
+import com.alibaba.csp.sentinel.Constants;
+import com.alibaba.csp.sentinel.config.SentinelConfig;
+import com.alibaba.csp.sentinel.transport.config.TransportConfig;
+import com.alibaba.csp.sentinel.util.AppNameUtil;
+import com.alibaba.csp.sentinel.util.HostNameUtil;
+import com.alibaba.csp.sentinel.util.PidUtil;
+
+import java.util.function.Supplier;
+
+/**
+ * Value supplier for key in {@link HeartbeatMessageKeyConstants}.
+ *
+ * @author wxq
+ * @since 1.8.2
+ */
+public final class HeartbeatMessageSuppliers {
+
+    private HeartbeatMessageSuppliers() {
+    }
+
+    /**
+     * @see HeartbeatMessageKeyConstants#PID for key
+     */
+    public static final Supplier<String> PID_SUPPLIER = () -> String.valueOf(PidUtil.getPid());
+
+    /**
+     * @see HeartbeatMessageKeyConstants#APP_NAME for key
+     */
+    public static final Supplier<String> APP_NAME_SUPPLIER = AppNameUtil::getAppName;
+
+    /**
+     * @see HeartbeatMessageKeyConstants#APP_TYPE for key
+     */
+    public static final Supplier<String> APP_TYPE_SUPPLIER = () -> String.valueOf(SentinelConfig.getAppType());
+
+    /**
+     * @see HeartbeatMessageKeyConstants#SENTINEL_VERSION for key
+     */
+    public static final Supplier<String> SENTINEL_VERSION_SUPPLIER = () -> Constants.SENTINEL_VERSION;
+
+    /**
+     * @see HeartbeatMessageKeyConstants#HOST_NAME for key
+     */
+    public static final Supplier<String> HOST_NAME_SUPPLIER = HostNameUtil::getHostName;
+
+    /**
+     * @see HeartbeatMessageKeyConstants#HEARTBEAT_CLIENT_IP for key
+     */
+    public static final Supplier<String> HEARTBEAT_CLIENT_IP_SUPPLIER = TransportConfig::getHeartbeatClientIp;
+
+    /**
+     * @see HeartbeatMessageKeyConstants#PORT for key
+     */
+    public static final Supplier<String> PORT_SUPPLIER = TransportConfig::getPort;
+
+    /**
+     * @see HeartbeatMessageKeyConstants#CURRENT_TIME_MILLIS for key
+     */
+    public static final Supplier<String> CURRENT_TIME_MILLIS_SUPPLIER = () -> String.valueOf(System.currentTimeMillis());
+}

--- a/sentinel-transport/sentinel-transport-common/src/main/resources/META-INF/services/com.alibaba.csp.sentinel.transport.message.HeartbeatMessage
+++ b/sentinel-transport/sentinel-transport-common/src/main/resources/META-INF/services/com.alibaba.csp.sentinel.transport.message.HeartbeatMessage
@@ -1,0 +1,1 @@
+com.alibaba.csp.sentinel.transport.message.DefaultHeartbeatMessage

--- a/sentinel-transport/sentinel-transport-common/src/test/java/com/alibaba/csp/sentinel/heartbeat/HeartbeatMessageProviderTest.java
+++ b/sentinel-transport/sentinel-transport-common/src/test/java/com/alibaba/csp/sentinel/heartbeat/HeartbeatMessageProviderTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.heartbeat;
+
+import com.alibaba.csp.sentinel.transport.message.DefaultHeartbeatMessage;
+import com.alibaba.csp.sentinel.transport.message.HeartbeatMessage;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author wxq
+ * @since 1.8.2
+ */
+public class HeartbeatMessageProviderTest {
+
+    @Test
+    public void testGetHeartbeatMessage() {
+        HeartbeatMessage heartbeatMessage = HeartbeatMessageProvider.getHeartbeatMessage();
+        assertTrue(heartbeatMessage instanceof DefaultHeartbeatMessage);
+        assertTrue(heartbeatMessage.get().size() > 0);
+    }
+
+}

--- a/sentinel-transport/sentinel-transport-common/src/test/java/com/alibaba/csp/sentinel/transport/message/AbstractHeartbeatMessageTest.java
+++ b/sentinel-transport/sentinel-transport-common/src/test/java/com/alibaba/csp/sentinel/transport/message/AbstractHeartbeatMessageTest.java
@@ -15,7 +15,8 @@
  */
 package com.alibaba.csp.sentinel.transport.message;
 
-import static org.junit.Assert.*;
+import static com.alibaba.csp.sentinel.transport.message.HeartbeatMessageKeyConstants.HOST_NAME;
+import static org.junit.Assert.assertEquals;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
@@ -33,6 +34,20 @@ public class AbstractHeartbeatMessageTest {
 		HeartbeatMessage heartbeatMessage = new BeforeGetHeartbeatMessageTest();
 		assertEquals("1", heartbeatMessage.get().get("count"));
 		assertEquals("2", heartbeatMessage.get().get("count"));
+	}
+	
+	@Test(expected = UnsupportedOperationException.class)
+	public void testModify() {
+		HeartbeatMessage heartbeatMessage = new EmptyHeartbeatMessageTest();
+		heartbeatMessage.get().put(HOST_NAME, "error host name");
+	}
+	
+	/**
+	 * @author wxq
+	 * @since 1.8.2
+	 */
+	private static class EmptyHeartbeatMessageTest extends AbstractHeartbeatMessage {
+		
 	}
 	
 	/**

--- a/sentinel-transport/sentinel-transport-common/src/test/java/com/alibaba/csp/sentinel/transport/message/AbstractHeartbeatMessageTest.java
+++ b/sentinel-transport/sentinel-transport-common/src/test/java/com/alibaba/csp/sentinel/transport/message/AbstractHeartbeatMessageTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.transport.message;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import org.junit.Test;
+
+/**
+ * @author wxq
+ * @since 1.8.2
+ */
+public class AbstractHeartbeatMessageTest {
+
+	@Test
+	public void testBeforeGet() {
+		HeartbeatMessage heartbeatMessage = new BeforeGetHeartbeatMessageTest();
+		assertEquals("1", heartbeatMessage.get().get("count"));
+		assertEquals("2", heartbeatMessage.get().get("count"));
+	}
+	
+	/**
+	 * @author wxq
+	 * @since 1.8.2
+	 */
+	private static class BeforeGetHeartbeatMessageTest extends AbstractHeartbeatMessage {
+
+		public BeforeGetHeartbeatMessageTest() {
+			AtomicInteger atomicInteger = new AtomicInteger();
+			Supplier<String> countValueSupplier = () -> String.valueOf(atomicInteger.getAndIncrement());
+			this.registerInformationSupplier("count", countValueSupplier);
+		}
+		
+		@Override
+		protected void beforeGet() {
+			this.refresh("count");
+		}
+		
+	}
+
+}

--- a/sentinel-transport/sentinel-transport-common/src/test/java/com/alibaba/csp/sentinel/transport/message/AbstractHeartbeatMessageTest.java
+++ b/sentinel-transport/sentinel-transport-common/src/test/java/com/alibaba/csp/sentinel/transport/message/AbstractHeartbeatMessageTest.java
@@ -31,7 +31,8 @@ public class AbstractHeartbeatMessageTest {
 
 	@Test
 	public void testBeforeGet() {
-		HeartbeatMessage heartbeatMessage = new BeforeGetHeartbeatMessageTest();
+		HeartbeatMessage heartbeatMessage = new DynamicHeartbeatMessageTest();
+		assertEquals("0", heartbeatMessage.get().get("count"));
 		assertEquals("1", heartbeatMessage.get().get("count"));
 		assertEquals("2", heartbeatMessage.get().get("count"));
 	}
@@ -54,9 +55,9 @@ public class AbstractHeartbeatMessageTest {
 	 * @author wxq
 	 * @since 1.8.2
 	 */
-	private static class BeforeGetHeartbeatMessageTest extends AbstractHeartbeatMessage {
+	private static class DynamicHeartbeatMessageTest extends AbstractHeartbeatMessage {
 
-		public BeforeGetHeartbeatMessageTest() {
+		public DynamicHeartbeatMessageTest() {
 			AtomicInteger atomicInteger = new AtomicInteger();
 			Supplier<String> countValueSupplier = () -> String.valueOf(atomicInteger.getAndIncrement());
 			this.registerDynamicInformationSupplier("count", countValueSupplier);

--- a/sentinel-transport/sentinel-transport-common/src/test/java/com/alibaba/csp/sentinel/transport/message/AbstractHeartbeatMessageTest.java
+++ b/sentinel-transport/sentinel-transport-common/src/test/java/com/alibaba/csp/sentinel/transport/message/AbstractHeartbeatMessageTest.java
@@ -35,21 +35,21 @@ public class AbstractHeartbeatMessageTest {
 		assertEquals("1", heartbeatMessage.get().get("count"));
 		assertEquals("2", heartbeatMessage.get().get("count"));
 	}
-	
+
 	@Test(expected = UnsupportedOperationException.class)
 	public void testModify() {
 		HeartbeatMessage heartbeatMessage = new EmptyHeartbeatMessageTest();
 		heartbeatMessage.get().put(HOST_NAME, "error host name");
 	}
-	
+
 	/**
 	 * @author wxq
 	 * @since 1.8.2
 	 */
 	private static class EmptyHeartbeatMessageTest extends AbstractHeartbeatMessage {
-		
+
 	}
-	
+
 	/**
 	 * @author wxq
 	 * @since 1.8.2
@@ -59,14 +59,9 @@ public class AbstractHeartbeatMessageTest {
 		public BeforeGetHeartbeatMessageTest() {
 			AtomicInteger atomicInteger = new AtomicInteger();
 			Supplier<String> countValueSupplier = () -> String.valueOf(atomicInteger.getAndIncrement());
-			this.registerInformationSupplier("count", countValueSupplier);
+			this.registerDynamicInformationSupplier("count", countValueSupplier);
 		}
-		
-		@Override
-		protected void beforeGet() {
-			this.refresh("count");
-		}
-		
+
 	}
 
 }

--- a/sentinel-transport/sentinel-transport-common/src/test/java/com/alibaba/csp/sentinel/transport/message/DefaultHeartbeatMessageTest.java
+++ b/sentinel-transport/sentinel-transport-common/src/test/java/com/alibaba/csp/sentinel/transport/message/DefaultHeartbeatMessageTest.java
@@ -17,6 +17,7 @@ package com.alibaba.csp.sentinel.transport.message;
 
 import org.junit.Test;
 
+import static com.alibaba.csp.sentinel.transport.message.HeartbeatMessageKeyConstants.CURRENT_TIME_MILLIS;
 import static org.junit.Assert.*;
 
 /**
@@ -27,6 +28,7 @@ public class DefaultHeartbeatMessageTest {
 
     /**
      * key value pair's count.
+     *
      * @see HeartbeatMessageKeyConstants for how many keys
      */
     @Test
@@ -36,6 +38,16 @@ public class DefaultHeartbeatMessageTest {
 
         // should change here when add a new key value pair
         assertEquals(8, size);
+    }
+
+    @Test
+    public void testInformationCurrentTimeMillis() throws InterruptedException {
+        HeartbeatMessage heartbeatMessage = new DefaultHeartbeatMessage();
+        assertTrue(heartbeatMessage.get().containsKey(CURRENT_TIME_MILLIS));
+        String time1 = heartbeatMessage.get().get(CURRENT_TIME_MILLIS);
+        Thread.sleep(2);
+        String time2 = heartbeatMessage.get().get(CURRENT_TIME_MILLIS);
+        assertTrue(Long.parseLong(time2) > Long.parseLong(time1));
     }
 
 }

--- a/sentinel-transport/sentinel-transport-common/src/test/java/com/alibaba/csp/sentinel/transport/message/DefaultHeartbeatMessageTest.java
+++ b/sentinel-transport/sentinel-transport-common/src/test/java/com/alibaba/csp/sentinel/transport/message/DefaultHeartbeatMessageTest.java
@@ -59,7 +59,7 @@ public class DefaultHeartbeatMessageTest {
     	String value = UUID.randomUUID().toString();
     	assertFalse(heartbeatMessage.get().containsKey(key));
     	
-    	heartbeatMessage.setInformation(key, value);
+    	heartbeatMessage.put(key, value);
     	assertEquals(value, heartbeatMessage.get().get(key));
     }
 

--- a/sentinel-transport/sentinel-transport-common/src/test/java/com/alibaba/csp/sentinel/transport/message/DefaultHeartbeatMessageTest.java
+++ b/sentinel-transport/sentinel-transport-common/src/test/java/com/alibaba/csp/sentinel/transport/message/DefaultHeartbeatMessageTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.transport.message;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author wxq
+ * @since 1.8.2
+ */
+public class DefaultHeartbeatMessageTest {
+
+    /**
+     * key value pair's count.
+     * @see HeartbeatMessageKeyConstants for how many keys
+     */
+    @Test
+    public void testKeyValuesSize() {
+        HeartbeatMessage heartbeatMessage = new DefaultHeartbeatMessage();
+        int size = heartbeatMessage.get().size();
+
+        // should change here when add a new key value pair
+        assertEquals(8, size);
+    }
+
+}

--- a/sentinel-transport/sentinel-transport-common/src/test/java/com/alibaba/csp/sentinel/transport/message/DefaultHeartbeatMessageTest.java
+++ b/sentinel-transport/sentinel-transport-common/src/test/java/com/alibaba/csp/sentinel/transport/message/DefaultHeartbeatMessageTest.java
@@ -20,6 +20,8 @@ import org.junit.Test;
 import static com.alibaba.csp.sentinel.transport.message.HeartbeatMessageKeyConstants.CURRENT_TIME_MILLIS;
 import static org.junit.Assert.*;
 
+import java.util.UUID;
+
 /**
  * @author wxq
  * @since 1.8.2
@@ -48,6 +50,17 @@ public class DefaultHeartbeatMessageTest {
         Thread.sleep(2);
         String time2 = heartbeatMessage.get().get(CURRENT_TIME_MILLIS);
         assertTrue(Long.parseLong(time2) > Long.parseLong(time1));
+    }
+
+    @Test
+    public void testSetInformation() {
+    	HeartbeatMessage heartbeatMessage = new DefaultHeartbeatMessage();
+    	String key = UUID.randomUUID().toString();
+    	String value = UUID.randomUUID().toString();
+    	assertFalse(heartbeatMessage.get().containsKey(key));
+    	
+    	heartbeatMessage.setInformation(key, value);
+    	assertEquals(value, heartbeatMessage.get().get(key));
     }
 
 }

--- a/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/heartbeat/HeartbeatMessage.java
+++ b/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/heartbeat/HeartbeatMessage.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import com.alibaba.csp.sentinel.Constants;
 import com.alibaba.csp.sentinel.config.SentinelConfig;
+import com.alibaba.csp.sentinel.heartbeat.HeartbeatMessageProvider;
 import com.alibaba.csp.sentinel.transport.config.TransportConfig;
 import com.alibaba.csp.sentinel.util.AppNameUtil;
 import com.alibaba.csp.sentinel.util.HostNameUtil;
@@ -30,7 +31,9 @@ import com.alibaba.csp.sentinel.util.TimeUtil;
  * The message consists of key-value pair parameters.
  *
  * @author leyou
+ * @deprecated please use {@link HeartbeatMessageProvider#getHeartbeatMessage()} instead
  */
+@Deprecated
 public class HeartbeatMessage {
 
     private final Map<String, String> message = new HashMap<String, String>();

--- a/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/heartbeat/SimpleHttpHeartbeatSender.java
+++ b/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/heartbeat/SimpleHttpHeartbeatSender.java
@@ -15,13 +15,15 @@
  */
 package com.alibaba.csp.sentinel.transport.heartbeat;
 
+import com.alibaba.csp.sentinel.heartbeat.HeartbeatMessageProvider;
 import com.alibaba.csp.sentinel.log.RecordLog;
 import com.alibaba.csp.sentinel.transport.HeartbeatSender;
 import com.alibaba.csp.sentinel.transport.config.TransportConfig;
+import com.alibaba.csp.sentinel.transport.endpoint.Endpoint;
 import com.alibaba.csp.sentinel.transport.heartbeat.client.SimpleHttpClient;
 import com.alibaba.csp.sentinel.transport.heartbeat.client.SimpleHttpRequest;
 import com.alibaba.csp.sentinel.transport.heartbeat.client.SimpleHttpResponse;
-import com.alibaba.csp.sentinel.transport.endpoint.Endpoint;
+import com.alibaba.csp.sentinel.transport.message.HeartbeatMessage;
 
 import java.util.List;
 
@@ -39,7 +41,7 @@ public class SimpleHttpHeartbeatSender implements HeartbeatSender {
 
     private static final long DEFAULT_INTERVAL = 1000 * 10;
 
-    private final HeartbeatMessage heartBeat = new HeartbeatMessage();
+    private final HeartbeatMessage heartbeatMessage = HeartbeatMessageProvider.getHeartbeatMessage();
     private final SimpleHttpClient httpClient = new SimpleHttpClient();
 
     private final List<Endpoint> addressList;
@@ -69,7 +71,7 @@ public class SimpleHttpHeartbeatSender implements HeartbeatSender {
         }
 
         SimpleHttpRequest request = new SimpleHttpRequest(addrInfo, TransportConfig.getHeartbeatApiPath());
-        request.setParams(heartBeat.generateCurrentMessage());
+        request.setParams(this.heartbeatMessage.get());
         try {
             SimpleHttpResponse response = httpClient.post(request);
             if (response.getStatusCode() == OK_STATUS) {

--- a/sentinel-transport/sentinel-transport-spring-mvc/src/main/java/com/alibaba/csp/sentinel/transport/heartbeat/SpringMvcHttpHeartbeatSender.java
+++ b/sentinel-transport/sentinel-transport-spring-mvc/src/main/java/com/alibaba/csp/sentinel/transport/heartbeat/SpringMvcHttpHeartbeatSender.java
@@ -15,8 +15,7 @@
  */
 package com.alibaba.csp.sentinel.transport.heartbeat;
 
-import com.alibaba.csp.sentinel.Constants;
-import com.alibaba.csp.sentinel.config.SentinelConfig;
+import com.alibaba.csp.sentinel.heartbeat.HeartbeatMessageProvider;
 import com.alibaba.csp.sentinel.log.RecordLog;
 import com.alibaba.csp.sentinel.spi.Spi;
 import com.alibaba.csp.sentinel.transport.HeartbeatSender;
@@ -24,17 +23,19 @@ import com.alibaba.csp.sentinel.transport.config.TransportConfig;
 import com.alibaba.csp.sentinel.transport.endpoint.Endpoint;
 import com.alibaba.csp.sentinel.transport.endpoint.Protocol;
 import com.alibaba.csp.sentinel.transport.heartbeat.client.HttpClientsFactory;
-import com.alibaba.csp.sentinel.util.AppNameUtil;
-import com.alibaba.csp.sentinel.util.HostNameUtil;
-import com.alibaba.csp.sentinel.util.PidUtil;
+import com.alibaba.csp.sentinel.transport.message.HeartbeatMessage;
 import com.alibaba.csp.sentinel.util.StringUtil;
+import org.apache.http.NameValuePair;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.message.BasicNameValuePair;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author Eric Zhao
@@ -59,6 +60,8 @@ public class SpringMvcHttpHeartbeatSender implements HeartbeatSender {
     private final String consoleHost;
     private final int consolePort;
 
+    private final HeartbeatMessage heartbeatMessage = HeartbeatMessageProvider.getHeartbeatMessage();
+
     public SpringMvcHttpHeartbeatSender() {
         List<Endpoint> dashboardList = TransportConfig.getConsoleServerList();
         if (dashboardList == null || dashboardList.isEmpty()) {
@@ -75,22 +78,26 @@ public class SpringMvcHttpHeartbeatSender implements HeartbeatSender {
         this.client = HttpClientsFactory.getHttpClientsByProtocol(consoleProtocol);
     }
 
+    private List<NameValuePair> resolveParameters() {
+        List<NameValuePair> nameValuePairs = new ArrayList<>();
+        Map<String, String> map = this.heartbeatMessage.get();
+        for (Map.Entry<String, String> entry : map.entrySet()) {
+            NameValuePair nameValuePair = new BasicNameValuePair(entry.getKey(), entry.getValue());
+            nameValuePairs.add(nameValuePair);
+        }
+        return nameValuePairs;
+    }
+
     @Override
     public boolean sendHeartbeat() throws Exception {
         if (StringUtil.isEmpty(consoleHost)) {
             return false;
         }
+        List<NameValuePair> parameters = this.resolveParameters();
         URIBuilder uriBuilder = new URIBuilder();
         uriBuilder.setScheme(consoleProtocol.getProtocol()).setHost(consoleHost).setPort(consolePort)
             .setPath(TransportConfig.getHeartbeatApiPath())
-            .setParameter("app", AppNameUtil.getAppName())
-            .setParameter("app_type", String.valueOf(SentinelConfig.getAppType()))
-            .setParameter("v", Constants.SENTINEL_VERSION)
-            .setParameter("version", String.valueOf(System.currentTimeMillis()))
-            .setParameter("hostname", HostNameUtil.getHostName())
-            .setParameter("ip", TransportConfig.getHeartbeatClientIp())
-            .setParameter("port", TransportConfig.getPort())
-            .setParameter("pid", String.valueOf(PidUtil.getPid()));
+            .setParameters(parameters);
 
         HttpGet request = new HttpGet(uriBuilder.build());
         request.setConfig(requestConfig);


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Regular the message between sentinel client and sentinel dashboard,

and make heartbeat message more extensible.

#### HeartbeatMessage usage

use
```java
HeartbeatMessage heartbeatMessage = HeartbeatMessageProvider.getHeartbeatMessage();
Map<String, String> map = this.heartbeatMessage.get();
```


#### custom HeartbeatMessage

Use can define a custom implementation of `com.alibaba.csp.sentinel.transport.message.HeartbeatMessage`.

```java
public final class CustomHeartbeatMessage extends AbstractHeartbeatMessage {
   public CustomHeartbeatMessage() {
      // register information
   }
}
```

and `CustomHeartbeatMessage`'s class path to file

```
src/main/resources/META-INF/services/com.alibaba.csp.sentinel.transport.message.HeartbeatMessage
```


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #2084

### Describe how you did it

Use Spi to load `com.alibaba.csp.sentinel.transport.message.HeartbeatMessage`.

### Describe how to verify it

Unit test.

### Special notes for reviews

Maybe there are better way to implement it, or more flexible way?