### PR TITLE
Modify sentinel-demo-log-logback/pom.xml: remove :RELEASE version and use the latest specific version instead

### DIFF
--- a/sentinel-demo/sentinel-demo-log-logback/pom.xml
+++ b/sentinel-demo/sentinel-demo-log-logback/pom.xml
@@ -37,7 +37,8 @@
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>
             <artifactId>system-rules</artifactId>
-            <version>RELEASE</version>
+			<!--<version>RELEASE</version> -->
+            <version>1.19.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
We noticed that there was a point of improvement in this project.
In a pom.xml file, we see that there is a dependency with version :RELEASE. This means that every time the project is built, the dependency needs to find the latest version, which increases the cost of the build, so we replace it with the latest specific version, which is modified as follows:

Relative path: Sentinel/sentinel-demo/sentinel-demo-log-logback/pom.xml
dependency: {Name: com.github.stefanbirkner/system-rules, Version Specifier: RELEASE }  -------> 1.19.0