### PR TITLE
refactor: no double brace initialization

### DIFF
--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/GatewayParamParserTest.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/common/param/GatewayParamParserTest.java
@@ -96,54 +96,54 @@ public class GatewayParamParserTest {
         final String paramName = "p";
         final String cookieName = "myCookie";
         GatewayFlowRule routeRuleNoParam = new GatewayFlowRule(routeId1)
-            .setCount(10)
-            .setIntervalSec(10);
+                .setCount(10)
+                .setIntervalSec(10);
         GatewayFlowRule routeRule1 = new GatewayFlowRule(routeId1)
-            .setCount(2)
-            .setIntervalSec(2)
-            .setBurst(2)
-            .setParamItem(new GatewayParamFlowItem()
-                .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_CLIENT_IP)
-            );
+                .setCount(2)
+                .setIntervalSec(2)
+                .setBurst(2)
+                .setParamItem(new GatewayParamFlowItem()
+                        .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_CLIENT_IP)
+                );
         GatewayFlowRule routeRule2 = new GatewayFlowRule(routeId1)
-            .setCount(10)
-            .setIntervalSec(1)
-            .setControlBehavior(RuleConstant.CONTROL_BEHAVIOR_RATE_LIMITER)
-            .setMaxQueueingTimeoutMs(600)
-            .setParamItem(new GatewayParamFlowItem()
-                .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_HEADER)
-                .setFieldName(headerName)
-            );
+                .setCount(10)
+                .setIntervalSec(1)
+                .setControlBehavior(RuleConstant.CONTROL_BEHAVIOR_RATE_LIMITER)
+                .setMaxQueueingTimeoutMs(600)
+                .setParamItem(new GatewayParamFlowItem()
+                        .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_HEADER)
+                        .setFieldName(headerName)
+                );
         GatewayFlowRule routeRule3 = new GatewayFlowRule(routeId1)
-            .setCount(20)
-            .setIntervalSec(1)
-            .setBurst(5)
-            .setParamItem(new GatewayParamFlowItem()
-                .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_URL_PARAM)
-                .setFieldName(paramName)
-            );
+                .setCount(20)
+                .setIntervalSec(1)
+                .setBurst(5)
+                .setParamItem(new GatewayParamFlowItem()
+                        .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_URL_PARAM)
+                        .setFieldName(paramName)
+                );
         GatewayFlowRule routeRule4 = new GatewayFlowRule(routeId1)
-            .setCount(120)
-            .setIntervalSec(10)
-            .setBurst(30)
-            .setParamItem(new GatewayParamFlowItem()
-                .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_HOST)
-            );
+                .setCount(120)
+                .setIntervalSec(10)
+                .setBurst(30)
+                .setParamItem(new GatewayParamFlowItem()
+                        .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_HOST)
+                );
         GatewayFlowRule routeRule5 = new GatewayFlowRule(routeId1)
-            .setCount(50)
-            .setIntervalSec(30)
-            .setParamItem(new GatewayParamFlowItem()
-                .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_COOKIE)
-                .setFieldName(cookieName)
-            );
+                .setCount(50)
+                .setIntervalSec(30)
+                .setParamItem(new GatewayParamFlowItem()
+                        .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_COOKIE)
+                        .setFieldName(cookieName)
+                );
         GatewayFlowRule apiRule1 = new GatewayFlowRule(api1)
-            .setResourceMode(SentinelGatewayConstants.RESOURCE_MODE_CUSTOM_API_NAME)
-            .setCount(5)
-            .setIntervalSec(1)
-            .setParamItem(new GatewayParamFlowItem()
-                .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_URL_PARAM)
-                .setFieldName(paramName)
-            );
+                .setResourceMode(SentinelGatewayConstants.RESOURCE_MODE_CUSTOM_API_NAME)
+                .setCount(5)
+                .setIntervalSec(1)
+                .setParamItem(new GatewayParamFlowItem()
+                        .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_URL_PARAM)
+                        .setFieldName(paramName)
+                );
         rules.add(routeRule1);
         rules.add(routeRule2);
         rules.add(routeRule3);
@@ -160,9 +160,9 @@ public class GatewayParamParserTest {
         final String expectedCookieValue1 = "Sentinel-Foo";
 
         mockClientHostAddress(itemParser, expectedAddress);
-        Map<String, String> expectedHeaders = new HashMap<String, String>() {{
-            put(headerName, expectedHeaderValue1); put("Host", expectedHost);
-        }};
+        Map<String, String> expectedHeaders = new HashMap<String, String>();
+        expectedHeaders.put(headerName, expectedHeaderValue1);
+        expectedHeaders.put("Host", expectedHost);
         mockHeaders(itemParser, expectedHeaders);
         mockSingleUrlParam(itemParser, paramName, expectedUrlParamValue1);
         mockSingleCookie(itemParser, cookieName, expectedCookieValue1);

--- a/sentinel-adapter/sentinel-spring-cloud-gateway-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/sc/SpringCloudGatewayParamParserTest.java
+++ b/sentinel-adapter/sentinel-spring-cloud-gateway-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/sc/SpringCloudGatewayParamParserTest.java
@@ -86,44 +86,44 @@ public class SpringCloudGatewayParamParserTest {
         String headerName = "X-Sentinel-Flag";
         String paramName = "p";
         GatewayFlowRule routeRule1 = new GatewayFlowRule(routeId1)
-            .setCount(2)
-            .setIntervalSec(2)
-            .setBurst(2)
-            .setParamItem(new GatewayParamFlowItem()
-                .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_CLIENT_IP)
-            );
+                .setCount(2)
+                .setIntervalSec(2)
+                .setBurst(2)
+                .setParamItem(new GatewayParamFlowItem()
+                        .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_CLIENT_IP)
+                );
         GatewayFlowRule routeRule2 = new GatewayFlowRule(routeId1)
-            .setCount(10)
-            .setIntervalSec(1)
-            .setControlBehavior(RuleConstant.CONTROL_BEHAVIOR_RATE_LIMITER)
-            .setMaxQueueingTimeoutMs(600)
-            .setParamItem(new GatewayParamFlowItem()
-                .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_HEADER)
-                .setFieldName(headerName)
-            );
+                .setCount(10)
+                .setIntervalSec(1)
+                .setControlBehavior(RuleConstant.CONTROL_BEHAVIOR_RATE_LIMITER)
+                .setMaxQueueingTimeoutMs(600)
+                .setParamItem(new GatewayParamFlowItem()
+                        .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_HEADER)
+                        .setFieldName(headerName)
+                );
         GatewayFlowRule routeRule3 = new GatewayFlowRule(routeId1)
-            .setCount(20)
-            .setIntervalSec(1)
-            .setBurst(5)
-            .setParamItem(new GatewayParamFlowItem()
-                .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_URL_PARAM)
-                .setFieldName(paramName)
-            );
+                .setCount(20)
+                .setIntervalSec(1)
+                .setBurst(5)
+                .setParamItem(new GatewayParamFlowItem()
+                        .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_URL_PARAM)
+                        .setFieldName(paramName)
+                );
         GatewayFlowRule routeRule4 = new GatewayFlowRule(routeId1)
-            .setCount(120)
-            .setIntervalSec(10)
-            .setBurst(30)
-            .setParamItem(new GatewayParamFlowItem()
-                .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_HOST)
-            );
+                .setCount(120)
+                .setIntervalSec(10)
+                .setBurst(30)
+                .setParamItem(new GatewayParamFlowItem()
+                        .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_HOST)
+                );
         GatewayFlowRule apiRule1 = new GatewayFlowRule(api1)
-            .setResourceMode(SentinelGatewayConstants.RESOURCE_MODE_CUSTOM_API_NAME)
-            .setCount(5)
-            .setIntervalSec(1)
-            .setParamItem(new GatewayParamFlowItem()
-                .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_URL_PARAM)
-                .setFieldName(paramName)
-            );
+                .setResourceMode(SentinelGatewayConstants.RESOURCE_MODE_CUSTOM_API_NAME)
+                .setCount(5)
+                .setIntervalSec(1)
+                .setParamItem(new GatewayParamFlowItem()
+                        .setParseStrategy(SentinelGatewayConstants.PARAM_PARSE_STRATEGY_URL_PARAM)
+                        .setFieldName(paramName)
+                );
         rules.add(routeRule1);
         rules.add(routeRule2);
         rules.add(routeRule3);
@@ -136,9 +136,9 @@ public class SpringCloudGatewayParamParserTest {
         String expectedHeaderValue1 = "Sentinel";
         String expectedUrlParamValue1 = "17";
         mockClientHostAddress(request, expectedAddress);
-        Map<String, String> expectedHeaders = new HashMap<String, String>() {{
-            put(headerName, expectedHeaderValue1); put("Host", expectedHost);
-        }};
+        Map<String, String> expectedHeaders = new HashMap<String, String>();
+        expectedHeaders.put(headerName, expectedHeaderValue1);
+        expectedHeaders.put("Host", expectedHost);
         mockHeaders(request, expectedHeaders);
         mockSingleUrlParam(request, paramName, expectedUrlParamValue1);
         Object[] params = paramParser.parseParameterFor(routeId1, exchange, e -> e.getResourceMode() == 0);

--- a/sentinel-cluster/sentinel-cluster-client-default/src/test/java/com/alibaba/csp/sentinel/cluster/client/codec/data/ParamFlowRequestDataWriterTest.java
+++ b/sentinel-cluster/sentinel-cluster-client-default/src/test/java/com/alibaba/csp/sentinel/cluster/client/codec/data/ParamFlowRequestDataWriterTest.java
@@ -33,11 +33,10 @@ public class ParamFlowRequestDataWriterTest {
         final int maxSize = 15;
         ParamFlowRequestDataWriter writer = new ParamFlowRequestDataWriter(maxSize);
 
-        ArrayList<Object> params = new ArrayList<Object>() {{
-            add(1);
-            add(64);
-            add(3);
-        }};
+        ArrayList<Object> params = new ArrayList<Object>();
+        params.add(1);
+        params.add(64);
+        params.add(3);
 
         List<Object> validParams = writer.resolveValidParams(params);
         assertTrue(validParams.contains(1) && validParams.contains(64) && validParams.contains(3));

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/metric/MetricFetcher.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/metric/MetricFetcher.java
@@ -89,7 +89,7 @@ public class MetricFetcher {
 
     @SuppressWarnings("PMD.ThreadPoolCreationRule")
     private ScheduledExecutorService fetchScheduleService = Executors.newScheduledThreadPool(1,
-        new NamedThreadFactory("sentinel-dashboard-metrics-fetch-task", true));
+            new NamedThreadFactory("sentinel-dashboard-metrics-fetch-task", true));
     private ExecutorService fetchService;
     private ExecutorService fetchWorker;
 
@@ -99,27 +99,27 @@ public class MetricFetcher {
         int queueSize = 2048;
         RejectedExecutionHandler handler = new DiscardPolicy();
         fetchService = new ThreadPoolExecutor(cores, cores,
-            keepAliveTime, TimeUnit.MILLISECONDS, new ArrayBlockingQueue<>(queueSize),
-            new NamedThreadFactory("sentinel-dashboard-metrics-fetchService", true), handler);
+                keepAliveTime, TimeUnit.MILLISECONDS, new ArrayBlockingQueue<>(queueSize),
+                new NamedThreadFactory("sentinel-dashboard-metrics-fetchService", true), handler);
         fetchWorker = new ThreadPoolExecutor(cores, cores,
-            keepAliveTime, TimeUnit.MILLISECONDS, new ArrayBlockingQueue<>(queueSize),
-            new NamedThreadFactory("sentinel-dashboard-metrics-fetchWorker",true), handler);
+                keepAliveTime, TimeUnit.MILLISECONDS, new ArrayBlockingQueue<>(queueSize),
+                new NamedThreadFactory("sentinel-dashboard-metrics-fetchWorker", true), handler);
         IOReactorConfig ioConfig = IOReactorConfig.custom()
-            .setConnectTimeout(3000)
-            .setSoTimeout(3000)
-            .setIoThreadCount(Runtime.getRuntime().availableProcessors() * 2)
-            .build();
+                .setConnectTimeout(3000)
+                .setSoTimeout(3000)
+                .setIoThreadCount(Runtime.getRuntime().availableProcessors() * 2)
+                .build();
 
         httpclient = HttpAsyncClients.custom()
-            .setRedirectStrategy(new DefaultRedirectStrategy() {
-                @Override
-                protected boolean isRedirectable(final String method) {
-                    return false;
-                }
-            }).setMaxConnTotal(4000)
-            .setMaxConnPerRoute(1000)
-            .setDefaultIOReactorConfig(ioConfig)
-            .build();
+                .setRedirectStrategy(new DefaultRedirectStrategy() {
+                    @Override
+                    protected boolean isRedirectable(final String method) {
+                        return false;
+                    }
+                }).setMaxConnTotal(4000)
+                .setMaxConnPerRoute(1000)
+                .setDefaultIOReactorConfig(ioConfig)
+                .build();
         httpclient.start();
         start();
     }
@@ -181,7 +181,7 @@ public class MetricFetcher {
         }
         Set<MachineInfo> machines = appInfo.getMachines();
         logger.debug("enter fetchOnce(" + app + "), machines.size()=" + machines.size()
-            + ", time intervalMs [" + startTime + ", " + endTime + "]");
+                + ", time intervalMs [" + startTime + ", " + endTime + "]");
         if (machines.isEmpty()) {
             return;
         }
@@ -208,7 +208,7 @@ public class MetricFetcher {
                 continue;
             }
             final String url = "http://" + machine.getIp() + ":" + machine.getPort() + "/" + METRIC_URL_PATH
-                + "?startTime=" + startTime + "&endTime=" + endTime + "&refetch=" + false;
+                    + "?startTime=" + startTime + "&endTime=" + endTime + "&refetch=" + false;
             final HttpGet httpGet = new HttpGet(url);
             httpGet.setHeader(HTTP.CONN_DIRECTIVE, HTTP.CONN_CLOSE);
             httpclient.execute(httpGet, new FutureCallback<HttpResponse>() {
@@ -363,11 +363,13 @@ public class MetricFetcher {
         return RES_EXCLUSION_SET.contains(resource);
     }
 
-    private static final Set<String> RES_EXCLUSION_SET = new HashSet<String>() {{
-       add(Constants.TOTAL_IN_RESOURCE_NAME);
-       add(Constants.SYSTEM_LOAD_RESOURCE_NAME);
-       add(Constants.CPU_USAGE_RESOURCE_NAME);
-    }};
+    private static final Set<String> RES_EXCLUSION_SET;
+    static {
+        RES_EXCLUSION_SET = new HashSet<>();
+        RES_EXCLUSION_SET.add(Constants.TOTAL_IN_RESOURCE_NAME);
+        RES_EXCLUSION_SET.add(Constants.SYSTEM_LOAD_RESOURCE_NAME);
+        RES_EXCLUSION_SET.add(Constants.CPU_USAGE_RESOURCE_NAME);
+    }
 
 }
 


### PR DESCRIPTION
Happy Hacktoberfest!

Replace `List`, `Map`, and `Set` double brace initialization with an initialization block.

#### Background
Because Double Brace Initialization (DBI) creates an anonymous class with a reference to the instance of the owning object, its use can lead to memory leaks if the anonymous inner class is returned and held by other objects. Even when there's no leak, DBI is so obscure that it's bound to confuse most maintainers.

Non-static initializers are rarely used, and can be confusing for most developers because they only run when new class instances are created. When possible, non-static initializers should be refactored into standard constructors or field initializers.

Co-authored-by: Moderne <team@moderne.io>