### PR TITLE
Remove duplicate jar dependencies(aspectjweaver contains aspectjrt)

### DIFF
--- a/sentinel-extension/sentinel-annotation-aspectj/pom.xml
+++ b/sentinel-extension/sentinel-annotation-aspectj/pom.xml
@@ -26,11 +26,6 @@
 
         <dependency>
             <groupId>org.aspectj</groupId>
-            <artifactId>aspectjrt</artifactId>
-            <version>${aspectj.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.aspectj</groupId>
             <artifactId>aspectjweaver</artifactId>
             <version>${aspectj.version}</version>
         </dependency>


### PR DESCRIPTION
### Describe what this PR does / why we need it
存在重复的包依赖和传递, aspectjweaver.jar 包含了aspectjrt.jar.

传递到用户端，重复class分析结果
Found duplicate classes in below class path:
1  (1@2): ./aspectjweaver-1.9.6.jar ./aspectjrt-1.9.6.jar

