### PR TITLE
新增 csp.sentinel.log.level 启动配置项，可设置为OFF，进行关闭日志

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/LogBase.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/LogBase.java
@@ -18,6 +18,7 @@ package com.alibaba.csp.sentinel.log;
 
 import java.io.File;
 import java.util.Properties;
+import java.util.logging.Level;
 
 import static com.alibaba.csp.sentinel.util.ConfigUtil.addSeparator;
 
@@ -40,6 +41,7 @@ public class LogBase {
     public static final String LOG_NAME_USE_PID = "csp.sentinel.log.use.pid";
     public static final String LOG_OUTPUT_TYPE = "csp.sentinel.log.output.type";
     public static final String LOG_CHARSET = "csp.sentinel.log.charset";
+    public static final String LOG_LEVEL = "csp.sentinel.log.level";
 
     /**
      * Output biz log (e.g. RecordLog and CommandCenterLog) to file.
@@ -53,12 +55,14 @@ public class LogBase {
 
     private static final String DIR_NAME = "logs" + File.separator + "csp";
     private static final String USER_HOME = "user.home";
+    private static final Level LOG_DEFAULT_LEVEL = Level.INFO;
 
 
     private static boolean logNameUsePid;
     private static String logOutputType;
     private static String logBaseDir;
     private static String logCharSet;
+    private static Level logLevel;
 
     static {
         try {
@@ -75,6 +79,7 @@ public class LogBase {
         logOutputType = LOG_OUTPUT_TYPE_FILE;
         logBaseDir = addSeparator(System.getProperty(USER_HOME)) + DIR_NAME + File.separator;
         logCharSet = LOG_CHARSET_UTF8;
+        logLevel = LOG_DEFAULT_LEVEL;
     }
 
     private static void loadProperties() {
@@ -103,6 +108,13 @@ public class LogBase {
         String usePid = properties.getProperty(LOG_NAME_USE_PID);
         logNameUsePid = "true".equalsIgnoreCase(usePid);
         System.out.println("INFO: Sentinel log name use pid is: " + logNameUsePid);
+
+        // load log level
+        String logLevelString = properties.getProperty(LOG_LEVEL);
+        if (logLevelString != null && (logLevelString = logLevelString.trim()).length() > 0) {
+            logLevel = Level.parse(logLevelString);
+        }
+        System.out.println("INFO: Sentinel log level is: " + logLevel);
     }
 
 
@@ -142,4 +154,7 @@ public class LogBase {
         return logCharSet;
     }
 
+    public static Level getLogLevel() {
+        return logLevel;
+    }
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/LogBase.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/LogBase.java
@@ -112,7 +112,11 @@ public class LogBase {
         // load log level
         String logLevelString = properties.getProperty(LOG_LEVEL);
         if (logLevelString != null && (logLevelString = logLevelString.trim()).length() > 0) {
-            logLevel = Level.parse(logLevelString);
+            try {
+                logLevel = Level.parse(logLevelString);
+            } catch (IllegalArgumentException e) {
+                System.out.println("Log level : " + logLevel + " is invalid. Use default : " + LOG_DEFAULT_LEVEL.toString());
+            }
         }
         System.out.println("INFO: Sentinel log level is: " + logLevel);
     }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/BaseJulLogger.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/BaseJulLogger.java
@@ -70,6 +70,7 @@ public class BaseJulLogger {
                     handler = new DateFileLogHandler(fileName + ".%d", 1024 * 1024 * 200, 4, true);
                     handler.setFormatter(formatter);
                     handler.setEncoding(logCharSet);
+                    handler.setLevel(LogBase.getLogLevel());
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
@@ -79,6 +80,7 @@ public class BaseJulLogger {
                     handler = new ConsoleHandler();
                     handler.setFormatter(formatter);
                     handler.setEncoding(logCharSet);
+                    handler.setLevel(LogBase.getLogLevel());
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
@@ -92,7 +94,7 @@ public class BaseJulLogger {
         }
 
         // Set log level to INFO by default
-        heliumRecordLog.setLevel(Level.INFO);
+        heliumRecordLog.setLevel(LogBase.getLogLevel());
         return handler;
     }
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManager.java
@@ -17,6 +17,7 @@ package com.alibaba.csp.sentinel.slots.block.flow;
 
 import com.alibaba.csp.sentinel.concurrent.NamedThreadFactory;
 import com.alibaba.csp.sentinel.config.SentinelConfig;
+import com.alibaba.csp.sentinel.log.LogBase;
 import com.alibaba.csp.sentinel.log.RecordLog;
 import com.alibaba.csp.sentinel.node.metric.MetricTimerListener;
 import com.alibaba.csp.sentinel.property.DynamicSentinelProperty;
@@ -32,6 +33,7 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 
 /**
  * <p>
@@ -80,7 +82,9 @@ public class FlowRuleManager {
                 SentinelConfig.METRIC_FLUSH_INTERVAL);
             return;
         }
-        SCHEDULER.scheduleAtFixedRate(new MetricTimerListener(), 0, flushInterval, TimeUnit.SECONDS);
+        if (!LogBase.getLogLevel().equals(Level.OFF)) {
+            SCHEDULER.scheduleAtFixedRate(new MetricTimerListener(), 0, flushInterval, TimeUnit.SECONDS);
+        }
     }
 
     /**

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManager.java
@@ -17,7 +17,6 @@ package com.alibaba.csp.sentinel.slots.block.flow;
 
 import com.alibaba.csp.sentinel.concurrent.NamedThreadFactory;
 import com.alibaba.csp.sentinel.config.SentinelConfig;
-import com.alibaba.csp.sentinel.log.LogBase;
 import com.alibaba.csp.sentinel.log.RecordLog;
 import com.alibaba.csp.sentinel.node.metric.MetricTimerListener;
 import com.alibaba.csp.sentinel.property.DynamicSentinelProperty;
@@ -82,9 +81,7 @@ public class FlowRuleManager {
                 SentinelConfig.METRIC_FLUSH_INTERVAL);
             return;
         }
-        if (!LogBase.getLogLevel().equals(Level.OFF)) {
-            SCHEDULER.scheduleAtFixedRate(new MetricTimerListener(), 0, flushInterval, TimeUnit.SECONDS);
-        }
+        SCHEDULER.scheduleAtFixedRate(new MetricTimerListener(), 0, flushInterval, TimeUnit.SECONDS);
     }
 
     /**

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleManager.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 
 /**
  * <p>


### PR DESCRIPTION
对应issues：Add record log level configuration support | 支持配置 record 日志的输出级别配置 #2505
通过添加启动配置项 csp.sentinel.log.level=OFF，可以选择性的关闭产生的日志