### PR TITLE
提供spring的全局异常处理器，会导致熔断规则(异常数规则)失效解决方案

### DIFF
--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/AbstractSentinelInterceptor.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/AbstractSentinelInterceptor.java
@@ -132,8 +132,9 @@ public abstract class AbstractSentinelInterceptor implements HandlerInterceptor 
     protected String getContextName(HttpServletRequest request) {
         return SENTINEL_SPRING_WEB_CONTEXT_NAME;
     }
-	
-	/**
+
+
+    /**
      * The afterCompletion method of the HandlerInterceptor does not catch exception statistics when using @ControllerAdvice for global exception fetching
      * Call exceptionControllerAdviceExit method to realize exception statistics
      *

--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/AbstractSentinelInterceptor.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/AbstractSentinelInterceptor.java
@@ -35,8 +35,8 @@ import org.springframework.web.servlet.ModelAndView;
 
 /**
  * Since request may be reprocessed in flow if any forwarding or including or other action
- * happened (see {@link javax.servlet.ServletRequest#getDispatcherType()}) we will only 
- * deal with the initial request. So we use <b>reference count</b> to track in 
+ * happened (see {@link javax.servlet.ServletRequest#getDispatcherType()}) we will only
+ * deal with the initial request. So we use <b>reference count</b> to track in
  * dispathing "onion" though which we could figure out whether we are in initial type "REQUEST".
  * That means the sub-requests which we rarely meet in practice will NOT be recorded in Sentinel.
  * <p>
@@ -48,7 +48,7 @@ import org.springframework.web.servlet.ModelAndView;
  *     return mav;
  * }
  * </pre>
- * 
+ *
  * @author kaizi2009
  * @since 1.7.1
  */
@@ -64,26 +64,26 @@ public abstract class AbstractSentinelInterceptor implements HandlerInterceptor 
         AssertUtil.assertNotBlank(config.getRequestAttributeName(), "requestAttributeName should not be blank");
         this.baseWebMvcConfig = config;
     }
-    
+
     /**
      * @param request
      * @param rcKey
      * @param step
-     * @return reference count after increasing (initial value as zero to be increased) 
+     * @return reference count after increasing (initial value as zero to be increased)
      */
     private Integer increaseReferece(HttpServletRequest request, String rcKey, int step) {
         Object obj = request.getAttribute(rcKey);
-        
+
         if (obj == null) {
             // initial
             obj = Integer.valueOf(0);
         }
-        
+
         Integer newRc = (Integer)obj + step;
         request.setAttribute(rcKey, newRc);
         return newRc;
     }
-    
+
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
         throws Exception {
@@ -93,11 +93,11 @@ public abstract class AbstractSentinelInterceptor implements HandlerInterceptor 
             if (StringUtil.isEmpty(resourceName)) {
                 return true;
             }
-            
+
             if (increaseReferece(request, this.baseWebMvcConfig.getRequestRefName(), 1) != 1) {
                 return true;
             }
-            
+
             // Parse the request origin using registered origin parser.
             String origin = parseOrigin(request);
             String contextName = getContextName(request);
@@ -133,13 +133,24 @@ public abstract class AbstractSentinelInterceptor implements HandlerInterceptor 
         return SENTINEL_SPRING_WEB_CONTEXT_NAME;
     }
 
+    /**
+     * The afterCompletion method of the HandlerInterceptor does not catch exception statistics when using @ControllerAdvice for global exception fetching
+     * Call exceptionControllerAdviceExit method to realize exception statistics
+     *
+     * @param request
+     * @param ex
+     */
+    public void exceptionControllerAdviceExit(HttpServletRequest request, Exception ex) {
+        this.afterCompletion(request,null,null, ex);
+    }
+
     @Override
     public void afterCompletion(HttpServletRequest request, HttpServletResponse response,
-                                Object handler, Exception ex) throws Exception {
+                                Object handler, Exception ex){
         if (increaseReferece(request, this.baseWebMvcConfig.getRequestRefName(), -1) != 0) {
             return;
         }
-        
+
         Entry entry = getEntryInRequest(request, baseWebMvcConfig.getRequestAttributeName());
         if (entry == null) {
             // should not happen
@@ -147,7 +158,7 @@ public abstract class AbstractSentinelInterceptor implements HandlerInterceptor 
                     getClass().getSimpleName(), baseWebMvcConfig.getRequestAttributeName());
             return;
         }
-        
+
         traceExceptionAndExit(entry, ex);
         removeEntryInRequest(request);
         ContextUtil.exit();

--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/AbstractSentinelInterceptor.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/AbstractSentinelInterceptor.java
@@ -63,7 +63,6 @@ public abstract class AbstractSentinelInterceptor implements HandlerInterceptor 
         AssertUtil.notNull(config, "BaseWebMvcConfig should not be null");
         AssertUtil.assertNotBlank(config.getRequestAttributeName(), "requestAttributeName should not be blank");
         this.baseWebMvcConfig = config;
-        SentinelAfterException.abstractSentinelInterceptor = this;
     }
     
     /**

--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/AbstractSentinelInterceptor.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/AbstractSentinelInterceptor.java
@@ -64,7 +64,7 @@ public abstract class AbstractSentinelInterceptor implements HandlerInterceptor 
         AssertUtil.assertNotBlank(config.getRequestAttributeName(), "requestAttributeName should not be blank");
         this.baseWebMvcConfig = config;
     }
-	
+    
     /**
      * @param request
      * @param rcKey
@@ -73,31 +73,31 @@ public abstract class AbstractSentinelInterceptor implements HandlerInterceptor 
      */
     private Integer increaseReferece(HttpServletRequest request, String rcKey, int step) {
         Object obj = request.getAttribute(rcKey);
-		
+        
         if (obj == null) {
             // initial
             obj = Integer.valueOf(0);
         }
-		
+        
         Integer newRc = (Integer)obj + step;
         request.setAttribute(rcKey, newRc);
         return newRc;
     }
-	
+    
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
         throws Exception {
         try {
             String resourceName = getResourceName(request);
-			
+
             if (StringUtil.isEmpty(resourceName)) {
                 return true;
             }
-			
+            
             if (increaseReferece(request, this.baseWebMvcConfig.getRequestRefName(), 1) != 1) {
                 return true;
             }
-			
+            
             // Parse the request origin using registered origin parser.
             String origin = parseOrigin(request);
             String contextName = getContextName(request);
@@ -132,8 +132,8 @@ public abstract class AbstractSentinelInterceptor implements HandlerInterceptor 
     protected String getContextName(HttpServletRequest request) {
         return SENTINEL_SPRING_WEB_CONTEXT_NAME;
     }
-
-    /**
+	
+	/**
      * The afterCompletion method of the HandlerInterceptor does not catch exception statistics when using @ControllerAdvice for global exception fetching
      * Call exceptionControllerAdviceExit method to realize exception statistics
      *
@@ -146,11 +146,11 @@ public abstract class AbstractSentinelInterceptor implements HandlerInterceptor 
 
     @Override
     public void afterCompletion(HttpServletRequest request, HttpServletResponse response,
-                                Object handler, Exception ex){
+                                Object handler, Exception ex) {
         if (increaseReferece(request, this.baseWebMvcConfig.getRequestRefName(), -1) != 0) {
             return;
         }
-		
+        
         Entry entry = getEntryInRequest(request, baseWebMvcConfig.getRequestAttributeName());
         if (entry == null) {
             // should not happen
@@ -158,7 +158,7 @@ public abstract class AbstractSentinelInterceptor implements HandlerInterceptor 
                     getClass().getSimpleName(), baseWebMvcConfig.getRequestAttributeName());
             return;
         }
-		
+        
         traceExceptionAndExit(entry, ex);
         removeEntryInRequest(request);
         ContextUtil.exit();

--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/AbstractSentinelInterceptor.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/AbstractSentinelInterceptor.java
@@ -35,8 +35,8 @@ import org.springframework.web.servlet.ModelAndView;
 
 /**
  * Since request may be reprocessed in flow if any forwarding or including or other action
- * happened (see {@link javax.servlet.ServletRequest#getDispatcherType()}) we will only
- * deal with the initial request. So we use <b>reference count</b> to track in
+ * happened (see {@link javax.servlet.ServletRequest#getDispatcherType()}) we will only 
+ * deal with the initial request. So we use <b>reference count</b> to track in 
  * dispathing "onion" though which we could figure out whether we are in initial type "REQUEST".
  * That means the sub-requests which we rarely meet in practice will NOT be recorded in Sentinel.
  * <p>
@@ -48,7 +48,7 @@ import org.springframework.web.servlet.ModelAndView;
  *     return mav;
  * }
  * </pre>
- *
+ * 
  * @author kaizi2009
  * @since 1.7.1
  */
@@ -64,40 +64,40 @@ public abstract class AbstractSentinelInterceptor implements HandlerInterceptor 
         AssertUtil.assertNotBlank(config.getRequestAttributeName(), "requestAttributeName should not be blank");
         this.baseWebMvcConfig = config;
     }
-
+	
     /**
      * @param request
      * @param rcKey
      * @param step
-     * @return reference count after increasing (initial value as zero to be increased)
+     * @return reference count after increasing (initial value as zero to be increased) 
      */
     private Integer increaseReferece(HttpServletRequest request, String rcKey, int step) {
         Object obj = request.getAttribute(rcKey);
-
+		
         if (obj == null) {
             // initial
             obj = Integer.valueOf(0);
         }
-
+		
         Integer newRc = (Integer)obj + step;
         request.setAttribute(rcKey, newRc);
         return newRc;
     }
-
+	
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
         throws Exception {
         try {
             String resourceName = getResourceName(request);
-
+			
             if (StringUtil.isEmpty(resourceName)) {
                 return true;
             }
-
+			
             if (increaseReferece(request, this.baseWebMvcConfig.getRequestRefName(), 1) != 1) {
                 return true;
             }
-
+			
             // Parse the request origin using registered origin parser.
             String origin = parseOrigin(request);
             String contextName = getContextName(request);
@@ -150,7 +150,7 @@ public abstract class AbstractSentinelInterceptor implements HandlerInterceptor 
         if (increaseReferece(request, this.baseWebMvcConfig.getRequestRefName(), -1) != 0) {
             return;
         }
-
+		
         Entry entry = getEntryInRequest(request, baseWebMvcConfig.getRequestAttributeName());
         if (entry == null) {
             // should not happen
@@ -158,7 +158,7 @@ public abstract class AbstractSentinelInterceptor implements HandlerInterceptor 
                     getClass().getSimpleName(), baseWebMvcConfig.getRequestAttributeName());
             return;
         }
-
+		
         traceExceptionAndExit(entry, ex);
         removeEntryInRequest(request);
         ContextUtil.exit();

--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/SentinelAfterException.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/SentinelAfterException.java
@@ -1,0 +1,83 @@
+package com.alibaba.csp.sentinel.adapter.spring.webmvc;
+
+import com.alibaba.csp.sentinel.Entry;
+import com.alibaba.csp.sentinel.Tracer;
+import com.alibaba.csp.sentinel.adapter.spring.webmvc.config.BaseWebMvcConfig;
+import com.alibaba.csp.sentinel.context.ContextUtil;
+import com.alibaba.csp.sentinel.log.RecordLog;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Exception interception statistics
+ *
+ * @author Roy
+ * @date 2022/1/249:15
+ */
+public class SentinelAfterException {
+
+    protected static BaseWebMvcConfig baseWebMvcConfig;
+
+    /**
+     * The afterCompletion method of the HandlerInterceptor does not catch exception statistics when using @ControllerAdvice for global exception fetching
+     * Call SentinelAfterException.exit() method to realize exception statistics
+     *
+     * @param request
+     * @param ex
+     */
+    public static void exit(HttpServletRequest request, Exception ex) {
+        if (increaseReferece(request, baseWebMvcConfig.getRequestRefName(), -1) != 0) {
+            return;
+        }
+
+        Entry entry = getEntryInRequest(request, baseWebMvcConfig.getRequestAttributeName());
+        if (entry == null) {
+            // should not happen
+            RecordLog.warn("No entry found in request, key: {}",
+                    SentinelAfterException.class.getSimpleName(), baseWebMvcConfig.getRequestAttributeName());
+            return;
+        }
+
+        traceExceptionAndExit(entry, ex);
+        removeEntryInRequest(request);
+        ContextUtil.exit();
+    }
+
+    /**
+     * @param request
+     * @param rcKey
+     * @param step
+     * @return reference count after increasing (initial value as zero to be increased)
+     */
+    private static Integer increaseReferece(HttpServletRequest request, String rcKey, int step) {
+        Object obj = request.getAttribute(rcKey);
+
+        if (obj == null) {
+            // initial
+            obj = Integer.valueOf(0);
+        }
+
+        Integer newRc = (Integer) obj + step;
+        request.setAttribute(rcKey, newRc);
+        return newRc;
+    }
+
+    protected static Entry getEntryInRequest(HttpServletRequest request, String attrKey) {
+        Object entryObject = request.getAttribute(attrKey);
+        return entryObject == null ? null : (Entry) entryObject;
+    }
+
+
+    protected static void removeEntryInRequest(HttpServletRequest request) {
+        request.removeAttribute(baseWebMvcConfig.getRequestAttributeName());
+    }
+
+    protected static void traceExceptionAndExit(Entry entry, Exception ex) {
+        if (entry != null) {
+            if (ex != null) {
+                Tracer.traceEntry(ex, entry);
+            }
+            entry.exit();
+        }
+    }
+}

--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/SentinelAfterException.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/SentinelAfterException.java
@@ -1,11 +1,5 @@
 package com.alibaba.csp.sentinel.adapter.spring.webmvc;
 
-import com.alibaba.csp.sentinel.Entry;
-import com.alibaba.csp.sentinel.Tracer;
-import com.alibaba.csp.sentinel.adapter.spring.webmvc.config.BaseWebMvcConfig;
-import com.alibaba.csp.sentinel.context.ContextUtil;
-import com.alibaba.csp.sentinel.log.RecordLog;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -16,68 +10,16 @@ import javax.servlet.http.HttpServletRequest;
  */
 public class SentinelAfterException {
 
-    protected static BaseWebMvcConfig baseWebMvcConfig;
+    protected static AbstractSentinelInterceptor abstractSentinelInterceptor;
 
     /**
      * The afterCompletion method of the HandlerInterceptor does not catch exception statistics when using @ControllerAdvice for global exception fetching
-     * Call SentinelAfterException.exit() method to realize exception statistics
+     * Call SentinelAfterException.exit(request, ex) method to realize exception statistics
      *
      * @param request
      * @param ex
      */
     public static void exit(HttpServletRequest request, Exception ex) {
-        if (increaseReferece(request, baseWebMvcConfig.getRequestRefName(), -1) != 0) {
-            return;
-        }
-
-        Entry entry = getEntryInRequest(request, baseWebMvcConfig.getRequestAttributeName());
-        if (entry == null) {
-            // should not happen
-            RecordLog.warn("No entry found in request, key: {}",
-                    SentinelAfterException.class.getSimpleName(), baseWebMvcConfig.getRequestAttributeName());
-            return;
-        }
-
-        traceExceptionAndExit(entry, ex);
-        removeEntryInRequest(request);
-        ContextUtil.exit();
-    }
-
-    /**
-     * @param request
-     * @param rcKey
-     * @param step
-     * @return reference count after increasing (initial value as zero to be increased)
-     */
-    private static Integer increaseReferece(HttpServletRequest request, String rcKey, int step) {
-        Object obj = request.getAttribute(rcKey);
-
-        if (obj == null) {
-            // initial
-            obj = Integer.valueOf(0);
-        }
-
-        Integer newRc = (Integer) obj + step;
-        request.setAttribute(rcKey, newRc);
-        return newRc;
-    }
-
-    protected static Entry getEntryInRequest(HttpServletRequest request, String attrKey) {
-        Object entryObject = request.getAttribute(attrKey);
-        return entryObject == null ? null : (Entry) entryObject;
-    }
-
-
-    protected static void removeEntryInRequest(HttpServletRequest request) {
-        request.removeAttribute(baseWebMvcConfig.getRequestAttributeName());
-    }
-
-    protected static void traceExceptionAndExit(Entry entry, Exception ex) {
-        if (entry != null) {
-            if (ex != null) {
-                Tracer.traceEntry(ex, entry);
-            }
-            entry.exit();
-        }
+        abstractSentinelInterceptor.afterCompletion(request, null, null, ex);
     }
 }

--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/SentinelWebInterceptor.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/SentinelWebInterceptor.java
@@ -20,6 +20,7 @@ import com.alibaba.csp.sentinel.adapter.spring.webmvc.callback.UrlCleaner;
 
 import javax.servlet.http.HttpServletRequest;
 
+import com.alibaba.csp.sentinel.adapter.spring.webmvc.license.SentinelAfterCompletionUtil;
 import com.alibaba.csp.sentinel.util.StringUtil;
 import org.springframework.web.servlet.HandlerMapping;
 
@@ -45,6 +46,7 @@ public class SentinelWebInterceptor extends AbstractSentinelInterceptor {
         } else {
             this.config = config;
         }
+        SentinelAfterCompletionUtil.sentinelWebInterceptor = this;
     }
 
     @Override

--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/license/SentinelAfterCompletionUtil.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/license/SentinelAfterCompletionUtil.java
@@ -1,4 +1,6 @@
-package com.alibaba.csp.sentinel.adapter.spring.webmvc;
+package com.alibaba.csp.sentinel.adapter.spring.webmvc.license;
+
+import com.alibaba.csp.sentinel.adapter.spring.webmvc.SentinelWebInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -8,9 +10,9 @@ import javax.servlet.http.HttpServletRequest;
  * @author Roy
  * @date 2022/1/249:15
  */
-public class SentinelAfterException {
+public class SentinelAfterCompletionUtil {
 
-    protected static AbstractSentinelInterceptor abstractSentinelInterceptor;
+    public static SentinelWebInterceptor sentinelWebInterceptor;
 
     /**
      * The afterCompletion method of the HandlerInterceptor does not catch exception statistics when using @ControllerAdvice for global exception fetching
@@ -20,6 +22,6 @@ public class SentinelAfterException {
      * @param ex
      */
     public static void exit(HttpServletRequest request, Exception ex) {
-        abstractSentinelInterceptor.afterCompletion(request, null, null, ex);
+        sentinelWebInterceptor.afterCompletion(request, null, null, ex);
     }
 }

--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/license/SentinelAfterCompletionUtil.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/license/SentinelAfterCompletionUtil.java
@@ -6,7 +6,7 @@ import javax.servlet.http.HttpServletRequest;
 
 /**
  * Exception interception statistics
- *
+ * 
  * @author Roy
  * @date 2022/1/249:15
  */
@@ -17,7 +17,7 @@ public class SentinelAfterCompletionUtil {
     /**
      * The afterCompletion method of the HandlerInterceptor does not catch exception statistics when using @ControllerAdvice for global exception fetching
      * Call SentinelAfterException.exit(request, ex) method to realize exception statistics
-     *
+     * 
      * @param request
      * @param ex
      */

--- a/sentinel-demo/sentinel-demo-spring-webmvc/src/main/java/com/alibaba/csp/sentinel/demo/spring/webmvc/config/SentinelSpringMvcBlockHandlerConfig.java
+++ b/sentinel-demo/sentinel-demo-spring-webmvc/src/main/java/com/alibaba/csp/sentinel/demo/spring/webmvc/config/SentinelSpringMvcBlockHandlerConfig.java
@@ -15,7 +15,7 @@
  */
 package com.alibaba.csp.sentinel.demo.spring.webmvc.config;
 
-import com.alibaba.csp.sentinel.adapter.spring.webmvc.SentinelAfterException;
+import com.alibaba.csp.sentinel.adapter.spring.webmvc.license.SentinelAfterCompletionUtil;
 import com.alibaba.csp.sentinel.demo.spring.webmvc.vo.ResultWrapper;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
 import org.slf4j.Logger;
@@ -52,7 +52,7 @@ public class SentinelSpringMvcBlockHandlerConfig {
     @ResponseBody
     public ResultWrapper exceptionHandler(HttpServletRequest req, Exception e) {
         logger.warn("System Exception: ", e);
-        SentinelAfterException.exit(req, e);
+        SentinelAfterCompletionUtil.exit(req, e);
         return ResultWrapper.systemException();
     }
 

--- a/sentinel-demo/sentinel-demo-spring-webmvc/src/main/java/com/alibaba/csp/sentinel/demo/spring/webmvc/config/SentinelSpringMvcBlockHandlerConfig.java
+++ b/sentinel-demo/sentinel-demo-spring-webmvc/src/main/java/com/alibaba/csp/sentinel/demo/spring/webmvc/config/SentinelSpringMvcBlockHandlerConfig.java
@@ -15,9 +15,7 @@
  */
 package com.alibaba.csp.sentinel.demo.spring.webmvc.config;
 
-import com.alibaba.csp.sentinel.adapter.spring.webmvc.SentinelWebInterceptor;
-import com.alibaba.csp.sentinel.adapter.spring.webmvc.callback.DefaultBlockExceptionHandler;
-import com.alibaba.csp.sentinel.adapter.spring.webmvc.config.SentinelWebMvcConfig;
+import com.alibaba.csp.sentinel.adapter.spring.webmvc.SentinelAfterException;
 import com.alibaba.csp.sentinel.demo.spring.webmvc.vo.ResultWrapper;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
 import org.slf4j.Logger;
@@ -42,17 +40,6 @@ public class SentinelSpringMvcBlockHandlerConfig {
 
     private Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    private static SentinelWebInterceptor sentinelWebInterceptor;
-
-    static {
-        SentinelWebMvcConfig config = new SentinelWebMvcConfig();
-        config.setBlockExceptionHandler(new DefaultBlockExceptionHandler());
-        config.setHttpMethodSpecify(true);
-        config.setWebContextUnify(true);
-        config.setOriginParser(request -> request.getHeader("S-user"));
-        sentinelWebInterceptor = new SentinelWebInterceptor(config);
-    }
-
     /**
      * Global exception or a business exception to manually call sentinelWebInterceptor.exceptionControllerAdviceExit(req,e); Do exception statistics
      * Otherwise, Sentinel cannot perform exception statistics and exception degrade
@@ -65,7 +52,7 @@ public class SentinelSpringMvcBlockHandlerConfig {
     @ResponseBody
     public ResultWrapper exceptionHandler(HttpServletRequest req, Exception e) {
         logger.warn("System Exception: ", e);
-        sentinelWebInterceptor.exceptionControllerAdviceExit(req,e);
+        SentinelAfterException.exit(req, e);
         return ResultWrapper.systemException();
     }
 

--- a/sentinel-demo/sentinel-demo-spring-webmvc/src/main/java/com/alibaba/csp/sentinel/demo/spring/webmvc/config/SentinelSpringMvcBlockHandlerConfig.java
+++ b/sentinel-demo/sentinel-demo-spring-webmvc/src/main/java/com/alibaba/csp/sentinel/demo/spring/webmvc/config/SentinelSpringMvcBlockHandlerConfig.java
@@ -41,7 +41,7 @@ public class SentinelSpringMvcBlockHandlerConfig {
     private Logger logger = LoggerFactory.getLogger(this.getClass());
 
     /**
-     * Global exception or a business exception to manually call sentinelWebInterceptor.exceptionControllerAdviceExit(req,e); Do exception statistics
+     * Global exception or a business exception to manually call SentinelAfterException.exit(req, e); Do exception statistics
      * Otherwise, Sentinel cannot perform exception statistics and exception degrade
      *
      * @param req

--- a/sentinel-demo/sentinel-demo-spring-webmvc/src/main/java/com/alibaba/csp/sentinel/demo/spring/webmvc/config/SentinelSpringMvcBlockHandlerConfig.java
+++ b/sentinel-demo/sentinel-demo-spring-webmvc/src/main/java/com/alibaba/csp/sentinel/demo/spring/webmvc/config/SentinelSpringMvcBlockHandlerConfig.java
@@ -63,7 +63,7 @@ public class SentinelSpringMvcBlockHandlerConfig {
      */
     @ExceptionHandler(Exception.class)
     @ResponseBody
-    public ResultWrapper sentinelBlockHandler(HttpServletRequest req, Exception e) {
+    public ResultWrapper exceptionHandler(HttpServletRequest req, Exception e) {
         logger.warn("System Exception: ", e);
         sentinelWebInterceptor.exceptionControllerAdviceExit(req,e);
         return ResultWrapper.systemException();

--- a/sentinel-demo/sentinel-demo-spring-webmvc/src/main/java/com/alibaba/csp/sentinel/demo/spring/webmvc/vo/ResultWrapper.java
+++ b/sentinel-demo/sentinel-demo-spring-webmvc/src/main/java/com/alibaba/csp/sentinel/demo/spring/webmvc/vo/ResultWrapper.java
@@ -50,6 +50,10 @@ public class ResultWrapper {
         return new ResultWrapper(-1, "Blocked by Sentinel");
     }
 
+    public static ResultWrapper systemException() {
+        return new ResultWrapper(-1, "System Exception");
+    }
+
     public String toJsonString() {
         return JSONObject.toJSONString(this);
     }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
srntinel-spring-webmvc-adapter使用HandlerInterceptor做异常统计等处理，但在实际开发中都会用@ControllerAdvice全局异常处理如下：
![image](https://user-images.githubusercontent.com/24887350/147801857-044f8c39-0d43-4933-8f81-5d1340b2731f.png)

因为拦截顺序会按照controller -> aspect -> controllerAdvice -> interceptor -> filter往下走，这导致异常已在ControllerAdvice被捕获处理，HandlerInterceptor无法统计异常

### Does this pull request fix one issue?

Fixes #2461

### Describe how you did it
在AbstractSentinelInterceptor下添加与afterCompletion处理相同的方法exceptionControllerAdviceExit，提供给全局异常捕获类调用如下：
![image](https://user-images.githubusercontent.com/24887350/147801570-686d39d6-5d57-4e72-bab4-c8efc1879387.png)
![image](https://user-images.githubusercontent.com/24887350/147801691-e1c1b3b9-79de-4015-837c-52a4873910a4.png)
这样就可以捕获系统异常，自定义的业务异常也是同样调用，这里也不用担心会统计两次afterCompletion下的increaseReferece做了判断
### Describe how to verify it
只要定义异常捕获处理都无法对异常进行统计，业务异常也是如此
![image](https://user-images.githubusercontent.com/24887350/147801852-97cf62f7-f4e9-4918-8028-6cb9afaa883e.png)


### Special notes for reviews
