### PR TITLE
[feature #2145] Support GatewayFlowRule use multiple paramItem

### DIFF
--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/rule/GatewayFieldFlowItem.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/rule/GatewayFieldFlowItem.java
@@ -1,0 +1,90 @@
+package com.alibaba.csp.sentinel.adapter.gateway.common.rule;
+
+
+/**
+ * Special hotspot limit configuration for the gateway's personalized parameter field values
+ * @see com.alibaba.csp.sentinel.slots.block.flow.param.ParamFlowItem
+ * @author Renyansong
+ **/
+public class GatewayFieldFlowItem {
+
+    /**
+     * param value
+     */
+    private String object;
+
+    /**
+     * limit count
+     */
+    private Integer count;
+
+    /**
+     * param class type
+     */
+    private String classType;
+
+    public GatewayFieldFlowItem() {}
+
+    public GatewayFieldFlowItem(String object, Integer count, String classType) {
+        this.object = object;
+        this.count = count;
+        this.classType = classType;
+    }
+
+    public String getObject() {
+        return object;
+    }
+
+    public GatewayFieldFlowItem setObject(String object) {
+        this.object = object;
+        return this;
+    }
+
+    public Integer getCount() {
+        return count;
+    }
+
+    public GatewayFieldFlowItem setCount(Integer count) {
+        this.count = count;
+        return this;
+    }
+
+    public String getClassType() {
+        return classType;
+    }
+
+    public GatewayFieldFlowItem setClassType(String classType) {
+        this.classType = classType;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+
+        GatewayFieldFlowItem item = (GatewayFieldFlowItem)o;
+
+        if (object != null ? !object.equals(item.object) : item.object != null) { return false; }
+        if (count != null ? !count.equals(item.count) : item.count != null) { return false; }
+        return classType != null ? classType.equals(item.classType) : item.classType == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = object != null ? object.hashCode() : 0;
+        result = 31 * result + (count != null ? count.hashCode() : 0);
+        result = 31 * result + (classType != null ? classType.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "GatewayFieldFlowItem{" +
+                "object=" + object +
+                ", count=" + count +
+                ", classType='" + classType + '\'' +
+                '}';
+    }
+
+}

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/rule/GatewayParamFlowItem.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/rule/GatewayParamFlowItem.java
@@ -17,6 +17,8 @@ package com.alibaba.csp.sentinel.adapter.gateway.common.rule;
 
 import com.alibaba.csp.sentinel.adapter.gateway.common.SentinelGatewayConstants;
 
+import java.util.List;
+
 /**
  * @author Eric Zhao
  * @since 1.6.0
@@ -44,6 +46,11 @@ public class GatewayParamFlowItem {
      * Matching strategy for item value.
      */
     private int matchStrategy = SentinelGatewayConstants.PARAM_MATCH_STRATEGY_EXACT;
+
+    /**
+     * multiple param item flow rule.
+     */
+    private List<GatewayFieldFlowItem> gatewayFieldFlowItemList;
 
     public Integer getIndex() {
         return index;
@@ -88,6 +95,15 @@ public class GatewayParamFlowItem {
     public GatewayParamFlowItem setMatchStrategy(int matchStrategy) {
         this.matchStrategy = matchStrategy;
         return this;
+    }
+
+    public GatewayParamFlowItem setGatewayFieldFlowItemList(List<GatewayFieldFlowItem> gatewayFieldFlowItemList) {
+        this.gatewayFieldFlowItemList = gatewayFieldFlowItemList;
+        return this;
+    }
+
+    public List<GatewayFieldFlowItem> getGatewayFieldFlowItemList() {
+        return gatewayFieldFlowItemList;
     }
 
     @Override

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/rule/GatewayRuleConverter.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/rule/GatewayRuleConverter.java
@@ -20,6 +20,9 @@ import com.alibaba.csp.sentinel.slots.block.flow.FlowRule;
 import com.alibaba.csp.sentinel.slots.block.flow.param.ParamFlowItem;
 import com.alibaba.csp.sentinel.slots.block.flow.param.ParamFlowRule;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * @author Eric Zhao
  * @since 1.6.0
@@ -44,6 +47,16 @@ final class GatewayRuleConverter {
         return new ParamFlowItem().setClassType(String.class.getName())
             .setCount(0)
             .setObject(SentinelGatewayConstants.GATEWAY_NOT_MATCH_PARAM);
+    }
+
+    static List<ParamFlowItem> generateMatchedParamItem(List<GatewayFieldFlowItem> gatewayFieldFlowItemList) {
+        List<ParamFlowItem> paramFlowItemList = new ArrayList<>(gatewayFieldFlowItemList.size());
+        for (GatewayFieldFlowItem gatewayFieldFlowItem : gatewayFieldFlowItemList) {
+            paramFlowItemList.add(new ParamFlowItem().setClassType(gatewayFieldFlowItem.getClassType())
+                    .setCount(gatewayFieldFlowItem.getCount())
+                    .setObject(gatewayFieldFlowItem.getObject()));
+        }
+        return paramFlowItemList;
     }
 
     static ParamFlowRule applyNonParamToParamRule(/*@Valid*/ GatewayFlowRule gatewayRule, int idx) {
@@ -81,6 +94,10 @@ final class GatewayRuleConverter {
         String valuePattern = gatewayItem.getPattern();
         if (valuePattern != null) {
             paramRule.getParamFlowItemList().add(generateNonMatchPassParamItem());
+        }
+        // Apply the gateway field's flow param.
+        if (gatewayItem.getGatewayFieldFlowItemList() != null) {
+            paramRule.getParamFlowItemList().addAll(generateMatchedParamItem(gatewayItem.getGatewayFieldFlowItemList()));
         }
         return paramRule;
     }

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/common/rule/GatewayRuleConverterTest.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/common/rule/GatewayRuleConverterTest.java
@@ -19,13 +19,13 @@ import com.alibaba.csp.sentinel.adapter.gateway.common.SentinelGatewayConstants;
 import com.alibaba.csp.sentinel.slots.block.RuleConstant;
 import com.alibaba.csp.sentinel.slots.block.flow.FlowRule;
 import com.alibaba.csp.sentinel.slots.block.flow.param.ParamFlowRule;
-
 import org.junit.Test;
-
+import java.util.Arrays;
 import static org.junit.Assert.*;
 
 /**
  * @author Eric Zhao
+ * @author Renyansong
  */
 public class GatewayRuleConverterTest {
 
@@ -61,4 +61,70 @@ public class GatewayRuleConverterTest {
         assertEquals(idx, (int)paramRule.getParamIdx());
         assertEquals(idx, (int)routeRule1.getParamItem().getIndex());
     }
+
+    @Test
+    public void testConvertAndApplyToMultipleParamRule() {
+        GatewayFlowRule routeRule1 = new GatewayFlowRule("routeId1")
+                .setCount(2)
+                .setIntervalSec(2)
+                .setBurst(2)
+                .setParamItem(new GatewayParamFlowItem()
+                        .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_CLIENT_IP)
+                        .setGatewayFieldFlowItemList(
+                                Arrays.asList(
+                                        new GatewayFieldFlowItem()
+                                                .setClassType(String.class.getName())
+                                                .setCount(3)
+                                                .setObject("192.168.1.7"),
+                                        new GatewayFieldFlowItem()
+                                                .setClassType(String.class.getName())
+                                                .setCount(5)
+                                                .setObject("192.168.1.8")
+                                )
+                        )
+                );
+        int idx = 1;
+        ParamFlowRule paramRule1 = GatewayRuleConverter.applyToParamRule(routeRule1, idx);
+        assertEquals(routeRule1.getResource(), paramRule1.getResource());
+        assertEquals(routeRule1.getCount(), paramRule1.getCount(), 0.01);
+        assertEquals(routeRule1.getControlBehavior(), paramRule1.getControlBehavior());
+        assertEquals(routeRule1.getIntervalSec(), paramRule1.getDurationInSec());
+        assertEquals(routeRule1.getBurst(), paramRule1.getBurstCount());
+        assertEquals(idx, (int)paramRule1.getParamIdx());
+        assertEquals(idx, (int)routeRule1.getParamItem().getIndex());
+        assertEquals(routeRule1.getParamItem().getGatewayFieldFlowItemList().size(), paramRule1.getParamFlowItemList().size());
+
+        GatewayFlowRule routeRule2 = new GatewayFlowRule("routeId2")
+                .setCount(2)
+                .setIntervalSec(2)
+                .setBurst(2)
+                .setParamItem(new GatewayParamFlowItem()
+                        .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_HEADER)
+                        .setFieldName("X-Sentinel-Flag")
+                        .setMatchStrategy(SentinelGatewayConstants.PARAM_MATCH_STRATEGY_EXACT)
+                        .setGatewayFieldFlowItemList(
+                                Arrays.asList(
+                                        new GatewayFieldFlowItem()
+                                                .setClassType(String.class.getName())
+                                                .setCount(3)
+                                                .setObject("Flag1"),
+                                        new GatewayFieldFlowItem()
+                                                .setClassType(String.class.getName())
+                                                .setCount(5)
+                                                .setObject("Flag2")
+                                )
+                        )
+                );
+        ParamFlowRule paramRule2 = GatewayRuleConverter.applyToParamRule(routeRule2, idx);
+        assertEquals(routeRule2.getResource(), paramRule2.getResource());
+        assertEquals(routeRule2.getCount(), paramRule2.getCount(), 0.01);
+        assertEquals(routeRule2.getControlBehavior(), paramRule2.getControlBehavior());
+        assertEquals(routeRule2.getIntervalSec(), paramRule2.getDurationInSec());
+        assertEquals(routeRule2.getBurst(), paramRule2.getBurstCount());
+        assertEquals(idx, (int)paramRule2.getParamIdx());
+        assertEquals(idx, (int)routeRule2.getParamItem().getIndex());
+        assertEquals(routeRule2.getParamItem().getGatewayFieldFlowItemList().size(), paramRule2.getParamFlowItemList().size());
+
+    }
+
 }

--- a/sentinel-demo/sentinel-demo-zuul-gateway/src/main/java/com/alibaba/csp/sentinel/demo/zuul/gateway/GatewayRuleConfig.java
+++ b/sentinel-demo/sentinel-demo-zuul-gateway/src/main/java/com/alibaba/csp/sentinel/demo/zuul/gateway/GatewayRuleConfig.java
@@ -15,6 +15,8 @@
  */
 package com.alibaba.csp.sentinel.demo.zuul.gateway;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -25,6 +27,7 @@ import com.alibaba.csp.sentinel.adapter.gateway.common.api.ApiDefinition;
 import com.alibaba.csp.sentinel.adapter.gateway.common.api.ApiPathPredicateItem;
 import com.alibaba.csp.sentinel.adapter.gateway.common.api.ApiPredicateItem;
 import com.alibaba.csp.sentinel.adapter.gateway.common.api.GatewayApiDefinitionManager;
+import com.alibaba.csp.sentinel.adapter.gateway.common.rule.GatewayFieldFlowItem;
 import com.alibaba.csp.sentinel.adapter.gateway.common.rule.GatewayFlowRule;
 import com.alibaba.csp.sentinel.adapter.gateway.common.rule.GatewayParamFlowItem;
 import com.alibaba.csp.sentinel.adapter.gateway.common.rule.GatewayRuleManager;
@@ -70,13 +73,43 @@ public class GatewayRuleConfig {
             .setCount(10)
             .setIntervalSec(1)
         );
-        rules.add(new GatewayFlowRule("aliyun-product-route")
+        /*rules.add(new GatewayFlowRule("aliyun-product-route")
             .setCount(2)
-            .setIntervalSec(2)
-            .setBurst(2)
+            .setIntervalSec(5)
             .setParamItem(new GatewayParamFlowItem()
                 .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_CLIENT_IP)
+                .setGatewayFieldFlowItemList(Collections.singletonList(
+                                new GatewayFieldFlowItem()
+                                        .setClassType(String.class.getName())
+                                        .setCount(10)
+                                        .setObject("0:0:0:0:0:0:0:1")))
             )
+        );*/
+        // use http://localhost:8097/aliyun_product/1?testDemo=demo1
+        // then use http://localhost:8097/aliyun_product/1?testDemo=demo2
+        rules.add(new GatewayFlowRule("aliyun-product-route")
+                .setCount(2)
+                .setIntervalSec(10)
+                .setParamItem(new GatewayParamFlowItem()
+                        .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_URL_PARAM)
+                        .setFieldName("testDemo")
+                        .setPattern("demo")
+                        .setMatchStrategy(SentinelGatewayConstants.PARAM_MATCH_STRATEGY_CONTAINS)
+                        .setGatewayFieldFlowItemList(Collections.singletonList(
+                                new GatewayFieldFlowItem()
+                                        .setClassType(String.class.getName())
+                                        .setCount(4)
+                                        .setObject("demo2")))
+                )
+        );
+        rules.add(new GatewayFlowRule("aliyun-product-route")
+                .setCount(2)
+                .setIntervalSec(2)
+                .setBurst(2)
+                .setParamItem(new GatewayParamFlowItem()
+                        .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_HEADER)
+                        .setFieldName("X-Sentinel-Flag")
+                        .setMatchStrategy(SentinelGatewayConstants.PARAM_MATCH_STRATEGY_EXACT))
         );
         rules.add(new GatewayFlowRule("another-route-httpbin")
             .setCount(10)


### PR DESCRIPTION
issues #2145

### Describe what this PR does / why we need it

When we use the gateway current limiting, the current version does not support the use of personalized parameters in the current limiting configuration to apply to the personalized current limiting times.

### Does this pull request fix one issue?

yes.

### Describe how you did it

I just added a list parma for GatewayParamFlowItem.

### Describe how to verify it

I provided some unit tests (gateway rule convert to hotspot param rule).
And, I provide a demo for Zuul in some scenarios.

### Special notes for reviews
