### PR TITLE
refactor: use diamond operator

### DIFF
--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/api/GatewayApiDefinitionManager.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/api/GatewayApiDefinitionManager.java
@@ -115,7 +115,7 @@ public final class GatewayApiDefinitionManager {
         private static synchronized void applyApiUpdateInternal(Set<ApiDefinition> set) {
             if (set == null || set.isEmpty()) {
                 API_MAP.clear();
-                notifyDownstreamListeners(new HashSet<ApiDefinition>());
+                notifyDownstreamListeners(new HashSet<>());
                 return;
             }
             Map<String, ApiDefinition> map = new HashMap<>(set.size());

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/rule/GatewayRuleManager.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/rule/GatewayRuleManager.java
@@ -178,7 +178,7 @@ public final class GatewayRuleManager {
 
         private synchronized void applyGatewayRuleInternal(Set<GatewayFlowRule> conf) {
             if (conf == null || conf.isEmpty()) {
-                applyToConvertedParamMap(new HashSet<ParamFlowRule>());
+                applyToConvertedParamMap(new HashSet<>());
                 GATEWAY_RULE_MAP.clear();
                 return;
             }

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/GatewayParamParserTest.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/GatewayParamParserTest.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.Set;
 
 import com.alibaba.csp.sentinel.adapter.gateway.common.SentinelGatewayConstants;
-import com.alibaba.csp.sentinel.adapter.gateway.common.api.ApiDefinition;
 import com.alibaba.csp.sentinel.adapter.gateway.common.api.GatewayApiDefinitionManager;
 import com.alibaba.csp.sentinel.adapter.gateway.common.rule.GatewayFlowRule;
 import com.alibaba.csp.sentinel.adapter.gateway.common.rule.GatewayParamFlowItem;
@@ -335,15 +334,15 @@ public class GatewayParamParserTest {
 
     @Before
     public void setUp() {
-        GatewayApiDefinitionManager.loadApiDefinitions(new HashSet<ApiDefinition>());
-        GatewayRuleManager.loadRules(new HashSet<GatewayFlowRule>());
+        GatewayApiDefinitionManager.loadApiDefinitions(new HashSet<>());
+        GatewayRuleManager.loadRules(new HashSet<>());
         GatewayRegexCache.clear();
     }
 
     @After
     public void tearDown() {
-        GatewayApiDefinitionManager.loadApiDefinitions(new HashSet<ApiDefinition>());
-        GatewayRuleManager.loadRules(new HashSet<GatewayFlowRule>());
+        GatewayApiDefinitionManager.loadApiDefinitions(new HashSet<>());
+        GatewayRuleManager.loadRules(new HashSet<>());
         GatewayRegexCache.clear();
     }
 }

--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/common/rule/GatewayRuleManagerTest.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/common/rule/GatewayRuleManagerTest.java
@@ -105,11 +105,11 @@ public class GatewayRuleManagerTest {
 
     @Before
     public void setUp() {
-        GatewayRuleManager.loadRules(new HashSet<GatewayFlowRule>());
+        GatewayRuleManager.loadRules(new HashSet<>());
     }
 
     @After
     public void tearDown() {
-        GatewayRuleManager.loadRules(new HashSet<GatewayFlowRule>());
+        GatewayRuleManager.loadRules(new HashSet<>());
     }
 }

--- a/sentinel-adapter/sentinel-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/DubboUtilsTest.java
+++ b/sentinel-adapter/sentinel-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/DubboUtilsTest.java
@@ -17,7 +17,7 @@ public class DubboUtilsTest {
     @Test
     public void testGetApplication() {
         Invocation invocation = mock(Invocation.class);
-        when(invocation.getAttachments()).thenReturn(new HashMap<String, String>());
+        when(invocation.getAttachments()).thenReturn(new HashMap<>());
         when(invocation.getAttachment(DubboUtils.DUBBO_APPLICATION_KEY, "")).thenReturn("consumerA");
 
         String application = DubboUtils.getApplication(invocation, "");

--- a/sentinel-adapter/sentinel-quarkus-adapter/sentinel-annotation-quarkus-adapter-deployment/src/test/java/com/alibaba/csp/sentinel/adapter/quarkus/annotation/deployment/SentinelAnnotationQuarkusAdapterTest.java
+++ b/sentinel-adapter/sentinel-quarkus-adapter/sentinel-annotation-quarkus-adapter-deployment/src/test/java/com/alibaba/csp/sentinel/adapter/quarkus/annotation/deployment/SentinelAnnotationQuarkusAdapterTest.java
@@ -56,13 +56,13 @@ public class SentinelAnnotationQuarkusAdapterTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        FlowRuleManager.loadRules(new ArrayList<FlowRule>());
+        FlowRuleManager.loadRules(new ArrayList<>());
         ClusterBuilderSlot.resetClusterNodes();
     }
 
     @AfterEach
     public void tearDown() throws Exception {
-        FlowRuleManager.loadRules(new ArrayList<FlowRule>());
+        FlowRuleManager.loadRules(new ArrayList<>());
         ClusterBuilderSlot.resetClusterNodes();
     }
 

--- a/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/handler/TokenClientPromiseHolder.java
+++ b/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/handler/TokenClientPromiseHolder.java
@@ -32,7 +32,7 @@ public final class TokenClientPromiseHolder {
     private static final Map<Integer, SimpleEntry<ChannelPromise, ClusterResponse>> PROMISE_MAP = new ConcurrentHashMap<>();
 
     public static void putPromise(int xid, ChannelPromise promise) {
-        PROMISE_MAP.put(xid, new SimpleEntry<ChannelPromise, ClusterResponse>(promise, null));
+        PROMISE_MAP.put(xid, new SimpleEntry<>(promise, null));
     }
 
     public static SimpleEntry<ChannelPromise, ClusterResponse> getEntry(int xid) {

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/rule/ClusterFlowRuleManager.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/rule/ClusterFlowRuleManager.java
@@ -260,7 +260,7 @@ public final class ClusterFlowRuleManager {
     }
 
     private static void resetNamespaceFlowIdMapFor(/*@Valid*/ String namespace) {
-        NAMESPACE_FLOW_ID_MAP.put(namespace, new HashSet<Long>());
+        NAMESPACE_FLOW_ID_MAP.put(namespace, new HashSet<>());
     }
 
     /**

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/rule/ClusterParamFlowRuleManager.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/rule/ClusterParamFlowRuleManager.java
@@ -185,7 +185,7 @@ public final class ClusterParamFlowRuleManager {
     }
 
     private static void resetNamespaceFlowIdMapFor(/*@Valid*/ String namespace) {
-        NAMESPACE_FLOW_ID_MAP.put(namespace, new HashSet<Long>());
+        NAMESPACE_FLOW_ID_MAP.put(namespace, new HashSet<>());
     }
 
     private static void clearAndResetRulesFor(/*@Valid*/ String namespace) {

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/statistic/ClusterMetricNodeGenerator.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/statistic/ClusterMetricNodeGenerator.java
@@ -95,7 +95,7 @@ public class ClusterMetricNodeGenerator {
             return new ClusterMetricNode().setFlowId(flowId)
                 .setResourceName(rule.getResource())
                 .setTimestamp(TimeUtil.currentTimeMillis())
-                .setTopParams(new HashMap<Object, Double>(0));
+                .setTopParams(new HashMap<>(0));
         }
         return new ClusterMetricNode()
             .setFlowId(flowId)

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/statistic/concurrent/CurrentConcurrencyManager.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/statistic/concurrent/CurrentConcurrencyManager.java
@@ -38,7 +38,7 @@ public final class CurrentConcurrencyManager {
     /**
      * use ConcurrentHashMap to store the nowCalls of rules.
      */
-    private static final ConcurrentHashMap<Long, AtomicInteger> NOW_CALLS_MAP = new ConcurrentHashMap<Long, AtomicInteger>();
+    private static final ConcurrentHashMap<Long, AtomicInteger> NOW_CALLS_MAP = new ConcurrentHashMap<>();
 
     @SuppressWarnings("PMD.ThreadPoolCreationRule")
     private static final ScheduledExecutorService SCHEDULER = Executors.newScheduledThreadPool(1,

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/statistic/metric/ClusterParamMetric.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/statistic/metric/ClusterParamMetric.java
@@ -118,7 +118,7 @@ public class ClusterParamMetric {
             }
         });
 
-        Map<Object, Double> doubleResult = new HashMap<Object, Double>();
+        Map<Object, Double> doubleResult = new HashMap<>();
 
         int size = list.size() > number ? number : list.size();
         for (int i = 0; i < size; i++) {

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/NettyTransportServer.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/NettyTransportServer.java
@@ -168,7 +168,7 @@ public class NettyTransportServer implements ClusterTokenServer {
     }
 
     public List<String> listAllClient() {
-        List<String> clients = new ArrayList<String>();
+        List<String> clients = new ArrayList<>();
         List<Connection> connections = connectionPool.listAllConnection();
         for (Connection conn : connections) {
             clients.add(conn.getConnectionKey());

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/connection/ConnectionGroup.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/connection/ConnectionGroup.java
@@ -34,7 +34,7 @@ public class ConnectionGroup {
 
     private final String namespace;
 
-    private final Set<ConnectionDescriptor> connectionSet = Collections.synchronizedSet(new HashSet<ConnectionDescriptor>());
+    private final Set<ConnectionDescriptor> connectionSet = Collections.synchronizedSet(new HashSet<>());
     private final AtomicInteger connectedCount = new AtomicInteger();
 
     public ConnectionGroup(String namespace) {

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/connection/ConnectionPool.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/connection/ConnectionPool.java
@@ -44,7 +44,7 @@ public class ConnectionPool {
     /**
      * Format: ("ip:port", connection)
      */
-    private final Map<String, Connection> CONNECTION_MAP = new ConcurrentHashMap<String, Connection>();
+    private final Map<String, Connection> CONNECTION_MAP = new ConcurrentHashMap<>();
 
     /**
      * Periodic scan task.
@@ -110,7 +110,7 @@ public class ConnectionPool {
     }
 
     public List<Connection> listAllConnection() {
-        List<Connection> connections = new ArrayList<Connection>(CONNECTION_MAP.values());
+        List<Connection> connections = new ArrayList<>(CONNECTION_MAP.values());
         return connections;
     }
 

--- a/sentinel-cluster/sentinel-cluster-server-default/src/test/java/com/alibaba/csp/sentinel/cluster/flow/statistic/metric/ClusterParamMetricTest.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/test/java/com/alibaba/csp/sentinel/cluster/flow/statistic/metric/ClusterParamMetricTest.java
@@ -27,7 +27,7 @@ public class ClusterParamMetricTest extends AbstractTimeBasedTest {
     @Test
     public void testClusterParamMetric() {
         setCurrentMillis(System.currentTimeMillis());
-        Map<Object, Double> topMap = new HashMap<Object, Double>();
+        Map<Object, Double> topMap = new HashMap<>();
         ClusterParamMetric metric = new ClusterParamMetric(5, 25, 100);
         metric.addValue("e1", -1);
         metric.addValue("e1", -2);

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/CtSph.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/CtSph.java
@@ -49,7 +49,7 @@ public class CtSph implements Sph {
      * {@link ProcessorSlotChain}, no matter in which {@link Context}.
      */
     private static volatile Map<ResourceWrapper, ProcessorSlotChain> chainMap
-        = new HashMap<ResourceWrapper, ProcessorSlotChain>();
+        = new HashMap<>();
 
     private static final Object LOCK = new Object();
 
@@ -203,7 +203,7 @@ public class CtSph implements Sph {
                     }
 
                     chain = SlotChainProvider.newSlotChain();
-                    Map<ResourceWrapper, ProcessorSlotChain> newMap = new HashMap<ResourceWrapper, ProcessorSlotChain>(
+                    Map<ResourceWrapper, ProcessorSlotChain> newMap = new HashMap<>(
                         chainMap.size() + 1);
                     newMap.putAll(chainMap);
                     newMap.put(resourceWrapper, chain);

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/cluster/ClusterStateManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/cluster/ClusterStateManager.java
@@ -44,7 +44,7 @@ public final class ClusterStateManager {
     private static volatile int mode = CLUSTER_NOT_STARTED;
     private static volatile long lastModified = -1;
 
-    private static volatile SentinelProperty<Integer> stateProperty = new DynamicSentinelProperty<Integer>();
+    private static volatile SentinelProperty<Integer> stateProperty = new DynamicSentinelProperty<>();
     private static final PropertyListener<Integer> PROPERTY_LISTENER = new ClusterStatePropertyListener();
 
     static {

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/eagleeye/EagleEyeCoreUtils.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/eagleeye/EagleEyeCoreUtils.java
@@ -82,7 +82,7 @@ final class EagleEyeCoreUtils {
         if (len == 0) {
             return EMPTY_STRING_ARRAY;
         }
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         int i = 0, start = 0;
         boolean match = false;
         boolean lastMatch = false;

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/eagleeye/EagleEyeLogDaemon.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/eagleeye/EagleEyeLogDaemon.java
@@ -28,7 +28,7 @@ class EagleEyeLogDaemon implements Runnable {
     private static Thread worker = null;
 
     private static final CopyOnWriteArrayList<EagleEyeAppender> watchedAppenders
-        = new CopyOnWriteArrayList<EagleEyeAppender>();
+        = new CopyOnWriteArrayList<>();
 
     static EagleEyeAppender watch(EagleEyeAppender appender) {
         watchedAppenders.addIfAbsent(appender);

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/eagleeye/StatEntryFunc.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/eagleeye/StatEntryFunc.java
@@ -117,8 +117,8 @@ class StatEntryFuncCountAndSum implements StatEntryFunc {
 
 class StatEntryFuncMinMax implements StatEntryFunc {
 
-    private AtomicReference<ValueRef> max = new AtomicReference<ValueRef>(new ValueRef(Long.MIN_VALUE, null));
-    private AtomicReference<ValueRef> min = new AtomicReference<ValueRef>(new ValueRef(Long.MAX_VALUE, null));
+    private AtomicReference<ValueRef> max = new AtomicReference<>(new ValueRef(Long.MIN_VALUE, null));
+    private AtomicReference<ValueRef> min = new AtomicReference<>(new ValueRef(Long.MAX_VALUE, null));
 
     @Override
     public void appendTo(StringBuilder appender, char delimiter) {

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/eagleeye/StatLogController.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/eagleeye/StatLogController.java
@@ -28,7 +28,7 @@ import com.alibaba.csp.sentinel.concurrent.NamedThreadFactory;
 
 class StatLogController {
 
-    private static final Map<String, StatLogger> statLoggers = new ConcurrentHashMap<String, StatLogger>();
+    private static final Map<String, StatLogger> statLoggers = new ConcurrentHashMap<>();
 
     private static final int STAT_ENTRY_COOL_DOWN_MILLIS = 200;
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/eagleeye/StatLogger.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/eagleeye/StatLogger.java
@@ -46,7 +46,7 @@ public final class StatLogger {
         this.entryDelimiter = entryDelimiter;
         this.keyDelimiter = keyDelimiter;
         this.valueDelimiter = valueDelimiter;
-        this.ref = new AtomicReference<StatRollingData>();
+        this.ref = new AtomicReference<>();
         rolling();
     }
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/eagleeye/StatRollingData.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/eagleeye/StatRollingData.java
@@ -39,7 +39,7 @@ final class StatRollingData {
 
     StatRollingData(StatLogger statLogger, int initialCapacity, long timeSlot, long rollingTimeMillis) {
         this(statLogger, timeSlot, rollingTimeMillis,
-            new ConcurrentHashMap<StatEntry, StatEntryFunc>(
+            new ConcurrentHashMap<>(
                 Math.min(initialCapacity, statLogger.getMaxEntryCount())));
     }
 
@@ -68,7 +68,7 @@ final class StatRollingData {
                     }
                 } else {
                     Map<StatEntry, StatEntryFunc> cloneStatMap =
-                        new HashMap<StatEntry, StatEntryFunc>(statMap);
+                        new HashMap<>(statMap);
                     statMap.clear();
 
                     func = factory.create();

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/init/InitExecutor.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/init/InitExecutor.java
@@ -44,7 +44,7 @@ public final class InitExecutor {
         }
         try {
             List<InitFunc> initFuncs = SpiLoader.of(InitFunc.class).loadInstanceListSorted();
-            List<OrderWrapper> initList = new ArrayList<OrderWrapper>();
+            List<OrderWrapper> initList = new ArrayList<>();
             for (InitFunc initFunc : initFuncs) {
                 RecordLog.info("[InitExecutor] Found init func: {}", initFunc.getClass().getCanonicalName());
                 insertSorted(initList, initFunc);

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/MessageFormatter.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/MessageFormatter.java
@@ -219,13 +219,13 @@ final public class MessageFormatter {
                         // itself escaped: "abc x:\\{}"
                         // we have to consume one backward slash
                         sbuf.append(messagePattern, i, j - 1);
-                        deeplyAppendParameter(sbuf, argArray[L], new HashMap<Object[], Object>());
+                        deeplyAppendParameter(sbuf, argArray[L], new HashMap<>());
                         i = j + 2;
                     }
                 } else {
                     // normal case
                     sbuf.append(messagePattern, i, j);
-                    deeplyAppendParameter(sbuf, argArray[L], new HashMap<Object[], Object>());
+                    deeplyAppendParameter(sbuf, argArray[L], new HashMap<>());
                     i = j + 2;
                 }
             }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/metric/MetricTimerListener.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/metric/MetricTimerListener.java
@@ -62,7 +62,7 @@ public class MetricTimerListener implements Runnable {
             MetricNode metricNode = entry.getValue();
             metricNode.setResource(node.getName());
             metricNode.setClassification(node.getResourceType());
-            maps.computeIfAbsent(time, k -> new ArrayList<MetricNode>());
+            maps.computeIfAbsent(time, k -> new ArrayList<>());
             List<MetricNode> nodes = maps.get(time);
             nodes.add(entry.getValue());
         }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/metric/MetricWriter.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/metric/MetricWriter.java
@@ -189,7 +189,7 @@ public class MetricWriter {
     }
 
     private String nextFileNameOfDay(long time) {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         File baseFile = new File(baseDir);
         DateFormat fileNameDf = new SimpleDateFormat("yyyy-MM-dd");
         String dateStr = fileNameDf.format(new Date(time));
@@ -279,7 +279,7 @@ public class MetricWriter {
      * @throws Exception
      */
     static List<String> listMetricFiles(String baseDir, String baseFileName) throws Exception {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         File baseFile = new File(baseDir);
         File[] files = baseFile.listFiles();
         if (files == null) {

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/metric/MetricsReader.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/metric/MetricsReader.java
@@ -121,7 +121,7 @@ class MetricsReader {
      */
     List<MetricNode> readMetricsByEndTime(List<String> fileNames, int pos, long offset,
                                           long beginTimeMs, long endTimeMs, String identity) throws Exception {
-        List<MetricNode> list = new ArrayList<MetricNode>(1024);
+        List<MetricNode> list = new ArrayList<>(1024);
         if (readMetricsInOneFileByEndTime(list, fileNames.get(pos++), offset, beginTimeMs, endTimeMs, identity)) {
             while (pos < fileNames.size()
                 && readMetricsInOneFileByEndTime(list, fileNames.get(pos++), 0, beginTimeMs, endTimeMs, identity)) {
@@ -132,7 +132,7 @@ class MetricsReader {
 
     List<MetricNode> readMetrics(List<String> fileNames, int pos,
                                  long offset, int recommendLines) throws Exception {
-        List<MetricNode> list = new ArrayList<MetricNode>(recommendLines);
+        List<MetricNode> list = new ArrayList<>(recommendLines);
         readMetricsInOneFile(list, fileNames.get(pos++), offset, recommendLines);
         while (list.size() < recommendLines && pos < fileNames.size()) {
             readMetricsInOneFile(list, fileNames.get(pos++), 0, recommendLines);

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/property/DynamicSentinelProperty.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/property/DynamicSentinelProperty.java
@@ -23,7 +23,7 @@ import com.alibaba.csp.sentinel.log.RecordLog;
 
 public class DynamicSentinelProperty<T> implements SentinelProperty<T> {
 
-    protected Set<PropertyListener<T>> listeners = Collections.synchronizedSet(new HashSet<PropertyListener<T>>());
+    protected Set<PropertyListener<T>> listeners = Collections.synchronizedSet(new HashSet<>());
     private T value = null;
 
     public DynamicSentinelProperty() {

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManager.java
@@ -51,7 +51,7 @@ public class FlowRuleManager {
     private static volatile Map<String, List<FlowRule>> flowRules = new HashMap<>();
 
     private static final FlowPropertyListener LISTENER = new FlowPropertyListener();
-    private static SentinelProperty<List<FlowRule>> currentProperty = new DynamicSentinelProperty<List<FlowRule>>();
+    private static SentinelProperty<List<FlowRule>> currentProperty = new DynamicSentinelProperty<>();
 
     /** the corePool size of SCHEDULER must be set at 1, so the two task ({@link #startMetricTimerListener()} can run orderly by the SCHEDULER **/
     @SuppressWarnings("PMD.ThreadPoolCreationRule")
@@ -105,7 +105,7 @@ public class FlowRuleManager {
      * @return a new copy of the rules.
      */
     public static List<FlowRule> getRules() {
-        List<FlowRule> rules = new ArrayList<FlowRule>();
+        List<FlowRule> rules = new ArrayList<>();
         for (Map.Entry<String, List<FlowRule>> entry : flowRules.entrySet()) {
             rules.addAll(entry.getValue());
         }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/nodeselector/NodeSelectorSlot.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/nodeselector/NodeSelectorSlot.java
@@ -130,7 +130,7 @@ public class NodeSelectorSlot extends AbstractLinkedProcessorSlot<Object> {
     /**
      * {@link DefaultNode}s of the same resource in different context.
      */
-    private volatile Map<String, DefaultNode> map = new HashMap<String, DefaultNode>(10);
+    private volatile Map<String, DefaultNode> map = new HashMap<>(10);
 
     @Override
     public void entry(Context context, ResourceWrapper resourceWrapper, Object obj, int count, boolean prioritized, Object... args)
@@ -159,7 +159,7 @@ public class NodeSelectorSlot extends AbstractLinkedProcessorSlot<Object> {
                 node = map.get(context.getName());
                 if (node == null) {
                     node = new DefaultNode(resourceWrapper, null);
-                    HashMap<String, DefaultNode> cacheMap = new HashMap<String, DefaultNode>(map.size());
+                    HashMap<String, DefaultNode> cacheMap = new HashMap<>(map.size());
                     cacheMap.putAll(map);
                     cacheMap.put(context.getName(), node);
                     map = cacheMap;

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/StatisticSlotCallbackRegistry.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/StatisticSlotCallbackRegistry.java
@@ -38,10 +38,10 @@ import com.alibaba.csp.sentinel.slotchain.ProcessorSlotExitCallback;
 public final class StatisticSlotCallbackRegistry {
 
     private static final Map<String, ProcessorSlotEntryCallback<DefaultNode>> entryCallbackMap
-        = new ConcurrentHashMap<String, ProcessorSlotEntryCallback<DefaultNode>>();
+        = new ConcurrentHashMap<>();
 
     private static final Map<String, ProcessorSlotExitCallback> exitCallbackMap
-        = new ConcurrentHashMap<String, ProcessorSlotExitCallback>();
+        = new ConcurrentHashMap<>();
 
     public static void clearEntryCallback() {
         entryCallbackMap.clear();

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/base/LeapArray.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/base/LeapArray.java
@@ -144,7 +144,7 @@ public abstract class LeapArray<T> {
                  * then try to update circular array via a CAS operation. Only one thread can
                  * succeed to update, while other threads yield its time slice.
                  */
-                WindowWrap<T> window = new WindowWrap<T>(windowLengthInMs, windowStart, newEmptyBucket(timeMillis));
+                WindowWrap<T> window = new WindowWrap<>(windowLengthInMs, windowStart, newEmptyBucket(timeMillis));
                 if (array.compareAndSet(idx, null, window)) {
                     // Successfully updated, return the created bucket.
                     return window;
@@ -196,7 +196,7 @@ public abstract class LeapArray<T> {
                 }
             } else if (windowStart < old.windowStart()) {
                 // Should not go through here, as the provided time is already behind.
-                return new WindowWrap<T>(windowLengthInMs, windowStart, newEmptyBucket(timeMillis));
+                return new WindowWrap<>(windowLengthInMs, windowStart, newEmptyBucket(timeMillis));
             }
         }
     }
@@ -283,7 +283,7 @@ public abstract class LeapArray<T> {
 
     public List<WindowWrap<T>> list(long validTime) {
         int size = array.length();
-        List<WindowWrap<T>> result = new ArrayList<WindowWrap<T>>(size);
+        List<WindowWrap<T>> result = new ArrayList<>(size);
 
         for (int i = 0; i < size; i++) {
             WindowWrap<T> windowWrap = array.get(i);
@@ -303,7 +303,7 @@ public abstract class LeapArray<T> {
      */
     public List<WindowWrap<T>> listAll() {
         int size = array.length();
-        List<WindowWrap<T>> result = new ArrayList<WindowWrap<T>>(size);
+        List<WindowWrap<T>> result = new ArrayList<>(size);
 
         for (int i = 0; i < size; i++) {
             WindowWrap<T> windowWrap = array.get(i);
@@ -328,10 +328,10 @@ public abstract class LeapArray<T> {
 
     public List<T> values(long timeMillis) {
         if (timeMillis < 0) {
-            return new ArrayList<T>();
+            return new ArrayList<>();
         }
         int size = array.length();
-        List<T> result = new ArrayList<T>(size);
+        List<T> result = new ArrayList<>(size);
 
         for (int i = 0; i < size; i++) {
             WindowWrap<T> windowWrap = array.get(i);

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/system/SystemRuleManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/system/SystemRuleManager.java
@@ -86,7 +86,7 @@ public final class SystemRuleManager {
 
     private static SystemStatusListener statusListener = null;
     private final static SystemPropertyListener listener = new SystemPropertyListener();
-    private static SentinelProperty<List<SystemRule>> currentProperty = new DynamicSentinelProperty<List<SystemRule>>();
+    private static SentinelProperty<List<SystemRule>> currentProperty = new DynamicSentinelProperty<>();
 
     @SuppressWarnings("PMD.ThreadPoolCreationRule")
     private final static ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1,
@@ -130,7 +130,7 @@ public final class SystemRuleManager {
      */
     public static List<SystemRule> getRules() {
 
-        List<SystemRule> result = new ArrayList<SystemRule>();
+        List<SystemRule> result = new ArrayList<>();
         if (!checkSystemStatus.get()) {
             return result;
         }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/spi/SpiLoader.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/spi/SpiLoader.java
@@ -79,10 +79,10 @@ public final class SpiLoader<S> {
     private static final ConcurrentHashMap<String, SpiLoader> SPI_LOADER_MAP = new ConcurrentHashMap<>();
 
     // Cache the classes of Provider
-    private final List<Class<? extends S>> classList = Collections.synchronizedList(new ArrayList<Class<? extends S>>());
+    private final List<Class<? extends S>> classList = Collections.synchronizedList(new ArrayList<>());
 
     // Cache the sorted classes of Provider
-    private final List<Class<? extends S>> sortedClassList = Collections.synchronizedList(new ArrayList<Class<? extends S>>());
+    private final List<Class<? extends S>> sortedClassList = Collections.synchronizedList(new ArrayList<>());
 
     /**
      * Cache the classes of Provider, key: aliasName, value: class of Provider.

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/MethodUtil.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/MethodUtil.java
@@ -26,7 +26,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public final class MethodUtil {
 
-    private static final Map<Method, String> methodNameMap = new ConcurrentHashMap<Method, String>();
+    private static final Map<Method, String> methodNameMap = new ConcurrentHashMap<>();
 
     private static final Object LOCK = new Object();
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/TimeUtil.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/TimeUtil.java
@@ -164,9 +164,9 @@ public final class TimeUtil implements Runnable {
             writes += windowWrap.value().getWrites().longValue();
         }
         if (cnt < 1) {
-            return new Tuple2<Long, Long>(0L, 0L);
+            return new Tuple2<>(0L, 0L);
         }
-        return new Tuple2<Long, Long>(reads / cnt, writes / cnt);
+        return new Tuple2<>(reads / cnt, writes / cnt);
     }
 
     /**

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/function/Tuple2.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/function/Tuple2.java
@@ -21,7 +21,7 @@ public class Tuple2<R1, R2> {
      * @return new Tuple
      */
     public static <C1, C2> Tuple2<C1, C2> of(C1 c1, C2 c2) {
-        return new Tuple2<C1, C2>(c1, c2);
+        return new Tuple2<>(c1, c2);
     }
 
     /**
@@ -30,7 +30,7 @@ public class Tuple2<R1, R2> {
      * @return a new Tuple where the first element is the second element of this Tuple and the second element is the first element of this Tuple.
      */
     public Tuple2<R2, R1> swap() {
-        return new Tuple2<R2, R1>(this.r2, this.r1);
+        return new Tuple2<>(this.r2, this.r1);
     }
 
     @Override

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/node/ClusterNodeTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/node/ClusterNodeTest.java
@@ -76,7 +76,7 @@ public class ClusterNodeTest {
 
             // Store all distinct nodes by calling ClusterNode#getOrCreateOriginNode.
             // Here we need a thread-safe concurrent set (created from ConcurrentHashMap).
-            final Set<Node> createdNodes = Collections.newSetFromMap(new ConcurrentHashMap<Node, Boolean>());
+            final Set<Node> createdNodes = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
             // 10 threads, 3 origins, 20 tasks (calling 20 times of ClusterNode#getOrCreateOriginNode concurrently)
             final ExecutorService es = Executors.newFixedThreadPool(10);
@@ -84,7 +84,7 @@ public class ClusterNodeTest {
             int taskCount = 20;
             final CountDownLatch latch = new CountDownLatch(taskCount);
 
-            List<Callable<Object>> tasks = new ArrayList<Callable<Object>>(taskCount);
+            List<Callable<Object>> tasks = new ArrayList<>(taskCount);
             for (int i = 0; i < taskCount; i++) {
                 final int index = i % origins.size();
                 tasks.add(new Callable<Object>() {

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/node/StatisticNodeTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/node/StatisticNodeTest.java
@@ -217,10 +217,10 @@ public class StatisticNodeTest {
         StatisticNode statisticNode = new StatisticNode();
         ExecutorService bizEs1 = new ThreadPoolExecutor(THREAD_COUNT, THREAD_COUNT,
                 0L, TimeUnit.MILLISECONDS,
-                new LinkedBlockingQueue<Runnable>());
+                new LinkedBlockingQueue<>());
         ExecutorService bizEs2 = new ThreadPoolExecutor(THREAD_COUNT, THREAD_COUNT,
                 0L, TimeUnit.MILLISECONDS,
-                new LinkedBlockingQueue<Runnable>());
+                new LinkedBlockingQueue<>());
         int taskCount = 100;
         for (int i = 0; i < taskCount; i++) {
             int op = i % 2;

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/node/metric/MetricWriterTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/node/metric/MetricWriterTest.java
@@ -30,7 +30,7 @@ public class MetricWriterTest {
             "metrics.log.2018-03-07.10",
             "metrics.log.2018-03-07.51"
         };
-        ArrayList<String> list = new ArrayList<String>(Arrays.asList(arr));
+        ArrayList<String> list = new ArrayList<>(Arrays.asList(arr));
         Collections.sort(list, MetricWriter.METRIC_FILE_NAME_CMP);
         assertEquals(Arrays.asList(key), list);
     }
@@ -51,7 +51,7 @@ public class MetricWriterTest {
             "metrics.log.pid1234.2018-03-07.10",
             "metrics.log.pid1234.2018-03-07.51"
         };
-        ArrayList<String> list = new ArrayList<String>(Arrays.asList(arr));
+        ArrayList<String> list = new ArrayList<>(Arrays.asList(arr));
         Collections.sort(list, MetricWriter.METRIC_FILE_NAME_CMP);
         assertEquals(Arrays.asList(key), list);
     }

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/degrade/CircuitBreakingIntegrationTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/degrade/CircuitBreakingIntegrationTest.java
@@ -44,12 +44,12 @@ public class CircuitBreakingIntegrationTest extends AbstractTimeBasedTest {
 
     @Before
     public void setUp() {
-        DegradeRuleManager.loadRules(new ArrayList<DegradeRule>());
+        DegradeRuleManager.loadRules(new ArrayList<>());
     }
 
     @After
     public void tearDown() throws Exception {
-        DegradeRuleManager.loadRules(new ArrayList<DegradeRule>());
+        DegradeRuleManager.loadRules(new ArrayList<>());
     }
 
     @Test

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeRuleManagerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradeRuleManagerTest.java
@@ -36,12 +36,12 @@ public class DegradeRuleManagerTest {
 
     @Before
     public void setUp() throws Exception {
-        DegradeRuleManager.loadRules(new ArrayList<DegradeRule>());
+        DegradeRuleManager.loadRules(new ArrayList<>());
     }
 
     @After
     public void tearDown() throws Exception {
-        DegradeRuleManager.loadRules(new ArrayList<DegradeRule>());
+        DegradeRuleManager.loadRules(new ArrayList<>());
     }
 
     @Test

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ExceptionCircuitBreakerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ExceptionCircuitBreakerTest.java
@@ -38,12 +38,12 @@ public class ExceptionCircuitBreakerTest extends AbstractTimeBasedTest {
     
     @Before
     public void setUp() {
-        DegradeRuleManager.loadRules(new ArrayList<DegradeRule>());
+        DegradeRuleManager.loadRules(new ArrayList<>());
     }
 
     @After
     public void tearDown() throws Exception {
-        DegradeRuleManager.loadRules(new ArrayList<DegradeRule>());
+        DegradeRuleManager.loadRules(new ArrayList<>());
     }
 
     @Test

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ResponseTimeCircuitBreakerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ResponseTimeCircuitBreakerTest.java
@@ -21,12 +21,12 @@ import static org.junit.Assert.assertTrue;
 public class ResponseTimeCircuitBreakerTest extends AbstractTimeBasedTest {
     @Before
     public void setUp() {
-        DegradeRuleManager.loadRules(new ArrayList<DegradeRule>());
+        DegradeRuleManager.loadRules(new ArrayList<>());
     }
 
     @After
     public void tearDown() throws Exception {
-        DegradeRuleManager.loadRules(new ArrayList<DegradeRule>());
+        DegradeRuleManager.loadRules(new ArrayList<>());
     }
 
     @Test

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/FlowPartialIntegrationTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/FlowPartialIntegrationTest.java
@@ -39,12 +39,12 @@ public class FlowPartialIntegrationTest {
 
     @Before
     public void setUp() throws Exception {
-        FlowRuleManager.loadRules(new ArrayList<FlowRule>());
+        FlowRuleManager.loadRules(new ArrayList<>());
     }
 
     @After
     public void tearDown() throws Exception {
-        FlowRuleManager.loadRules(new ArrayList<FlowRule>());
+        FlowRuleManager.loadRules(new ArrayList<>());
     }
 
     @Test

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManagerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManagerTest.java
@@ -29,8 +29,8 @@ import static org.junit.Assert.assertEquals;
  */
 public class FlowRuleManagerTest {
 
-    public static final List<FlowRule> STATIC_RULES_1 = new ArrayList<FlowRule>();
-    public static final List<FlowRule> STATIC_RULES_2 = new ArrayList<FlowRule>();
+    public static final List<FlowRule> STATIC_RULES_1 = new ArrayList<>();
+    public static final List<FlowRule> STATIC_RULES_2 = new ArrayList<>();
 
     static {
         FlowRule first = new FlowRule();

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/statistic/metric/ArrayMetricTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/statistic/metric/ArrayMetricTest.java
@@ -43,7 +43,7 @@ public class ArrayMetricTest {
     @Test
     public void testOperateArrayMetric() {
         BucketLeapArray leapArray = mock(BucketLeapArray.class);
-        final WindowWrap<MetricBucket> windowWrap = new WindowWrap<MetricBucket>(windowLengthInMs, 0,
+        final WindowWrap<MetricBucket> windowWrap = new WindowWrap<>(windowLengthInMs, 0,
             new MetricBucket());
         when(leapArray.currentWindow()).thenReturn(windowWrap);
         when(leapArray.values()).thenReturn(new ArrayList<MetricBucket>() {{ add(windowWrap.value()); }});

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/statistic/metric/BucketLeapArrayTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/statistic/metric/BucketLeapArrayTest.java
@@ -110,7 +110,7 @@ public class BucketLeapArrayTest {
         BucketLeapArray leapArray = new BucketLeapArray(sampleCount, intervalInMs);
         final int len = sampleCount;
         long firstTime = TimeUtil.currentTimeMillis();
-        List<WindowWrap<MetricBucket>> firstIterWindowList = new ArrayList<WindowWrap<MetricBucket>>(len);
+        List<WindowWrap<MetricBucket>> firstIterWindowList = new ArrayList<>(len);
         for (int i = 0; i < len; i++) {
             WindowWrap<MetricBucket> w = leapArray.currentWindow(firstTime + windowLengthInMs * i);
             w.value().addPass(1);
@@ -169,7 +169,7 @@ public class BucketLeapArrayTest {
         BucketLeapArray leapArray = new BucketLeapArray(sampleCount, intervalInMs);
         long time = TimeUtil.currentTimeMillis();
 
-        Set<WindowWrap<MetricBucket>> windowWraps = new HashSet<WindowWrap<MetricBucket>>();
+        Set<WindowWrap<MetricBucket>> windowWraps = new HashSet<>();
 
         windowWraps.add(leapArray.currentWindow(time));
         windowWraps.add(leapArray.currentWindow(time + windowLengthInMs));
@@ -197,7 +197,7 @@ public class BucketLeapArrayTest {
         BucketLeapArray leapArray = new BucketLeapArray(sampleCount, intervalInMs);
         long time = TimeUtil.currentTimeMillis();
 
-        Set<WindowWrap<MetricBucket>> windowWraps = new HashSet<WindowWrap<MetricBucket>>();
+        Set<WindowWrap<MetricBucket>> windowWraps = new HashSet<>();
 
         windowWraps.add(leapArray.currentWindow(time));
         windowWraps.add(leapArray.currentWindow(time + windowLengthInMs));

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/system/SystemRuleManagerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/system/SystemRuleManagerTest.java
@@ -101,11 +101,11 @@ public class SystemRuleManagerTest {
 
     @Before
     public void setUp() throws Exception {
-        SystemRuleManager.loadRules(new ArrayList<SystemRule>());
+        SystemRuleManager.loadRules(new ArrayList<>());
     }
 
     @After
     public void tearDown() throws Exception {
-        SystemRuleManager.loadRules(new ArrayList<SystemRule>());
+        SystemRuleManager.loadRules(new ArrayList<>());
     }
 }

--- a/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/client/SentinelApiClientTest.java
+++ b/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/client/SentinelApiClientTest.java
@@ -33,7 +33,7 @@ public class SentinelApiClientTest {
         // Processor is required because it will determine the final request body including
         // headers before outgoing.
         RequestContent processor = new RequestContent();
-        Map<String, String> params = new HashMap<String, String>();
+        Map<String, String> params = new HashMap<>();
         params.put("a", "1");
         params.put("b", "2+");
         params.put("c", "3 ");

--- a/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/flow/FlowQpsDemo.java
+++ b/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/flow/FlowQpsDemo.java
@@ -59,7 +59,7 @@ public class FlowQpsDemo {
     }
 
     private static void initFlowQpsRule() {
-        List<FlowRule> rules = new ArrayList<FlowRule>();
+        List<FlowRule> rules = new ArrayList<>();
         FlowRule rule1 = new FlowRule();
         rule1.setResource(KEY);
         // set limit qps to 20

--- a/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/flow/FlowThreadDemo.java
+++ b/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/flow/FlowThreadDemo.java
@@ -85,7 +85,7 @@ public class FlowThreadDemo {
     }
 
     private static void initFlowRule() {
-        List<FlowRule> rules = new ArrayList<FlowRule>();
+        List<FlowRule> rules = new ArrayList<>();
         FlowRule rule1 = new FlowRule();
         rule1.setResource("methodA");
         // set limit concurrent thread for 'methodA' to 20

--- a/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/flow/PaceFlowDemo.java
+++ b/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/flow/PaceFlowDemo.java
@@ -133,7 +133,7 @@ public class PaceFlowDemo {
     }
 
     private static void initPaceFlowRule() {
-        List<FlowRule> rules = new ArrayList<FlowRule>();
+        List<FlowRule> rules = new ArrayList<>();
         FlowRule rule1 = new FlowRule();
         rule1.setResource(KEY);
         rule1.setCount(count);
@@ -151,7 +151,7 @@ public class PaceFlowDemo {
     }
 
     private static void initDefaultFlowRule() {
-        List<FlowRule> rules = new ArrayList<FlowRule>();
+        List<FlowRule> rules = new ArrayList<>();
         FlowRule rule1 = new FlowRule();
         rule1.setResource(KEY);
         rule1.setCount(count);

--- a/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/flow/WarmUpFlowDemo.java
+++ b/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/flow/WarmUpFlowDemo.java
@@ -109,7 +109,7 @@ public class WarmUpFlowDemo {
     }
 
     private static void initFlowRule() {
-        List<FlowRule> rules = new ArrayList<FlowRule>();
+        List<FlowRule> rules = new ArrayList<>();
         FlowRule rule1 = new FlowRule();
         rule1.setResource(KEY);
         rule1.setCount(20);

--- a/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/flow/WarmUpRateLimiterFlowDemo.java
+++ b/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/flow/WarmUpRateLimiterFlowDemo.java
@@ -98,7 +98,7 @@ public class WarmUpRateLimiterFlowDemo {
     }
 
     private static void initFlowRule() {
-        List<FlowRule> rules = new ArrayList<FlowRule>();
+        List<FlowRule> rules = new ArrayList<>();
         FlowRule rule1 = new FlowRule();
         rule1.setResource(KEY);
         rule1.setCount(20);

--- a/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/system/SystemGuardDemo.java
+++ b/sentinel-demo/sentinel-demo-basic/src/main/java/com/alibaba/csp/sentinel/demo/system/SystemGuardDemo.java
@@ -87,7 +87,7 @@ public class SystemGuardDemo {
     }
 
     private static void initSystemRule() {
-        List<SystemRule> rules = new ArrayList<SystemRule>();
+        List<SystemRule> rules = new ArrayList<>();
         SystemRule rule = new SystemRule();
         // max load is 3
         rule.setHighestSystemLoad(3.0);

--- a/sentinel-demo/sentinel-demo-motan/src/main/java/com/alibaba/csp/sentinel/demo/motan/SentinelMotanConsumerService.java
+++ b/sentinel-demo/sentinel-demo-motan/src/main/java/com/alibaba/csp/sentinel/demo/motan/SentinelMotanConsumerService.java
@@ -35,7 +35,7 @@ public class SentinelMotanConsumerService {
     private static final String RES_KEY = INTERFACE_RES_KEY + ":hello(java.lang.String)";
 
     public static void main(String[] args) {
-        RefererConfig<MotanDemoService> motanDemoServiceReferer = new RefererConfig<MotanDemoService>();
+        RefererConfig<MotanDemoService> motanDemoServiceReferer = new RefererConfig<>();
         // 设置接口及实现类
         motanDemoServiceReferer.setInterface(MotanDemoService.class);
         // 配置服务的group以及版本号

--- a/sentinel-demo/sentinel-demo-motan/src/main/java/com/alibaba/csp/sentinel/demo/motan/SentinelMotanProviderService.java
+++ b/sentinel-demo/sentinel-demo-motan/src/main/java/com/alibaba/csp/sentinel/demo/motan/SentinelMotanProviderService.java
@@ -33,7 +33,7 @@ public class SentinelMotanProviderService {
 
         InitExecutor.doInit();
 
-        ServiceConfig<MotanDemoService> motanDemoService = new ServiceConfig<MotanDemoService>();
+        ServiceConfig<MotanDemoService> motanDemoService = new ServiceConfig<>();
 
         // 设置接口及实现类
         motanDemoService.setInterface(MotanDemoService.class);

--- a/sentinel-demo/sentinel-demo-quarkus/src/main/java/com/alibaba/csp/sentinel/demo/quarkus/GreetingResource.java
+++ b/sentinel-demo/sentinel-demo-quarkus/src/main/java/com/alibaba/csp/sentinel/demo/quarkus/GreetingResource.java
@@ -31,7 +31,7 @@ public class GreetingResource {
 
     ExecutorService executor = new ThreadPoolExecutor(5, 5,
             0L, TimeUnit.MILLISECONDS,
-            new LinkedBlockingQueue<Runnable>());
+            new LinkedBlockingQueue<>());
 
     @GET
     @Path("/txt")

--- a/sentinel-demo/sentinel-demo-rocketmq/src/main/java/com/alibaba/csp/sentinel/demo/rocketmq/PullConsumerDemo.java
+++ b/sentinel-demo/sentinel-demo-rocketmq/src/main/java/com/alibaba/csp/sentinel/demo/rocketmq/PullConsumerDemo.java
@@ -43,7 +43,7 @@ public class PullConsumerDemo {
 
     private static final String KEY = String.format("%s:%s", Constants.TEST_GROUP_NAME, Constants.TEST_TOPIC_NAME);
 
-    private static final Map<MessageQueue, Long> OFFSET_TABLE = new HashMap<MessageQueue, Long>();
+    private static final Map<MessageQueue, Long> OFFSET_TABLE = new HashMap<>();
 
     @SuppressWarnings("PMD.ThreadPoolCreationRule")
     private static final ExecutorService pool = Executors.newFixedThreadPool(32);

--- a/sentinel-demo/sentinel-demo-slotchain-spi/src/main/java/com/alibaba/csp/sentinel/demo/slotchain/DemoFlowRuleApplication.java
+++ b/sentinel-demo/sentinel-demo-slotchain-spi/src/main/java/com/alibaba/csp/sentinel/demo/slotchain/DemoFlowRuleApplication.java
@@ -62,7 +62,7 @@ public class DemoFlowRuleApplication {
     }
 
     private static void initFlowQpsRule() {
-        List<FlowRule> rules = new ArrayList<FlowRule>();
+        List<FlowRule> rules = new ArrayList<>();
         FlowRule rule1 = new FlowRule();
         rule1.setResource(RESOURCE_KEY);
         // set limit qps to 5

--- a/sentinel-extension/sentinel-annotation-aspectj/src/test/java/com/alibaba/csp/sentinel/annotation/aspectj/integration/SentinelAnnotationIntegrationTest.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/test/java/com/alibaba/csp/sentinel/annotation/aspectj/integration/SentinelAnnotationIntegrationTest.java
@@ -232,13 +232,13 @@ public class SentinelAnnotationIntegrationTest extends AbstractJUnit4SpringConte
 
     @Before
     public void setUp() throws Exception {
-        FlowRuleManager.loadRules(new ArrayList<FlowRule>());
+        FlowRuleManager.loadRules(new ArrayList<>());
         ClusterBuilderSlot.resetClusterNodes();
     }
 
     @After
     public void tearDown() throws Exception {
-        FlowRuleManager.loadRules(new ArrayList<FlowRule>());
+        FlowRuleManager.loadRules(new ArrayList<>());
         ClusterBuilderSlot.resetClusterNodes();
     }
 }

--- a/sentinel-extension/sentinel-annotation-cdi-interceptor/src/test/java/com/alibaba/csp/sentinel/annotation/cdi/interceptor/integration/SentinelAnnotationInterceptorIntegrationTest.java
+++ b/sentinel-extension/sentinel-annotation-cdi-interceptor/src/test/java/com/alibaba/csp/sentinel/annotation/cdi/interceptor/integration/SentinelAnnotationInterceptorIntegrationTest.java
@@ -55,14 +55,14 @@ public class SentinelAnnotationInterceptorIntegrationTest {
 
     @Before
     public void setUp() throws Exception {
-        FlowRuleManager.loadRules(new ArrayList<FlowRule>());
+        FlowRuleManager.loadRules(new ArrayList<>());
         ClusterBuilderSlot.resetClusterNodes();
         fooService = container.select(FooService.class).get();
     }
 
     @After
     public void tearDown() throws Exception {
-        FlowRuleManager.loadRules(new ArrayList<FlowRule>());
+        FlowRuleManager.loadRules(new ArrayList<>());
         ClusterBuilderSlot.resetClusterNodes();
     }
 

--- a/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/AbstractDataSource.java
+++ b/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/AbstractDataSource.java
@@ -36,7 +36,7 @@ public abstract class AbstractDataSource<S, T> implements ReadableDataSource<S, 
             throw new IllegalArgumentException("parser can't be null");
         }
         this.parser = parser;
-        this.property = new DynamicSentinelProperty<T>();
+        this.property = new DynamicSentinelProperty<>();
     }
 
     @Override

--- a/sentinel-extension/sentinel-datasource-nacos/src/main/java/com/alibaba/csp/sentinel/datasource/nacos/NacosDataSource.java
+++ b/sentinel-extension/sentinel-datasource-nacos/src/main/java/com/alibaba/csp/sentinel/datasource/nacos/NacosDataSource.java
@@ -47,7 +47,7 @@ public class NacosDataSource<T> extends AbstractDataSource<String, T> {
      * Single-thread pool. Once the thread pool is blocked, we throw up the old task.
      */
     private final ExecutorService pool = new ThreadPoolExecutor(1, 1, 0, TimeUnit.MILLISECONDS,
-        new ArrayBlockingQueue<Runnable>(1), new NamedThreadFactory("sentinel-nacos-ds-update", true),
+        new ArrayBlockingQueue<>(1), new NamedThreadFactory("sentinel-nacos-ds-update", true),
         new ThreadPoolExecutor.DiscardOldestPolicy());
 
     private final Listener configListener;

--- a/sentinel-extension/sentinel-datasource-redis/src/main/java/com/alibaba/csp/sentinel/datasource/redis/config/RedisConnectionConfig.java
+++ b/sentinel-extension/sentinel-datasource-redis/src/main/java/com/alibaba/csp/sentinel/datasource/redis/config/RedisConnectionConfig.java
@@ -55,8 +55,8 @@ public class RedisConnectionConfig {
     private String clientName;
     private char[] password;
     private long timeout = DEFAULT_TIMEOUT_MILLISECONDS;
-    private final List<RedisConnectionConfig> redisSentinels = new ArrayList<RedisConnectionConfig>();
-    private final List<RedisConnectionConfig> redisClusters = new ArrayList<RedisConnectionConfig>();
+    private final List<RedisConnectionConfig> redisSentinels = new ArrayList<>();
+    private final List<RedisConnectionConfig> redisClusters = new ArrayList<>();
 
     /**
      * Default empty constructor.
@@ -330,8 +330,8 @@ public class RedisConnectionConfig {
         private String clientName;
         private char[] password;
         private long timeout = DEFAULT_TIMEOUT_MILLISECONDS;
-        private final List<RedisHostAndPort> redisSentinels = new ArrayList<RedisHostAndPort>();
-        private final List<RedisHostAndPort> redisClusters = new ArrayList<RedisHostAndPort>();
+        private final List<RedisHostAndPort> redisSentinels = new ArrayList<>();
+        private final List<RedisHostAndPort> redisClusters = new ArrayList<>();
 
         private Builder() {
         }

--- a/sentinel-extension/sentinel-datasource-redis/src/test/java/com/alibaba/csp/sentinel/datasource/redis/StandaloneRedisDataSourceTest.java
+++ b/sentinel-extension/sentinel-datasource-redis/src/test/java/com/alibaba/csp/sentinel/datasource/redis/StandaloneRedisDataSourceTest.java
@@ -75,7 +75,7 @@ public class StandaloneRedisDataSourceTest {
             .withPort(server.getBindPort())
             .build();
         initRedisRuleData();
-        ReadableDataSource<String, List<FlowRule>> redisDataSource = new RedisDataSource<List<FlowRule>>(config,
+        ReadableDataSource<String, List<FlowRule>> redisDataSource = new RedisDataSource<>(config,
             ruleKey, channel, flowConfigParser);
         FlowRuleManager.register2Property(redisDataSource.getProperty());
     }

--- a/sentinel-extension/sentinel-datasource-zookeeper/src/main/java/com/alibaba/csp/sentinel/datasource/zookeeper/ZookeeperDataSource.java
+++ b/sentinel-extension/sentinel-datasource-zookeeper/src/main/java/com/alibaba/csp/sentinel/datasource/zookeeper/ZookeeperDataSource.java
@@ -37,7 +37,7 @@ public class ZookeeperDataSource<T> extends AbstractDataSource<String, T> {
 
 
     private final ExecutorService pool = new ThreadPoolExecutor(1, 1, 0, TimeUnit.MILLISECONDS,
-            new ArrayBlockingQueue<Runnable>(1), new NamedThreadFactory("sentinel-zookeeper-ds-update", true),
+            new ArrayBlockingQueue<>(1), new NamedThreadFactory("sentinel-zookeeper-ds-update", true),
             new ThreadPoolExecutor.DiscardOldestPolicy());
 
     private NodeCacheListener listener;

--- a/sentinel-extension/sentinel-datasource-zookeeper/src/test/java/com/alibaba/csp/sentinel/datasource/zookeeper/ZookeeperDataSourceTest.java
+++ b/sentinel-extension/sentinel-datasource-zookeeper/src/test/java/com/alibaba/csp/sentinel/datasource/zookeeper/ZookeeperDataSourceTest.java
@@ -44,7 +44,7 @@ public class ZookeeperDataSourceTest {
         final String remoteAddress = server.getConnectString();
         final String path = "/sentinel-zk-ds-demo/flow-HK";
 
-        ReadableDataSource<String, List<FlowRule>> flowRuleDataSource = new ZookeeperDataSource<List<FlowRule>>(remoteAddress, path,
+        ReadableDataSource<String, List<FlowRule>> flowRuleDataSource = new ZookeeperDataSource<>(remoteAddress, path,
                 new Converter<String, List<FlowRule>>() {
                     @Override
                     public List<FlowRule> convert(String source) {
@@ -100,7 +100,7 @@ public class ZookeeperDataSourceTest {
             zkClient.create().creatingParentContainersIfNeeded().withACL(Collections.singletonList(acl)).forPath(path, null);
         }
 
-        ReadableDataSource<String, List<FlowRule>> flowRuleDataSource = new ZookeeperDataSource<List<FlowRule>>(remoteAddress,
+        ReadableDataSource<String, List<FlowRule>> flowRuleDataSource = new ZookeeperDataSource<>(remoteAddress,
                 authInfoList, groupId, dataId,
                 new Converter<String, List<FlowRule>>() {
                     @Override
@@ -194,7 +194,7 @@ public class ZookeeperDataSourceTest {
         List<AuthInfo> authInfoList = Collections.singletonList(authInfo);
 
 
-        ZookeeperDataSource<List<FlowRule>> flowRuleZkAutoDataSource = new ZookeeperDataSource<List<FlowRule>>(remoteAddress,
+        ZookeeperDataSource<List<FlowRule>> flowRuleZkAutoDataSource = new ZookeeperDataSource<>(remoteAddress,
                 authInfoList, groupId, flowDataId,
                 new Converter<String, List<FlowRule>>() {
                     @Override
@@ -204,7 +204,7 @@ public class ZookeeperDataSourceTest {
                     }
                 });
 
-        ZookeeperDataSource<List<DegradeRule>> degradeRuleZkAutoDataSource = new ZookeeperDataSource<List<DegradeRule>>(remoteAddress,
+        ZookeeperDataSource<List<DegradeRule>> degradeRuleZkAutoDataSource = new ZookeeperDataSource<>(remoteAddress,
                 authInfoList, groupId, degradeDataId,
                 new Converter<String, List<DegradeRule>>() {
                     @Override

--- a/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowChecker.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowChecker.java
@@ -263,7 +263,7 @@ public final class ParamFlowChecker {
         if (value instanceof Collection) {
             return (Collection<Object>)value;
         } else if (value.getClass().isArray()) {
-            List<Object> params = new ArrayList<Object>();
+            List<Object> params = new ArrayList<>();
             int length = Array.getLength(value);
             for (int i = 0; i < length; i++) {
                 Object param = Array.get(value, i);

--- a/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowRule.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowRule.java
@@ -66,12 +66,12 @@ public class ParamFlowRule extends AbstractRule {
     /**
      * Original exclusion items of parameters.
      */
-    private List<ParamFlowItem> paramFlowItemList = new ArrayList<ParamFlowItem>();
+    private List<ParamFlowItem> paramFlowItemList = new ArrayList<>();
 
     /**
      * Parsed exclusion items of parameters. Only for internal use.
      */
-    private Map<Object, Integer> hotItems = new HashMap<Object, Integer>();
+    private Map<Object, Integer> hotItems = new HashMap<>();
 
     /**
      * Indicating whether the rule is for cluster mode.

--- a/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowRuleUtil.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowRuleUtil.java
@@ -77,7 +77,7 @@ public final class ParamFlowRuleUtil {
     public static void fillExceptionFlowItems(ParamFlowRule rule) {
         if (rule != null) {
             if (rule.getParamFlowItemList() == null) {
-                rule.setParamFlowItemList(new ArrayList<ParamFlowItem>());
+                rule.setParamFlowItemList(new ArrayList<>());
             }
 
             Map<Object, Integer> itemMap = parseHotItems(rule.getParamFlowItemList());

--- a/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParameterMetric.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParameterMetric.java
@@ -97,7 +97,7 @@ public class ParameterMetric {
             synchronized (lock) {
                 if (ruleTimeCounters.get(rule) == null) {
                     long size = Math.min(BASE_PARAM_MAX_CAPACITY * rule.getDurationInSec(), TOTAL_MAX_CAPACITY);
-                    ruleTimeCounters.put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(size));
+                    ruleTimeCounters.put(rule, new ConcurrentLinkedHashMapWrapper<>(size));
                 }
             }
         }
@@ -106,7 +106,7 @@ public class ParameterMetric {
             synchronized (lock) {
                 if (ruleTokenCounter.get(rule) == null) {
                     long size = Math.min(BASE_PARAM_MAX_CAPACITY * rule.getDurationInSec(), TOTAL_MAX_CAPACITY);
-                    ruleTokenCounter.put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(size));
+                    ruleTokenCounter.put(rule, new ConcurrentLinkedHashMapWrapper<>(size));
                 }
             }
         }
@@ -115,7 +115,7 @@ public class ParameterMetric {
             synchronized (lock) {
                 if (threadCountMap.get(rule.getParamIdx()) == null) {
                     threadCountMap.put(rule.getParamIdx(),
-                        new ConcurrentLinkedHashMapWrapper<Object, AtomicInteger>(THREAD_COUNT_MAX_CAPACITY));
+                        new ConcurrentLinkedHashMapWrapper<>(THREAD_COUNT_MAX_CAPACITY));
                 }
             }
         }

--- a/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/statistic/data/ParamMapBucket.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/statistic/data/ParamMapBucket.java
@@ -43,7 +43,7 @@ public class ParamMapBucket {
         RollingParamEvent[] events = RollingParamEvent.values();
         this.data = new CacheMap[events.length];
         for (RollingParamEvent event : events) {
-            data[event.ordinal()] = new ConcurrentLinkedHashMapWrapper<Object, AtomicInteger>(capacity);
+            data[event.ordinal()] = new ConcurrentLinkedHashMapWrapper<>(capacity);
         }
     }
 

--- a/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowCheckerTest.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowCheckerTest.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -82,14 +81,14 @@ public class ParamFlowCheckerTest {
         String valueD = "valueD";
 
         // Directly set parsed map for test.
-        Map<Object, Integer> map = new HashMap<Object, Integer>();
+        Map<Object, Integer> map = new HashMap<>();
         map.put(valueB, thresholdB);
         map.put(valueD, thresholdD);
         rule.setParsedHotItems(map);
 
         ParameterMetric metric = new ParameterMetric();
         ParameterMetricStorage.getMetricsMap().put(resourceWrapper.getName(), metric);
-        metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
+        metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<>(4000));
 
         assertTrue(ParamFlowChecker.passSingleValueCheck(resourceWrapper, rule, 1, valueA));
         assertFalse(ParamFlowChecker.passSingleValueCheck(resourceWrapper, rule, 1, valueB));
@@ -115,7 +114,7 @@ public class ParamFlowCheckerTest {
         String valueD = "valueD";
 
         // Directly set parsed map for test.
-        Map<Object, Integer> map = new HashMap<Object, Integer>();
+        Map<Object, Integer> map = new HashMap<>();
         map.put(valueB, thresholdB);
         map.put(valueD, thresholdD);
         rule.setParsedHotItems(map);
@@ -157,8 +156,8 @@ public class ParamFlowCheckerTest {
         List<String> list = Arrays.asList(v1, v2, v3);
         ParameterMetric metric = new ParameterMetric();
         ParameterMetricStorage.getMetricsMap().put(resourceWrapper.getName(), metric);
-        metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
-        metric.getRuleTokenCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
+        metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<>(4000));
+        metric.getRuleTokenCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<>(4000));
 
         assertTrue(ParamFlowChecker.passCheck(resourceWrapper, rule, 1, list));
         assertFalse(ParamFlowChecker.passCheck(resourceWrapper, rule, 1, list));
@@ -180,7 +179,7 @@ public class ParamFlowCheckerTest {
         Object arr = new String[]{v1, v2, v3};
         ParameterMetric metric = new ParameterMetric();
         ParameterMetricStorage.getMetricsMap().put(resourceWrapper.getName(), metric);
-        metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
+        metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<>(4000));
 
         assertTrue(ParamFlowChecker.passCheck(resourceWrapper, rule, 1, arr));
         assertFalse(ParamFlowChecker.passCheck(resourceWrapper, rule, 1, arr));
@@ -214,8 +213,8 @@ public class ParamFlowCheckerTest {
         Object[] args = new Object[]{new User(1, "Bob", "Hangzhou"), 10, "Demo"};
         ParameterMetric metric = new ParameterMetric();
         ParameterMetricStorage.getMetricsMap().put(resourceWrapper.getName(), metric);
-        metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
-        metric.getRuleTokenCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
+        metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<>(4000));
+        metric.getRuleTokenCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<>(4000));
 
         assertTrue(ParamFlowChecker.passCheck(resourceWrapper, rule, 1, args));
         assertFalse(ParamFlowChecker.passCheck(resourceWrapper, rule, 1, args));

--- a/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowDefaultCheckerTest.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowDefaultCheckerTest.java
@@ -23,7 +23,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.After;
 import org.junit.Before;
@@ -59,9 +58,9 @@ public class ParamFlowDefaultCheckerTest extends AbstractTimeBasedTest {
         String valueA = "valueA";
         ParameterMetric metric = new ParameterMetric();
         ParameterMetricStorage.getMetricsMap().put(resourceWrapper.getName(), metric);
-        metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
+        metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<>(4000));
         metric.getRuleTokenCounterMap().put(rule,
-            new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
+            new ConcurrentLinkedHashMapWrapper<>(4000));
 
         // We mock the time directly to avoid unstable behaviour.
         setCurrentMillis(System.currentTimeMillis());
@@ -97,9 +96,9 @@ public class ParamFlowDefaultCheckerTest extends AbstractTimeBasedTest {
         String valueA = "valueA";
         ParameterMetric metric = new ParameterMetric();
         ParameterMetricStorage.getMetricsMap().put(resourceWrapper.getName(), metric);
-        metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
+        metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<>(4000));
         metric.getRuleTokenCounterMap().put(rule,
-            new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
+            new ConcurrentLinkedHashMapWrapper<>(4000));
 
         // We mock the time directly to avoid unstable behaviour.
         setCurrentMillis(System.currentTimeMillis());
@@ -137,9 +136,9 @@ public class ParamFlowDefaultCheckerTest extends AbstractTimeBasedTest {
         String valueA = "valueA";
         ParameterMetric metric = new ParameterMetric();
         ParameterMetricStorage.getMetricsMap().put(resourceWrapper.getName(), metric);
-        metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
+        metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<>(4000));
         metric.getRuleTokenCounterMap().put(rule,
-            new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
+            new ConcurrentLinkedHashMapWrapper<>(4000));
 
         // We mock the time directly to avoid unstable behaviour.
         setCurrentMillis(System.currentTimeMillis());
@@ -207,9 +206,9 @@ public class ParamFlowDefaultCheckerTest extends AbstractTimeBasedTest {
         String valueA = "helloWorld";
         ParameterMetric metric = new ParameterMetric();
         ParameterMetricStorage.getMetricsMap().put(resourceWrapper.getName(), metric);
-        metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
+        metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<>(4000));
         metric.getRuleTokenCounterMap().put(rule,
-            new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
+            new ConcurrentLinkedHashMapWrapper<>(4000));
 
         // We mock the time directly to avoid unstable behaviour.
         setCurrentMillis(System.currentTimeMillis());
@@ -260,9 +259,9 @@ public class ParamFlowDefaultCheckerTest extends AbstractTimeBasedTest {
         final String valueA = "valueA";
         ParameterMetric metric = new ParameterMetric();
         ParameterMetricStorage.getMetricsMap().put(resourceWrapper.getName(), metric);
-        metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
+        metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<>(4000));
         metric.getRuleTokenCounterMap().put(rule,
-            new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
+            new ConcurrentLinkedHashMapWrapper<>(4000));
         int threadCount = 40;
 
         final CountDownLatch waitLatch = new CountDownLatch(threadCount);

--- a/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowRuleUtilTest.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowRuleUtilTest.java
@@ -72,7 +72,7 @@ public class ParamFlowRuleUtilTest {
     public void testParseHotParamExceptionItemsSuccess() {
         // Test for empty list.
         assertEquals(0, ParamFlowRuleUtil.parseHotItems(null).size());
-        assertEquals(0, ParamFlowRuleUtil.parseHotItems(new ArrayList<ParamFlowItem>()).size());
+        assertEquals(0, ParamFlowRuleUtil.parseHotItems(new ArrayList<>()).size());
 
         // Test for boxing objects and primitive types.
         Double valueA = 1.1d;

--- a/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowThrottleRateLimitingCheckerTest.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowThrottleRateLimitingCheckerTest.java
@@ -19,7 +19,6 @@ import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.After;
 import org.junit.Before;
@@ -57,7 +56,7 @@ public class ParamFlowThrottleRateLimitingCheckerTest {
         String valueA = "valueA";
         ParameterMetric metric = new ParameterMetric();
         ParameterMetricStorage.getMetricsMap().put(resourceWrapper.getName(), metric);
-        metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
+        metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<>(4000));
 
         long currentTime = TimeUtil.currentTimeMillis();
         long endTime = currentTime + rule.getDurationInSec() * 1000;
@@ -101,7 +100,7 @@ public class ParamFlowThrottleRateLimitingCheckerTest {
         final String valueA = "valueA";
         ParameterMetric metric = new ParameterMetric();
         ParameterMetricStorage.getMetricsMap().put(resourceWrapper.getName(), metric);
-        metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
+        metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<>(4000));
 
         int threadCount = 40;
         System.out.println(metric.getRuleTimeCounter(rule));

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/command/CommandHandlerProvider.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/command/CommandHandlerProvider.java
@@ -36,7 +36,7 @@ public class CommandHandlerProvider implements Iterable<CommandHandler> {
      * @return list of all named command handlers
      */
     public Map<String, CommandHandler> namedHandlers() {
-        Map<String, CommandHandler> map = new HashMap<String, CommandHandler>();
+        Map<String, CommandHandler> map = new HashMap<>();
         List<CommandHandler> handlers = spiLoader.loadInstanceList();
         for (CommandHandler handler : handlers) {
             String name = parseCommandName(handler);

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/command/CommandRequest.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/command/CommandRequest.java
@@ -27,8 +27,8 @@ import com.alibaba.csp.sentinel.util.StringUtil;
  */
 public class CommandRequest {
 
-    private final Map<String, String> metadata = new HashMap<String, String>();
-    private final Map<String, String> parameters = new HashMap<String, String>();
+    private final Map<String, String> metadata = new HashMap<>();
+    private final Map<String, String> parameters = new HashMap<>();
     private byte[] body;
 
     public byte[] getBody() {

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/command/CommandResponse.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/command/CommandResponse.java
@@ -45,7 +45,7 @@ public class CommandResponse<R> {
      * @return constructed server response
      */
     public static <T> CommandResponse<T> ofSuccess(T result) {
-        return new CommandResponse<T>(result);
+        return new CommandResponse<>(result);
     }
 
     /**
@@ -55,7 +55,7 @@ public class CommandResponse<R> {
      * @return constructed server response
      */
     public static <T> CommandResponse<T> ofFailure(Throwable ex) {
-        return new CommandResponse<T>(null, false, ex);
+        return new CommandResponse<>(null, false, ex);
     }
 
     /**
@@ -66,7 +66,7 @@ public class CommandResponse<R> {
      * @return constructed server response
      */
     public static <T> CommandResponse<T> ofFailure(Throwable ex, T result) {
-        return new CommandResponse<T>(result, false, ex);
+        return new CommandResponse<>(result, false, ex);
     }
 
     public boolean isSuccess() {

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/command/handler/FetchJsonTreeCommandHandler.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/command/handler/FetchJsonTreeCommandHandler.java
@@ -37,7 +37,7 @@ public class FetchJsonTreeCommandHandler implements CommandHandler<String> {
 
     @Override
     public CommandResponse<String> handle(CommandRequest request) {
-        List<NodeVo> results = new ArrayList<NodeVo>();
+        List<NodeVo> results = new ArrayList<>();
         visit(Constants.ROOT, results, null);
         return CommandResponse.ofSuccess(JSON.toJSONString(results));
     }

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/command/handler/FetchSimpleClusterNodeCommandHandler.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/command/handler/FetchSimpleClusterNodeCommandHandler.java
@@ -41,7 +41,7 @@ public class FetchSimpleClusterNodeCommandHandler implements CommandHandler<Stri
          * type==notZero means nodes whose totalRequest <= 0 will be ignored.
          */
         String type = request.getParam("type");
-        List<NodeVo> list = new ArrayList<NodeVo>();
+        List<NodeVo> list = new ArrayList<>();
         Map<ResourceWrapper, ClusterNode> map = ClusterBuilderSlot.getClusterNodeMap();
         if (map == null) {
             return CommandResponse.ofSuccess(JSONArray.toJSONString(list));

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/command/handler/FetchSystemStatusCommandHandler.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/command/handler/FetchSystemStatusCommandHandler.java
@@ -34,7 +34,7 @@ public class FetchSystemStatusCommandHandler implements CommandHandler<String> {
     @Override
     public CommandResponse<String> handle(CommandRequest request) {
 
-        Map<String, Object> systemStatus = new HashMap<String, Object>();
+        Map<String, Object> systemStatus = new HashMap<>();
 
         systemStatus.put("rqps", Constants.ENTRY_NODE.successQps());
         systemStatus.put("qps", Constants.ENTRY_NODE.passQps());

--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/config/TransportConfig.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/config/TransportConfig.java
@@ -67,7 +67,7 @@ public class TransportConfig {
      */
     public static List<Endpoint> getConsoleServerList() {
         String config = SentinelConfig.getConfig(CONSOLE_SERVER);
-        List<Endpoint> list = new ArrayList<Endpoint>();
+        List<Endpoint> list = new ArrayList<>();
         if (StringUtil.isBlank(config)) {
             return list;
         }

--- a/sentinel-transport/sentinel-transport-netty-http/src/main/java/com/alibaba/csp/sentinel/transport/command/codec/CodecRegistry.java
+++ b/sentinel-transport/sentinel-transport-netty-http/src/main/java/com/alibaba/csp/sentinel/transport/command/codec/CodecRegistry.java
@@ -23,8 +23,8 @@ import java.util.List;
  */
 public final class CodecRegistry {
 
-    private final List<Encoder<?>> encoderList = new ArrayList<Encoder<?>>();
-    private final List<Decoder<?>> decoderList = new ArrayList<Decoder<?>>();
+    private final List<Encoder<?>> encoderList = new ArrayList<>();
+    private final List<Decoder<?>> decoderList = new ArrayList<>();
 
     public CodecRegistry() {
         // Register default codecs.

--- a/sentinel-transport/sentinel-transport-netty-http/src/main/java/com/alibaba/csp/sentinel/transport/command/netty/HttpServer.java
+++ b/sentinel-transport/sentinel-transport-netty-http/src/main/java/com/alibaba/csp/sentinel/transport/command/netty/HttpServer.java
@@ -43,7 +43,7 @@ public final class HttpServer {
 
     private Channel channel;
 
-    final static Map<String, CommandHandler> handlerMap = new ConcurrentHashMap<String, CommandHandler>();
+    final static Map<String, CommandHandler> handlerMap = new ConcurrentHashMap<>();
 
     public void start() throws Exception {
         EventLoopGroup bossGroup = new NioEventLoopGroup(1);

--- a/sentinel-transport/sentinel-transport-netty-http/src/test/java/com/alibaba/csp/sentinel/transport/command/netty/HttpServerHandlerTest.java
+++ b/sentinel-transport/sentinel-transport-netty-http/src/test/java/com/alibaba/csp/sentinel/transport/command/netty/HttpServerHandlerTest.java
@@ -150,7 +150,7 @@ public class HttpServerHandlerTest {
 
     @Test
     public void testFetchActiveRuleCommandSomeFlowRules() {
-        List<FlowRule> rules = new ArrayList<FlowRule>();
+        List<FlowRule> rules = new ArrayList<>();
         FlowRule rule1 = new FlowRule();
         rule1.setResource("key");
         rule1.setCount(20);

--- a/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/command/SimpleHttpCommandCenter.java
+++ b/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/command/SimpleHttpCommandCenter.java
@@ -53,7 +53,7 @@ public class SimpleHttpCommandCenter implements CommandCenter {
     private static final int DEFAULT_PORT = 8719;
 
     @SuppressWarnings("rawtypes")
-    private static final Map<String, CommandHandler> handlerMap = new ConcurrentHashMap<String, CommandHandler>();
+    private static final Map<String, CommandHandler> handlerMap = new ConcurrentHashMap<>();
 
     @SuppressWarnings("PMD.ThreadPoolCreationRule")
     private ExecutorService executor = Executors.newSingleThreadExecutor(
@@ -74,7 +74,7 @@ public class SimpleHttpCommandCenter implements CommandCenter {
     public void start() throws Exception {
         int nThreads = Runtime.getRuntime().availableProcessors();
         this.bizExecutor = new ThreadPoolExecutor(nThreads, nThreads, 0L, TimeUnit.MILLISECONDS,
-            new ArrayBlockingQueue<Runnable>(10),
+            new ArrayBlockingQueue<>(10),
             new NamedThreadFactory("sentinel-command-center-service-executor", true),
             new RejectedExecutionHandler() {
                 @Override

--- a/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/command/http/HttpEventTask.java
+++ b/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/command/http/HttpEventTask.java
@@ -202,7 +202,7 @@ public class HttpEventTask implements Runnable {
      * @throws IOException
      */
     protected static Map<String, String> parsePostHeaders(InputStream in) throws IOException {
-        Map<String, String> headerMap = new HashMap<String, String>(4);
+        Map<String, String> headerMap = new HashMap<>(4);
         String line;
         while (true) {
             line = readLine(in);

--- a/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/heartbeat/HeartbeatMessage.java
+++ b/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/heartbeat/HeartbeatMessage.java
@@ -33,7 +33,7 @@ import com.alibaba.csp.sentinel.util.TimeUtil;
  */
 public class HeartbeatMessage {
 
-    private final Map<String, String> message = new HashMap<String, String>();
+    private final Map<String, String> message = new HashMap<>();
 
     public HeartbeatMessage() {
         message.put("hostname", HostNameUtil.getHostName());

--- a/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/heartbeat/client/SimpleHttpRequest.java
+++ b/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/heartbeat/client/SimpleHttpRequest.java
@@ -92,7 +92,7 @@ public class SimpleHttpRequest {
             throw new IllegalArgumentException("Parameter key cannot be empty");
         }
         if (params == null) {
-            params = new HashMap<String, String>();
+            params = new HashMap<>();
         }
         params.put(key, value);
         return this;

--- a/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/heartbeat/client/SimpleHttpResponseParser.java
+++ b/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/heartbeat/client/SimpleHttpResponseParser.java
@@ -61,7 +61,7 @@ public class SimpleHttpResponseParser {
         int bg = 0;
         int len;
         String statusLine = null;
-        Map<String, String> headers = new HashMap<String, String>();
+        Map<String, String> headers = new HashMap<>();
         Charset charset = Charset.forName("utf-8");
         int contentLength = -1;
         SimpleHttpResponse response;


### PR DESCRIPTION
Java 7 introduced the diamond operator `<>` to reduce the verbosity of generics code.

Happy Hacktoberfest!

Co-authored-by: Moderne <team@moderne.io>