### PR TITLE
增加metric过滤配置。

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/config/SentinelConfig.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/config/SentinelConfig.java
@@ -61,6 +61,7 @@ public final class SentinelConfig {
     public static final String STATISTIC_MAX_RT = "csp.sentinel.statistic.max.rt";
     public static final String SPI_CLASSLOADER = "csp.sentinel.spi.classloader";
     public static final String METRIC_FLUSH_INTERVAL = "csp.sentinel.metric.flush.interval";
+    public static final String METRIC_FILTER = "csp.sentinel.metric.filter";
 
     public static final String DEFAULT_CHARSET = "UTF-8";
     public static final long DEFAULT_SINGLE_METRIC_FILE_SIZE = 1024 * 1024 * 50;
@@ -68,6 +69,7 @@ public final class SentinelConfig {
     public static final int DEFAULT_COLD_FACTOR = 3;
     public static final int DEFAULT_STATISTIC_MAX_RT = 5000;
     public static final long DEFAULT_METRIC_FLUSH_INTERVAL = 1L;
+    public static final boolean DEFAULT_METRIC_FILTER = Boolean.FALSE;
 
     static {
         try {
@@ -208,6 +210,16 @@ public final class SentinelConfig {
             RecordLog.warn("[SentinelConfig] Parse singleMetricFileSize fail, use default value: "
                     + DEFAULT_SINGLE_METRIC_FILE_SIZE, throwable);
             return DEFAULT_SINGLE_METRIC_FILE_SIZE;
+        }
+    }
+
+    public static boolean shouldFilterMetric() {
+        try {
+            return Boolean.parseBoolean(props.get(METRIC_FILTER)) || Boolean.parseBoolean(System.getProperty(METRIC_FILTER));
+        } catch (Throwable throwable) {
+            RecordLog.warn("[SentinelConfig] Parse shouldFilterMetric fail, use default value: "
+                    + DEFAULT_METRIC_FILTER, throwable);
+            return DEFAULT_METRIC_FILTER;
         }
     }
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/metric/MetricTimerListener.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/metric/MetricTimerListener.java
@@ -26,6 +26,7 @@ import com.alibaba.csp.sentinel.config.SentinelConfig;
 import com.alibaba.csp.sentinel.log.RecordLog;
 import com.alibaba.csp.sentinel.node.ClusterNode;
 import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
+import com.alibaba.csp.sentinel.slots.RuleProvider;
 import com.alibaba.csp.sentinel.slots.clusterbuilder.ClusterBuilderSlot;
 
 /**
@@ -40,9 +41,13 @@ public class MetricTimerListener implements Runnable {
     public void run() {
         Map<Long, List<MetricNode>> maps = new TreeMap<>();
         for (Entry<ResourceWrapper, ClusterNode> e : ClusterBuilderSlot.getClusterNodeMap().entrySet()) {
-            ClusterNode node = e.getValue();
-            Map<Long, MetricNode> metrics = node.metrics();
-            aggregate(maps, metrics, node);
+            if (SentinelConfig.shouldFilterMetric() && RuleProvider.isNotInRules(e.getValue().getName())) {
+                RecordLog.debug("[MetricTimerListener] Metric filter by config ", e.getValue().getName());
+            } else {
+                ClusterNode node = e.getValue();
+                Map<Long, MetricNode> metrics = node.metrics();
+                aggregate(maps, metrics, node);
+            }
         }
         aggregate(maps, Constants.ENTRY_NODE.metrics(), Constants.ENTRY_NODE);
         if (!maps.isEmpty()) {

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/RuleProvider.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/RuleProvider.java
@@ -1,0 +1,48 @@
+package com.alibaba.csp.sentinel.slots;
+
+import com.alibaba.csp.sentinel.slots.block.AbstractRule;
+import com.alibaba.csp.sentinel.slots.block.authority.AuthorityRule;
+import com.alibaba.csp.sentinel.slots.block.authority.AuthorityRuleManager;
+import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRule;
+import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRuleManager;
+import com.alibaba.csp.sentinel.slots.block.flow.FlowRule;
+import com.alibaba.csp.sentinel.slots.block.flow.FlowRuleManager;
+import com.alibaba.csp.sentinel.slots.system.SystemRule;
+import com.alibaba.csp.sentinel.slots.system.SystemRuleManager;
+import com.alibaba.csp.sentinel.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RuleProvider {
+
+    public static List<AbstractRule> getAllRule() {
+        List<AuthorityRule> authorityRules = AuthorityRuleManager.getRules();
+        List<DegradeRule> degradeRules = DegradeRuleManager.getRules();
+        List<FlowRule> flowRules = FlowRuleManager.getRules();
+        List<SystemRule> systemRules = SystemRuleManager.getRules();
+
+        List<AbstractRule> allRules = new ArrayList<>();
+        allRules.addAll(authorityRules);
+        allRules.addAll(degradeRules);
+        allRules.addAll(flowRules);
+        allRules.addAll(systemRules);
+
+        return allRules;
+    }
+
+    public static boolean isInRules(String resource) {
+        List<AbstractRule> allRules = getAllRule();
+        for (AbstractRule abstractRule : allRules) {
+            if (StringUtil.equals(abstractRule.getResource(), resource)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static boolean isNotInRules(String resource) {
+        return !isInRules(resource);
+    }
+}

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/config/SentinelConfigTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/config/SentinelConfigTest.java
@@ -11,6 +11,8 @@ import java.io.IOException;
 import static com.alibaba.csp.sentinel.config.SentinelConfig.*;
 import static com.alibaba.csp.sentinel.util.ConfigUtil.addSeparator;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test cases for {@link SentinelConfig}.
@@ -67,6 +69,17 @@ public class SentinelConfigTest {
         assertEquals(4, SentinelConfig.coldFactor());
     }
 
+    @Test
+    public void testShouldFilterMetric() {
+        assertFalse(SentinelConfig.shouldFilterMetric());
+
+        System.setProperty(METRIC_FILTER, "true");
+        assertTrue(SentinelConfig.shouldFilterMetric());
+
+        SentinelConfig.setConfig(METRIC_FILTER, "true");
+        assertTrue(SentinelConfig.shouldFilterMetric());
+    }
+
 
     //add Jvm parameter
     //-Dcsp.sentinel.config.file=classpath:sentinel-propertiesTest.properties
@@ -97,12 +110,12 @@ public class SentinelConfigTest {
             out.flush();
             out.close();
 
-            Assert.assertTrue(SentinelConfig.getConfig(CHARSET).equals("utf-8"));
-            Assert.assertTrue(SentinelConfig.getConfig(SINGLE_METRIC_FILE_SIZE).equals("1000"));
-            Assert.assertTrue(SentinelConfig.getConfig(TOTAL_METRIC_FILE_COUNT).equals("20"));
-            Assert.assertTrue(SentinelConfig.getConfig(COLD_FACTOR).equals("5"));
-            Assert.assertTrue(SentinelConfig.getConfig(STATISTIC_MAX_RT).equals("1000"));
-            Assert.assertTrue(SentinelConfig.getAppName().equals("sentinel_test"));
+            assertEquals("utf-8", getConfig(CHARSET));
+            assertTrue(SentinelConfig.getConfig(SINGLE_METRIC_FILE_SIZE).equals("1000"));
+            assertTrue(SentinelConfig.getConfig(TOTAL_METRIC_FILE_COUNT).equals("20"));
+            assertTrue(SentinelConfig.getConfig(COLD_FACTOR).equals("5"));
+            assertTrue(SentinelConfig.getConfig(STATISTIC_MAX_RT).equals("1000"));
+            assertTrue(SentinelConfig.getAppName().equals("sentinel_test"));
 
         } finally {
             if (file != null) {

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/RuleProviderTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/RuleProviderTest.java
@@ -1,0 +1,29 @@
+package com.alibaba.csp.sentinel.slots;
+
+import com.alibaba.csp.sentinel.slots.block.flow.FlowRule;
+import com.alibaba.csp.sentinel.slots.block.flow.FlowRuleManager;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+
+public class RuleProviderTest {
+
+    @Test
+    public void testIsInRules() {
+        assertFalse(RuleProvider.isInRules("testResource"));
+    }
+
+    @Test
+    public void testNotIsInRules() {
+        List<FlowRule> rules = new ArrayList<>();
+        FlowRule flowRule = new FlowRule();
+        flowRule.setResource("newResource");
+        rules.add(flowRule);
+        FlowRuleManager.loadRules(rules);
+        assertFalse(RuleProvider.isNotInRules("newResource"));
+    }
+
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
We are using sentinel, while we collected the metric, we found that all request will be recorded in the **metric.log. In our scenes, we hope the resource those are not in our rules may not be recorded, in case to reduce metrics.
The code of this PR is used in my company.
我们公司当前正在使用sentinel，我们发现在收集metric的时候，所有的请求都会被统计在 metric.log中，不论资源是否是限流或者熔断或者是未配置的资源。
我们希望有配置能够让非配置的资源不进入metric统计，来实现减少metric的目标。当前统计所有接口的话metric实在太多了。
本次PR的修改内容，已经在本公司生产环境使用。

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #2169 

### Describe how you did it
Add 'csp.sentinel.metric.filter' in SentinelConfig, and use the config to decide whether to filter them while write into the metric.log.
增加”csp.sentinel.metric.filter”配置，在写入metric到metric.log的时候通过该配置来决定是否写入非资源配置的metric。

### Describe how to verify it
Start the app and add '-Dcsp.sentinel.metric.filter=true', then the metric whose resource names are not in rules(degrade rules, flow rules and so on) will not saved in the metric.log file.
启动app的时候增加“-Dcsp.sentinel.metric.filter=true”配置，不在规则配置中的资源，它们的metric将不会记录在metric.log文件中。

### Special notes for reviews
The PR only support AuthorityRule, DegradeRule, FlowRule and SystemRule. Because the other RuleManagers are  implemented in extended modules. The APIs of RuleManagers are static methods, there is not a way to fetch all rules. I figure out two ways to support the other rules, but both of them are not graceful.
1. The extended RuleManagers inject their rules into the RuleProvider while their rules are loaded or updated. It is a complex job to finished by other deveplers. 
2. In RuleProvider, we use Reflection to get rules from the extended RuleManagers. It is inefficient and hard to understand.

本次PR仅支持AuthorityRule, DegradeRule, FlowRule and SystemRule四种规则。因为其他的RuleManagers都是在扩展模块中实现，在sentinel-core中不能直接访问它们。当前的规则管理器的方式使用静态方法管理，没有归属容器管理，没有一种获取所有规则的方式。我想到两种方法来支持所有规则，但是都不够优雅。
1. 在扩展的RuleManagers逻辑中，自行将自己的规则写入到RuleProvider中。这种方式写起来繁琐。
2. 在RuleProvider中，使用反射来获取扩展模块中的RuleManagers的内容。这种方式效率低下且晦涩难懂。
同时我发现现有的FetchActiveRuleCommandHandler也仅支持上述四种规则，我想我们需要一种容器化管理所有规则的实现，再在过滤器的实现中支持所有规则。
