### PR TITLE
Dashboard : Provide flexibility to users of configuring metric time p…

### DIFF
--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/MetricController.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/MetricController.java
@@ -29,6 +29,7 @@ import com.alibaba.csp.sentinel.dashboard.repository.metric.MetricsRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -49,6 +50,9 @@ public class MetricController {
     private static Logger logger = LoggerFactory.getLogger(MetricController.class);
 
     private static final long maxQueryIntervalMs = 1000 * 60 * 60;
+
+    @Value("${metric.time.period.ms}")
+    private long metricTimePeriod;
 
     @Autowired
     private MetricsRepository<MetricEntity> metricStore;
@@ -79,7 +83,7 @@ public class MetricController {
             endTime = System.currentTimeMillis();
         }
         if (startTime == null) {
-            startTime = endTime - 1000 * 60 * 5;
+            startTime = endTime - metricTimePeriod;
         }
         if (endTime - startTime > maxQueryIntervalMs) {
             return Result.ofFail(-1, "time intervalMs is too big, must <= 1h");

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/repository/metric/InMemoryMetricsRepository.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/repository/metric/InMemoryMetricsRepository.java
@@ -18,6 +18,7 @@ package com.alibaba.csp.sentinel.dashboard.repository.metric;
 import com.alibaba.csp.sentinel.dashboard.datasource.entity.MetricEntity;
 import com.alibaba.csp.sentinel.util.StringUtil;
 import com.alibaba.csp.sentinel.util.TimeUtil;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -39,7 +40,8 @@ import java.util.stream.Collectors;
 @Component
 public class InMemoryMetricsRepository implements MetricsRepository<MetricEntity> {
 
-    private static final long MAX_METRIC_LIVE_TIME_MS = 1000 * 60 * 5;
+    @Value("${max.metric.live.time.ms}")
+    private long MAX_METRIC_LIVE_TIME_MS;
 
     /**
      * {@code app -> resource -> timestamp -> metric}

--- a/sentinel-dashboard/src/main/resources/application.properties
+++ b/sentinel-dashboard/src/main/resources/application.properties
@@ -22,3 +22,8 @@ auth.password=sentinel
 # Inject the dashboard version. It's required to enable
 # filtering in pom.xml for this resource file.
 sentinel.dashboard.version=@project.version@
+
+# fetch recent metric data, time unit is ms, default value is 1000 * 60 * 5
+metric.time.period.ms=300000
+# MAX_METRIC_LIVE_TIME_MS
+max.metric.live.time.ms=300000


### PR DESCRIPTION
…eriod and max metric live time as to their needs

Resolves #2448

### Describe what this PR does / why we need it
目前dashbord的实时监控数据只 展示最近5分钟 和 保存最近5分钟的数据，这两个属性是hard code在代码中的；希望能将这两个属性用配置文件管理起来，这样对用户使用的时候更有友好，可以根据需要扩大时间。
### Does this pull request fix one issue?


### Describe how you did it


### Describe how to verify it


### Special notes for reviews
