### PR TITLE
:apple:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,6 +324,19 @@
 
     <profiles>
         <profile>
+            <id>apple silicon</id>
+            <activation>
+                <os>
+                    <name>Mac OS X</name>
+                    <family>unix</family>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <properties>
+                <os.detected.classifier>osx-x86_64</os.detected.classifier>
+            </properties>
+        </profile>
+        <profile>
             <id>oss</id>
             <build>
                 <plugins>


### PR DESCRIPTION
mac m1 处理器的笔记本，maven 构建时，google protoful 插件基于系统类型来选择涉及系统的版本
但涉及的相关插件，目前还未提供基于 apple silicon 系统架构的版本。
因此，基于操作系统环境识别的机制，延用基于 intel 平台的 mac 架构的相关插件版本