### PR TITLE
fix degrade_service.js alert message issue 2476

### DIFF
--- a/sentinel-dashboard/src/main/webapp/resources/app/scripts/services/degrade_service.js
+++ b/sentinel-dashboard/src/main/webapp/resources/app/scripts/services/degrade_service.js
@@ -74,7 +74,7 @@ app.service('DegradeService', ['$http', function ($http) {
           return false;
       }
       if (rule.statIntervalMs !== undefined && rule.statIntervalMs > 60 * 1000 * 2) {
-          alert('统计窗口时长不能超过 120 分钟');
+          alert('统计窗口时长最大 120s');
           return false;
       }
       // 异常比率类型.


### PR DESCRIPTION
**Commit Message**

fix the degrade_service.js alert message on line 77, changed "统计窗口市场不能超过 120 分钟" to "统计窗口时长最大 120s"

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
**Issue**

错误的提示信息，degrade_service.js 提示：统计窗口市场不能超过 120 分钟，此处单位应当为 s(秒)

**Change**

"统计窗口市场不能超过 120 分钟" -> "统计窗口时长最大 120s"
### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Fixes #2476

### Describe how you did it
变更提示信息

### Describe how to verify it
/

### Special notes for reviews

/
