### PR TITLE
Bugfix 2344 FlowPropertyListener中的configUpdate需要优化

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleUtil.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleUtil.java
@@ -28,7 +28,6 @@ import com.alibaba.csp.sentinel.util.function.Predicate;
 
 import java.util.*;
 import java.util.Map.Entry;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author Eric Zhao
@@ -82,11 +81,11 @@ public final class FlowRuleUtil {
      */
     public static <K> Map<K, List<FlowRule>> buildFlowRuleMap(List<FlowRule> list, Function<FlowRule, K> groupFunction,
                                                               Predicate<FlowRule> filter, boolean shouldSort) {
-        Map<K, List<FlowRule>> newRuleMap = new ConcurrentHashMap<>();
+        Map<K, List<FlowRule>> newRuleMap = new HashMap<>();
         if (list == null || list.isEmpty()) {
             return newRuleMap;
         }
-        Map<K, Set<FlowRule>> tmpMap = new ConcurrentHashMap<>();
+        Map<K, Set<FlowRule>> tmpMap = new HashMap<>();
 
         for (FlowRule rule : list) {
             if (!isValidRule(rule)) {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

FlowPropertyListener中方法已经使用了synchronized，FlowRuleUtil.buildFlowRuleMap(value); 是否还有必要返回ConcurrentHashMap？。
并且flowRules是hashMap。在方法中被莫名其妙的替换成了ConcurrentHashMap类型。

### Does this pull request fix one issue?
yeah
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Fixes #2344 

### Describe how to verify it

1、排查工具方法的使用范围仅为当前指定的文件
2、将工具类中ConcurrentHashMap替换为HashMap

### Special notes for reviews
