### PR TITLE
Improve DefaultDubboFallback implementation(apache-dubbo-adapter).

### DIFF
--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/fallback/DefaultDubboFallback.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/fallback/DefaultDubboFallback.java
@@ -17,6 +17,7 @@ package com.alibaba.csp.sentinel.adapter.dubbo.fallback;
 
 import com.alibaba.csp.sentinel.slots.block.BlockException;
 
+import com.alibaba.csp.sentinel.slots.block.SentinelRpcException;
 import org.apache.dubbo.rpc.AsyncRpcResult;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
@@ -30,6 +31,6 @@ public class DefaultDubboFallback implements DubboFallback {
     @Override
     public Result handle(Invoker<?> invoker, Invocation invocation, BlockException ex) {
         // Just wrap the exception.
-        return AsyncRpcResult.newDefaultAsyncResult(ex.toRuntimeException(), invocation);
+        return AsyncRpcResult.newDefaultAsyncResult(new SentinelRpcException(ex.toRuntimeException()), invocation);
     }
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it
The caller cannot determine the type of runtime exception thrown.
I suggest the same way as sentinel-dubbo-adapter(dubbo-2.6.x).

### Does this pull request fix one issue?
#1252

