### PR TITLE
Repair using a third-party persistence in sync, restart the project I…

### DIFF
--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/config/DashboardConfig.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/config/DashboardConfig.java
@@ -15,12 +15,15 @@
  */
 package com.alibaba.csp.sentinel.dashboard.config;
 
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.springframework.lang.NonNull;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * <p>Dashboard local config support.</p>
@@ -65,7 +68,48 @@ public class DashboardConfig {
     public static final String CONFIG_AUTO_REMOVE_MACHINE_MILLIS = "sentinel.dashboard.autoRemoveMachineMillis";
 
     private static final ConcurrentMap<String, Object> cacheMap = new ConcurrentHashMap<>();
-    
+
+    public static final String FLOW_RULE_TYPE = "flow";
+    public static final String DEGRADE_RULE_TYPE = "degrade";
+    public static final String SYSTEM_RULE_TYPE = "system";
+    public static final String AUTHORITY_TYPE = "authority";
+    public static final String PARAM_FLOW_TYPE = "paramFlow";
+    public static final String API_DEFINITIONS_TYPE = "apiDefinitions";
+    public static final String GATEWAY_FLOW_TYPE = "gatewayFlow";
+
+    /**
+     * Persistent flag of the third-party ,default false memory persistent
+     */
+    public static Boolean THIRD_PARTY_PERSISTENCE_FLAG = Boolean.FALSE;
+
+    /**
+     * Third-party persistence initializes memory the app/type list
+     */
+    public static final List<String> THIRD_PARTY_PERSISTENCE_LIST = Collections.synchronizedList(new ArrayList<>());
+
+    private static final String CONCAT_APP_TYPE_TEMPLATE = "%s/%s";
+
+    /**
+     * @param app  appName
+     * @param type type
+     * @return String
+     */
+    public static String concatAppAndType(String app, String type) {
+        return String.format(CONCAT_APP_TYPE_TEMPLATE, app, type);
+    }
+
+    /**
+     * Initialization memory is required
+     *
+     * @param appType appType
+     * @return Boolean
+     */
+    public static Boolean initFlag(String appType) {
+        return THIRD_PARTY_PERSISTENCE_FLAG &&
+                !THIRD_PARTY_PERSISTENCE_LIST.contains(appType);
+    }
+
+
     @NonNull
     private static String getConfig(String name) {
         // env
@@ -98,7 +142,7 @@ public class DashboardConfig {
 
     protected static int getConfigInt(String name, int defaultVal, int minVal) {
         if (cacheMap.containsKey(name)) {
-            return (int)cacheMap.get(name);
+            return (int) cacheMap.get(name);
         }
         int val = NumberUtils.toInt(getConfig(name));
         if (val == 0) {
@@ -121,19 +165,19 @@ public class DashboardConfig {
     public static int getHideAppNoMachineMillis() {
         return getConfigInt(CONFIG_HIDE_APP_NO_MACHINE_MILLIS, 0, 60000);
     }
-    
+
     public static int getRemoveAppNoMachineMillis() {
         return getConfigInt(CONFIG_REMOVE_APP_NO_MACHINE_MILLIS, 0, 120000);
     }
-    
+
     public static int getAutoRemoveMachineMillis() {
         return getConfigInt(CONFIG_AUTO_REMOVE_MACHINE_MILLIS, 0, 300000);
     }
-    
+
     public static int getUnhealthyMachineMillis() {
         return getConfigInt(CONFIG_UNHEALTHY_MACHINE_MILLIS, DEFAULT_MACHINE_HEALTHY_TIMEOUT_MS, 30000);
     }
-    
+
     public static void clearCache() {
         cacheMap.clear();
     }

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/DegradeController.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/DegradeController.java
@@ -15,32 +15,25 @@
  */
 package com.alibaba.csp.sentinel.dashboard.controller;
 
-import java.util.Date;
-import java.util.List;
-
 import com.alibaba.csp.sentinel.dashboard.auth.AuthAction;
-import com.alibaba.csp.sentinel.dashboard.client.SentinelApiClient;
-import com.alibaba.csp.sentinel.dashboard.discovery.MachineInfo;
 import com.alibaba.csp.sentinel.dashboard.auth.AuthService.PrivilegeType;
+import com.alibaba.csp.sentinel.dashboard.client.SentinelApiClient;
+import com.alibaba.csp.sentinel.dashboard.config.DashboardConfig;
+import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.DegradeRuleEntity;
+import com.alibaba.csp.sentinel.dashboard.discovery.MachineInfo;
+import com.alibaba.csp.sentinel.dashboard.domain.Result;
 import com.alibaba.csp.sentinel.dashboard.repository.rule.RuleRepository;
 import com.alibaba.csp.sentinel.slots.block.RuleConstant;
 import com.alibaba.csp.sentinel.slots.block.degrade.circuitbreaker.CircuitBreakerStrategy;
 import com.alibaba.csp.sentinel.util.StringUtil;
-
-import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.DegradeRuleEntity;
-import com.alibaba.csp.sentinel.dashboard.domain.Result;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Date;
+import java.util.List;
 
 /**
  * Controller regarding APIs of degrade rules. Refactored since 1.8.0.
@@ -73,6 +66,16 @@ public class DegradeController {
         }
         try {
             List<DegradeRuleEntity> rules = sentinelApiClient.fetchDegradeRuleOfMachine(app, ip, port);
+            if (!CollectionUtils.isEmpty(rules)) {
+                String appType = DashboardConfig.concatAppAndType(app, DashboardConfig.DEGRADE_RULE_TYPE);
+                if (DashboardConfig.initFlag(appType)) {
+                    rules.forEach(rule -> rule.setId(null));
+                    rules = repository.saveAll(rules);
+                    publishRules(app, null, null);
+                    DashboardConfig.THIRD_PARTY_PERSISTENCE_LIST.add(appType);
+                    return Result.ofSuccess(rules);
+                }
+            }
             rules = repository.saveAll(rules);
             return Result.ofSuccess(rules);
         } catch (Throwable throwable) {
@@ -106,7 +109,7 @@ public class DegradeController {
     @PutMapping("/rule/{id}")
     @AuthAction(PrivilegeType.WRITE_RULE)
     public Result<DegradeRuleEntity> apiUpdateRule(@PathVariable("id") Long id,
-                                                     @RequestBody DegradeRuleEntity entity) {
+                                                   @RequestBody DegradeRuleEntity entity) {
         if (id == null || id <= 0) {
             return Result.ofFail(-1, "id can't be null or negative");
         }
@@ -195,10 +198,10 @@ public class DegradeController {
             return Result.ofFail(-1, "circuit breaker strategy cannot be null");
         }
         if (strategy < CircuitBreakerStrategy.SLOW_REQUEST_RATIO.getType()
-            || strategy > RuleConstant.DEGRADE_GRADE_EXCEPTION_COUNT) {
+                || strategy > RuleConstant.DEGRADE_GRADE_EXCEPTION_COUNT) {
             return Result.ofFail(-1, "Invalid circuit breaker strategy: " + strategy);
         }
-        if (entity.getMinRequestAmount()  == null || entity.getMinRequestAmount() <= 0) {
+        if (entity.getMinRequestAmount() == null || entity.getMinRequestAmount() <= 0) {
             return Result.ofFail(-1, "Invalid minRequestAmount");
         }
         if (entity.getStatIntervalMs() == null || entity.getStatIntervalMs() <= 0) {

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/FlowControllerV1.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/FlowControllerV1.java
@@ -15,33 +15,26 @@
  */
 package com.alibaba.csp.sentinel.dashboard.controller;
 
+import com.alibaba.csp.sentinel.dashboard.auth.AuthAction;
+import com.alibaba.csp.sentinel.dashboard.auth.AuthService.PrivilegeType;
+import com.alibaba.csp.sentinel.dashboard.client.SentinelApiClient;
+import com.alibaba.csp.sentinel.dashboard.config.DashboardConfig;
+import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.FlowRuleEntity;
+import com.alibaba.csp.sentinel.dashboard.discovery.MachineInfo;
+import com.alibaba.csp.sentinel.dashboard.domain.Result;
+import com.alibaba.csp.sentinel.dashboard.repository.rule.InMemoryRuleRepositoryAdapter;
+import com.alibaba.csp.sentinel.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.bind.annotation.*;
+
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-
-import com.alibaba.csp.sentinel.dashboard.auth.AuthAction;
-import com.alibaba.csp.sentinel.dashboard.auth.AuthService.PrivilegeType;
-import com.alibaba.csp.sentinel.util.StringUtil;
-
-import com.alibaba.csp.sentinel.dashboard.client.SentinelApiClient;
-import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.FlowRuleEntity;
-import com.alibaba.csp.sentinel.dashboard.discovery.MachineInfo;
-import com.alibaba.csp.sentinel.dashboard.domain.Result;
-import com.alibaba.csp.sentinel.dashboard.repository.rule.InMemoryRuleRepositoryAdapter;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Flow rule controller.
@@ -78,6 +71,16 @@ public class FlowControllerV1 {
         }
         try {
             List<FlowRuleEntity> rules = sentinelApiClient.fetchFlowRuleOfMachine(app, ip, port);
+            if (!CollectionUtils.isEmpty(rules)) {
+                String appType = DashboardConfig.concatAppAndType(app, DashboardConfig.FLOW_RULE_TYPE);
+                if (DashboardConfig.initFlag(appType)) {
+                    rules.forEach(rule -> rule.setId(null));
+                    rules = repository.saveAll(rules);
+                    publishRules(app, null, null);
+                    DashboardConfig.THIRD_PARTY_PERSISTENCE_LIST.add(appType);
+                    return Result.ofSuccess(rules);
+                }
+            }
             rules = repository.saveAll(rules);
             return Result.ofSuccess(rules);
         } catch (Throwable throwable) {
@@ -161,10 +164,10 @@ public class FlowControllerV1 {
     @PutMapping("/save.json")
     @AuthAction(PrivilegeType.WRITE_RULE)
     public Result<FlowRuleEntity> apiUpdateFlowRule(Long id, String app,
-                                                  String limitApp, String resource, Integer grade,
-                                                  Double count, Integer strategy, String refResource,
-                                                  Integer controlBehavior, Integer warmUpPeriodSec,
-                                                  Integer maxQueueingTimeMs) {
+                                                    String limitApp, String resource, Integer grade,
+                                                    Double count, Integer strategy, String refResource,
+                                                    Integer controlBehavior, Integer warmUpPeriodSec,
+                                                    Integer maxQueueingTimeMs) {
         if (id == null) {
             return Result.ofFail(-1, "id can't be null");
         }
@@ -233,7 +236,7 @@ public class FlowControllerV1 {
         } catch (Throwable t) {
             Throwable e = t instanceof ExecutionException ? t.getCause() : t;
             logger.error("Error when updating flow rules, app={}, ip={}, ruleId={}", entity.getApp(),
-                entity.getIp(), id, e);
+                    entity.getIp(), id, e);
             return Result.ofFail(-1, e.getMessage());
         }
     }
@@ -261,7 +264,7 @@ public class FlowControllerV1 {
         } catch (Throwable t) {
             Throwable e = t instanceof ExecutionException ? t.getCause() : t;
             logger.error("Error when deleting flow rules, app={}, ip={}, id={}", oldEntity.getApp(),
-                oldEntity.getIp(), id, e);
+                    oldEntity.getIp(), id, e);
             return Result.ofFail(-1, e.getMessage());
         }
     }

--- a/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/rule/apollo/ApolloConfig.java
+++ b/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/rule/apollo/ApolloConfig.java
@@ -17,6 +17,7 @@ package com.alibaba.csp.sentinel.dashboard.rule.apollo;
 
 import java.util.List;
 
+import com.alibaba.csp.sentinel.dashboard.config.DashboardConfig;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -45,6 +46,7 @@ public class ApolloConfig {
 
     @Bean
     public ApolloOpenApiClient apolloOpenApiClient() {
+        DashboardConfig.THIRD_PARTY_PERSISTENCE_FLAG = Boolean.TRUE;
         ApolloOpenApiClient client = ApolloOpenApiClient.newBuilder()
             .withPortalUrl("http://localhost:10034")
             .withToken("token")

--- a/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/rule/nacos/NacosConfig.java
+++ b/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/rule/nacos/NacosConfig.java
@@ -17,6 +17,7 @@ package com.alibaba.csp.sentinel.dashboard.rule.nacos;
 
 import java.util.List;
 
+import com.alibaba.csp.sentinel.dashboard.config.DashboardConfig;
 import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.FlowRuleEntity;
 import com.alibaba.csp.sentinel.datasource.Converter;
 import com.alibaba.fastjson.JSON;
@@ -45,6 +46,7 @@ public class NacosConfig {
 
     @Bean
     public ConfigService nacosConfigService() throws Exception {
-        return ConfigFactory.createConfigService("localhost");
+        DashboardConfig.THIRD_PARTY_PERSISTENCE_FLAG = Boolean.TRUE;
+        return ConfigFactory.createConfigService("localhost:8848");
     }
 }

--- a/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/rule/zookeeper/ZookeeperConfig.java
+++ b/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/rule/zookeeper/ZookeeperConfig.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.csp.sentinel.dashboard.rule.zookeeper;
 
+import com.alibaba.csp.sentinel.dashboard.config.DashboardConfig;
 import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.FlowRuleEntity;
 import com.alibaba.csp.sentinel.datasource.Converter;
 import com.alibaba.fastjson.JSON;
@@ -41,6 +42,7 @@ public class ZookeeperConfig {
 
     @Bean
     public CuratorFramework zkClient() {
+        DashboardConfig.THIRD_PARTY_PERSISTENCE_FLAG = Boolean.TRUE;
         CuratorFramework zkClient =
                 CuratorFrameworkFactory.newClient("127.0.0.1:2181",
                         new ExponentialBackoffRetry(ZookeeperConfigUtil.SLEEP_TIME, ZookeeperConfigUtil.RETRY_TIMES));


### PR DESCRIPTION
…nMemoryRuleRepositoryAdapter  parent class 'ids' uninitialized, lead to obtain when adding ids or starting from 1, cover the original data

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
在Sentinel服务端使用第三方（nacos，apollo，zookeeper）持久化同步数据时，（以第三方同步使用nacos为例，流控规则已经存储数据的情况）重启sentinel服务如：因为数据同步时获取的List<FlowRuleEntity>里的对象已经含有id值，导致InMemFlowRuleStore 下的ids没有初始化到已有数据量，再添加流控规则时ids获取还是从1开始，这样将覆盖原有的数据（因为allRules.put(processedEntity.getId(), processedEntity)是以id为键，同步数据保存id也是从1开始的）。其他类型数据保存也是一样

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #2465
### Describe how you did it
我准备两种方案如下
1：再添加保存数据的时候，将FlowRuleXxxxPublisher下的publish方法里将id赋值为空，在同步数据时就拿不到RuleEntity的id将会调用InMemoryRuleRepositoryAdapter的nextId()方法，这个ids将于同步数据量一致，但这对于已经线上运行想要迭代的用户不用好，因为他们有可能丢失数据（因为已有数据还是保存了id），所以我才用第二种方案修复问题
2：在重启项目时判断是否是第三方持久化以及是否是第一次访问类型数据（区分app，例如，第一次访问sentinel-dashboard下的flow数据），在调用/rules方法里获取数据时轮询，将id赋值为null，再重新通过nextId()获取id，然后再将数据推送回第三方同步。

### Describe how to verify it
以nacos持久化同步数据为例，随便注册一个app在sentinel服务端，在流控规则上随便添加几条数据，然后重新启动sentinel服务端，还是在流控规则上添加一条数据，这时你会发现新增的数据覆盖掉了原有的第一条数据，继续添加将继续覆盖，直到全部被覆盖为止

### Special notes for reviews
