### PR TITLE
Bugfix 2374 Param args missing in fireExit of StatisticSlot | StatisticSlot fireExit 参数传递丢失 args 

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleUtil.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleUtil.java
@@ -28,7 +28,6 @@ import com.alibaba.csp.sentinel.util.function.Predicate;
 
 import java.util.*;
 import java.util.Map.Entry;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author Eric Zhao
@@ -82,11 +81,11 @@ public final class FlowRuleUtil {
      */
     public static <K> Map<K, List<FlowRule>> buildFlowRuleMap(List<FlowRule> list, Function<FlowRule, K> groupFunction,
                                                               Predicate<FlowRule> filter, boolean shouldSort) {
-        Map<K, List<FlowRule>> newRuleMap = new ConcurrentHashMap<>();
+        Map<K, List<FlowRule>> newRuleMap = new HashMap<>();
         if (list == null || list.isEmpty()) {
             return newRuleMap;
         }
-        Map<K, Set<FlowRule>> tmpMap = new ConcurrentHashMap<>();
+        Map<K, Set<FlowRule>> tmpMap = new HashMap<>();
 
         for (FlowRule rule : list) {
             if (!isValidRule(rule)) {

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/StatisticSlot.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/StatisticSlot.java
@@ -15,22 +15,22 @@
  */
 package com.alibaba.csp.sentinel.slots.statistic;
 
-import java.util.Collection;
-
-import com.alibaba.csp.sentinel.node.Node;
-import com.alibaba.csp.sentinel.slotchain.ProcessorSlotEntryCallback;
-import com.alibaba.csp.sentinel.slotchain.ProcessorSlotExitCallback;
-import com.alibaba.csp.sentinel.slots.block.flow.PriorityWaitException;
-import com.alibaba.csp.sentinel.spi.Spi;
-import com.alibaba.csp.sentinel.util.TimeUtil;
 import com.alibaba.csp.sentinel.Constants;
 import com.alibaba.csp.sentinel.EntryType;
 import com.alibaba.csp.sentinel.context.Context;
 import com.alibaba.csp.sentinel.node.ClusterNode;
 import com.alibaba.csp.sentinel.node.DefaultNode;
+import com.alibaba.csp.sentinel.node.Node;
 import com.alibaba.csp.sentinel.slotchain.AbstractLinkedProcessorSlot;
+import com.alibaba.csp.sentinel.slotchain.ProcessorSlotEntryCallback;
+import com.alibaba.csp.sentinel.slotchain.ProcessorSlotExitCallback;
 import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
+import com.alibaba.csp.sentinel.slots.block.flow.PriorityWaitException;
+import com.alibaba.csp.sentinel.spi.Spi;
+import com.alibaba.csp.sentinel.util.TimeUtil;
+
+import java.util.Collection;
 
 /**
  * <p>
@@ -148,7 +148,7 @@ public class StatisticSlot extends AbstractLinkedProcessorSlot<DefaultNode> {
             handler.onExit(context, resourceWrapper, count, args);
         }
 
-        fireExit(context, resourceWrapper, count);
+        fireExit(context, resourceWrapper, count, args);
     }
 
     private void recordCompleteFor(Node node, int batchCount, long rt, Throwable error) {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Param args missing in fireExit of StatisticSlot | StatisticSlot fireExit 参数传递丢失 args #2374

这里slot销毁本身可以传递参数，省了麻烦

### Does this pull request fix one issue?
yeah
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #2374 
### Describe how you did it

修改src\main\java\com\alibaba\csp\sentinel\slots\statistic\StatisticSlot.java第152行，为fireExit添加参数args，接口本身支持，其他不做调整

### Describe how to verify it


### Special notes for reviews
