### PR TITLE
An improved method for obtaining ip address and port number from cont…

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/config/SentinelConfig.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/config/SentinelConfig.java
@@ -125,6 +125,24 @@ public final class SentinelConfig {
         AssertUtil.notNull(key, "key cannot be null");
         return props.get(key);
     }
+    
+    /**
+     * Get config value of the specific key.
+     *
+     * @param key config key
+     * @param envVariableKey Get the value of the environment variable with the given key
+     * @return the config value.
+     */
+    public static String getConfig(String key, boolean envVariableKey) {
+        AssertUtil.notNull(key, "key cannot be null");
+        if (envVariableKey) {
+            String value = System.getenv(key);
+            if (StringUtil.isNotEmpty(value)) {
+                return value;
+            }
+        }
+        return getConfig(key);
+    }
 
     public static void setConfig(String key, String value) {
         AssertUtil.notNull(key, "key cannot be null");

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/config/TransportConfig.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/config/TransportConfig.java
@@ -140,7 +140,7 @@ public class TransportConfig {
         if (runtimePort > 0) {
             return String.valueOf(runtimePort);
         }
-        return SentinelConfig.getConfig(SERVER_PORT);
+        return SentinelConfig.getConfig(SERVER_PORT, true);
     }
 
     /**
@@ -159,7 +159,7 @@ public class TransportConfig {
      * @return the local ip.
      */
     public static String getHeartbeatClientIp() {
-        String ip = SentinelConfig.getConfig(HEARTBEAT_CLIENT_IP);
+        String ip = SentinelConfig.getConfig(HEARTBEAT_CLIENT_IP, true);
         if (StringUtil.isBlank(ip)) {
             ip = HostNameUtil.getIp();
         }


### PR DESCRIPTION
如果用户代码docker化后,env的操作成本要比-D传进来的成本低很多.因此env是原生云环境下指定ip和端口的比较好的办法.
<img width="872" alt="env" src="https://user-images.githubusercontent.com/869986/115809193-4051aa00-a41e-11eb-814a-3a23a044dade.png">
<img width="1097" alt="yes" src="https://user-images.githubusercontent.com/869986/115809350-83ac1880-a41e-11eb-94b0-ffd9ca5de9c4.png">
<img width="997" alt="yes2" src="https://user-images.githubusercontent.com/869986/115809457-b8b86b00-a41e-11eb-96e9-2a03e6dbeabe.png">
这样dashboard 推送rule信息修改就没有任何问题了