### PR TITLE
feat: [ParamFlowRule]Add support for extracting param from complex object, when grade is RuleConstant.FLOW_GRADE_THREAD

### DIFF
--- a/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowChecker.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowChecker.java
@@ -60,9 +60,8 @@ public final class ParamFlowChecker {
         Object value = args[paramIdx];
 
         // Assign value with the result of paramFlowKey method
-        if (value instanceof ParamFlowArgument) {
-            value = ((ParamFlowArgument) value).paramFlowKey();
-        }
+        value = ParamFlowRuleUtil.getRealArg(value);
+
         // If value is null, then pass
         if (value == null) {
             return true;

--- a/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowRuleUtil.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowRuleUtil.java
@@ -239,6 +239,13 @@ public final class ParamFlowRuleUtil {
         return value;
     }
 
+    static Object getRealArg(Object arg) {
+        if (arg instanceof ParamFlowArgument) {
+            return ((ParamFlowArgument) arg).paramFlowKey();
+        }
+        return arg;
+    }
+
     private static final Function<ParamFlowRule, String> EXTRACT_RESOURCE = new Function<ParamFlowRule, String>() {
         @Override
         public String apply(ParamFlowRule rule) {

--- a/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParameterMetricTest.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParameterMetricTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -179,6 +180,37 @@ public class ParameterMetricTest {
         assertEquals(1, metric.getThreadCountMap().size());
         threadCountMap = metric.getThreadCountMap().get(rule.getParamIdx());
         assertEquals(0, threadCountMap.size());
+    }
+
+    @Test
+    public void testAddAndDecreaseThreadCountForParamFlowArgument() {
+        ParamFlowRule rule = new ParamFlowRule();
+        rule.setParamIdx(0);
+        ParameterMetric metric = new ParameterMetric();
+        metric.initialize(rule);
+        assertTrue(metric.getThreadCountMap().containsKey(rule.getParamIdx()));
+
+        class ParamFlowArgumentImpl implements ParamFlowArgument {
+            private final String name;
+            public ParamFlowArgumentImpl(String name) {
+                this.name = name;
+            }
+            @Override
+            public Object paramFlowKey() {
+                return this.name;
+            }
+        }
+
+        String realArg = "abc";
+        metric.addThreadCount(new ParamFlowArgumentImpl(realArg));
+        metric.addThreadCount(new ParamFlowArgumentImpl(realArg));
+        assertEquals(1, metric.getThreadCountMap().size());
+        assertEquals(2, metric.getThreadCountMap().get(0).get(realArg).get());
+
+        metric.decreaseThreadCount(new ParamFlowArgumentImpl(realArg));
+        assertEquals(1, metric.getThreadCountMap().get(0).get(realArg).get());
+        metric.decreaseThreadCount(new ParamFlowArgumentImpl(realArg));
+        assertNull(metric.getThreadCountMap().get(0).get(realArg));
     }
 
     private static final int PARAM_TYPE_NORMAL = 0;


### PR DESCRIPTION
### Describe what this PR does / why we need it

When use ParamFlowRule, set grade to RuleConstant.FLOW_GRADE_THREAD, and use ParamFlowArgument as argument, it doesn't work.
Add support for extracting param from complex object, when grade is RuleConstant.FLOW_GRADE_THREAD.

### Does this pull request fix one issue?

https://github.com/alibaba/Sentinel/issues/2427

### Describe how you did it

these two method takes ParamFlowArgument into account:
1. com.alibaba.csp.sentinel.slots.block.flow.param.ParameterMetric#decreaseThreadCount
2. com.alibaba.csp.sentinel.slots.block.flow.param.ParameterMetric#addThreadCount

### Describe how to verify it

See com.alibaba.csp.sentinel.slots.block.flow.param.ParameterMetricTest#testAddAndDecreaseThreadCountForParamFlowArgument

### Special notes for reviews
