### PR TITLE
Add Sentinel filter to handler UndeclaredThrowableException

### DIFF
--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/SentinelWebMvcFilter.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/SentinelWebMvcFilter.java
@@ -1,0 +1,99 @@
+package com.alibaba.csp.sentinel.adapter.spring.webmvc;
+
+
+import com.alibaba.csp.sentinel.adapter.spring.webmvc.config.BaseWebMvcConfig;
+import com.alibaba.csp.sentinel.adapter.spring.webmvc.config.SentinelWebMvcConfig;
+import com.alibaba.csp.sentinel.annotation.SentinelResource;
+import com.alibaba.csp.sentinel.slots.block.BlockException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.context.support.WebApplicationContextUtils;
+import org.springframework.web.util.NestedServletException;
+
+import javax.annotation.Resource;
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.lang.reflect.UndeclaredThrowableException;
+
+/**
+ * SentinelWebMvcFilter
+ * <p>
+ * When the {@link SentinelResource} annotation is configured, and the BlockHandler and FallbackHandler are not configured,
+ * the {@link BlockException} will be directly thrown.
+ * This exception will be wrapped into {@link UndeclaredThrowableException}, and the interface will return a 500 (INTERNAL_SERVER_ERROR) exception.
+ * The filter logic is Handle {@link UndeclaredThrowableException} and use the BlockExceptionHandler configured by
+ * {@link BaseWebMvcConfig} to return the default status code
+ *
+ * @author idefav
+ */
+public class SentinelWebMvcFilter implements Filter {
+    @Resource
+    @Lazy
+    private volatile BaseWebMvcConfig baseWebMvcConfig;
+
+    @Override
+    public void init(FilterConfig filterConfig) {
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        try {
+            filterChain.doFilter(servletRequest, servletResponse);
+        } catch (NestedServletException | UndeclaredThrowableException e) {
+            BlockException blockException = null;
+            if (e instanceof NestedServletException && e.getCause() instanceof UndeclaredThrowableException
+                    && (((UndeclaredThrowableException) e.getCause()).getUndeclaredThrowable() instanceof BlockException)) {
+                UndeclaredThrowableException undeclaredThrowableException = (UndeclaredThrowableException) e.getCause();
+                blockException = (BlockException) undeclaredThrowableException.getUndeclaredThrowable();
+            }
+            if (e instanceof UndeclaredThrowableException
+                    && ((UndeclaredThrowableException) e).getUndeclaredThrowable() instanceof BlockException) {
+                blockException = (BlockException) ((UndeclaredThrowableException) e).getUndeclaredThrowable();
+            }
+
+            if (ObjectUtils.isEmpty(blockException)) {
+                throw e;
+            }
+            handleBlockException((HttpServletRequest) servletRequest, (HttpServletResponse) servletResponse, blockException);
+
+        }
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+
+    private BaseWebMvcConfig getWebMvcConfig(ServletRequest servletRequest) {
+        if (baseWebMvcConfig == null) {
+            synchronized (this) {
+                if (baseWebMvcConfig == null) {
+                    ServletContext context = servletRequest.getServletContext();
+                    ApplicationContext ctx = WebApplicationContextUtils.getWebApplicationContext(context);
+                    if (ctx != null) {
+                        baseWebMvcConfig = ctx.getBean(SentinelWebMvcConfig.class);
+                    }
+                }
+            }
+        }
+        return baseWebMvcConfig;
+
+    }
+
+    protected void handleBlockException(HttpServletRequest request, HttpServletResponse response, BlockException e) {
+        BaseWebMvcConfig webMvcConfig = getWebMvcConfig(request);
+        if (webMvcConfig.getBlockExceptionHandler() != null) {
+            try {
+                webMvcConfig.getBlockExceptionHandler().handle(request, response, e);
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            }
+        } else {
+            throw new RuntimeException(e);
+        }
+    }
+
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
* Describe
When using the `@SentinelResource` annotation, blockExceptions are thrown if BlockHandler and FallbackHandler are not configured `@SentinelResource` is realized through AOP, BlockException is a checked exception, will be AOP wrapped into UndeclaredThrowableException by default Finally, the interface returns a 500 error, as shown in the figure:
![image](https://user-images.githubusercontent.com/6405415/134851079-a2d9ed11-b0c5-4621-a6b1-8a3b4bd646c6.png)

You might say that you need to configure a Handler to handle blockExceptions, but sometimes, if you don't want to configure a Handler, you need to default to a 429 status code.

The problem with this is that if the business interface fails, it will also be 500 errors, making it impossible to distinguish between Blocked and a business error.

* Solution:

By adding a Servlet Filter to handle `UndeclaredThrowableException`.

* How to use:
```java
 @Bean
    public SentinelWebMvcFilter webMvcFilter() {
        return new SentinelWebMvcFilter();
    }

    @Bean
    public FilterRegistrationBean registFilter(SentinelWebMvcFilter filter) {
        FilterRegistrationBean registration = new FilterRegistrationBean();
        registration.setFilter(filter);
        registration.addUrlPatterns("/*");
        registration.setName("sentinelFilter");
        registration.setOrder(1);
        return registration;
    }
```
The final result is shown as follows:
![image](https://user-images.githubusercontent.com/6405415/134851678-4c5fd514-3656-4c81-bf6e-d0692866646f.png)

