### PR TITLE
解决Dashboard网关流控规则推送丢失间隔时间的问题

### DIFF
--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/rule/GatewayFlowRule.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/rule/GatewayFlowRule.java
@@ -184,7 +184,7 @@ public class GatewayFlowRule {
         if (resourceMode != rule.resourceMode) { return false; }
         if (grade != rule.grade) { return false; }
         if (Double.compare(rule.count, count) != 0) { return false; }
-        if (intervalSec != rule.intervalSec) { return false; }
+        if (getIntervalSec() != rule.getIntervalSec()) { return false; }
         if (controlBehavior != rule.controlBehavior) { return false; }
         if (burst != rule.burst) { return false; }
         if (maxQueueingTimeoutMs != rule.maxQueueingTimeoutMs) { return false; }
@@ -197,6 +197,7 @@ public class GatewayFlowRule {
     public int hashCode() {
         int result;
         long temp;
+        long intervalSec = getIntervalSec();
         result = resource != null ? resource.hashCode() : 0;
         result = 31 * result + resourceMode;
         result = 31 * result + grade;
@@ -217,7 +218,7 @@ public class GatewayFlowRule {
             ", resourceMode=" + resourceMode +
             ", grade=" + grade +
             ", count=" + count +
-            ", intervalSec=" + intervalSec +
+            ", intervalSec=" + getIntervalSec() +
             ", controlBehavior=" + controlBehavior +
             ", burst=" + burst +
             ", maxQueueingTimeoutMs=" + maxQueueingTimeoutMs +

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/rule/GatewayFlowRule.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/rule/GatewayFlowRule.java
@@ -25,6 +25,15 @@ import com.alibaba.csp.sentinel.slots.block.RuleConstant;
  * @since 1.6.0
  */
 public class GatewayFlowRule {
+    /**间隔单位*/
+    /**0-秒*/
+    public static final int INTERVAL_UNIT_SECOND = 0;
+    /**1-分*/
+    public static final int INTERVAL_UNIT_MINUTE = 1;
+    /**2-时*/
+    public static final int INTERVAL_UNIT_HOUR = 2;
+    /**3-天*/
+    public static final int INTERVAL_UNIT_DAY = 3;
 
     private String resource;
     private int resourceMode = SentinelGatewayConstants.RESOURCE_MODE_ROUTE_ID;
@@ -32,6 +41,8 @@ public class GatewayFlowRule {
     private int grade = RuleConstant.FLOW_GRADE_QPS;
     private double count;
     private long intervalSec = 1;
+    private Long interval;
+    private Integer intervalUnit;
 
     private int controlBehavior = RuleConstant.CONTROL_BEHAVIOR_DEFAULT;
     private int burst;
@@ -98,12 +109,42 @@ public class GatewayFlowRule {
     }
 
     public long getIntervalSec() {
+        if (interval != null && intervalUnit != null){
+            switch (intervalUnit) {
+                case INTERVAL_UNIT_SECOND:
+                    return interval;
+                case INTERVAL_UNIT_MINUTE:
+                    return interval * 60;
+                case INTERVAL_UNIT_HOUR:
+                    return interval * 60 * 60;
+                case INTERVAL_UNIT_DAY:
+                    return interval * 60 * 60 * 24;
+                default:
+                    break;
+            }
+        }
         return intervalSec;
     }
 
     public GatewayFlowRule setIntervalSec(long intervalSec) {
         this.intervalSec = intervalSec;
         return this;
+    }
+
+    public Long getInterval() {
+        return interval;
+    }
+
+    public void setInterval(Long interval) {
+        this.interval = interval;
+    }
+
+    public Integer getIntervalUnit() {
+        return intervalUnit;
+    }
+
+    public void setIntervalUnit(Integer intervalUnit) {
+        this.intervalUnit = intervalUnit;
     }
 
     public int getBurst() {


### PR DESCRIPTION
### Describe what this PR does / why we need it
解决从1.7.1 Tag Dashboard中的网关流控页面设置间隔时间存储至配置中心(如Apollo)并再次从配置中心读取时转换为GatewayFlowRule后丢失间隔时间的问题。

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
