### PR TITLE
sentinel-dubbo-adapter 1.8.2 consumer端 SentinelRpcException 非业务异常也被统计…

### DIFF
--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboProviderFilter.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboProviderFilter.java
@@ -78,7 +78,8 @@ public class SentinelDubboProviderFilter extends BaseSentinelDubboFilter {
             methodEntry = SphU.entry(methodResourceName, ResourceTypeConstants.COMMON_RPC, EntryType.IN,
                 invocation.getArguments());
             Result result = invoker.invoke(invocation);
-            if (result.hasException()) {
+            // Non-BlockException,Non-wrapped-BlockException (business exception) is recorded.
+            if (result.hasException() && !BlockException.isBlockException(result.getException())) {
                 Tracer.traceEntry(result.getException(), interfaceEntry);
                 Tracer.traceEntry(result.getException(), methodEntry);
             }

--- a/sentinel-adapter/sentinel-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboConsumerFilter.java
+++ b/sentinel-adapter/sentinel-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboConsumerFilter.java
@@ -62,7 +62,9 @@ public class SentinelDubboConsumerFilter extends AbstractDubboFilter implements 
                 EntryType.OUT, invocation.getArguments());
 
             Result result = invoker.invoke(invocation);
-            if (result.hasException()) {
+
+            // Non-BlockException,Non-wrapped-BlockException (business exception) is recorded.
+            if (result.hasException() && !BlockException.isBlockException(result.getException())) {
                 Throwable e = result.getException();
                 // Record common exception.
                 Tracer.traceEntry(e, interfaceEntry);

--- a/sentinel-adapter/sentinel-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboProviderFilter.java
+++ b/sentinel-adapter/sentinel-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboProviderFilter.java
@@ -70,7 +70,9 @@ public class SentinelDubboProviderFilter extends AbstractDubboFilter implements 
                 EntryType.IN, invocation.getArguments());
 
             Result result = invoker.invoke(invocation);
-            if (result.hasException()) {
+
+            // Non-BlockException,Non-wrapped-BlockException (business exception) is recorded.
+            if (result.hasException() && !BlockException.isBlockException(result.getException())) {
                 Throwable e = result.getException();
                 // Record common exception.
                 Tracer.traceEntry(e, interfaceEntry);


### PR DESCRIPTION
… #2464

* Fixes #2464

Author Email: tianzh<812940766@qq.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
fix the issue #2464
Dubbo Adapter: A calls B, and if B limits the flow, A may be degraded

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes  #2464
### Describe how you did it
Add `!BlockException.isBlockException(result.getException())` before `Tracer.traceEntry()`.
If `!BlockException.isBlockException(result.getException())` pass, the `Throwable` can be recorded.

### Describe how to verify it
Please refer to the **How to reproduce it ** description of the issue #2464

### Special notes for reviews
`sentinel-dubbo-adapter1.8.2`  and `sentinel-apache-dubbo-adapter1.8.2`  have the same problem