### PR TITLE
【 ISSUE #904】【 ISSUE #2520】【ISSUE #2521】 optimize sentinel-datasource-extension support writable.  make sentinel-datasource-nacos support publish config

### DIFF
--- a/sentinel-demo/sentinel-demo-cluster/sentinel-demo-cluster-embedded/src/main/java/com/alibaba/csp/sentinel/demo/cluster/init/DemoClusterInitFunc.java
+++ b/sentinel-demo/sentinel-demo-cluster/sentinel-demo-cluster-embedded/src/main/java/com/alibaba/csp/sentinel/demo/cluster/init/DemoClusterInitFunc.java
@@ -81,15 +81,15 @@ public class DemoClusterInitFunc implements InitFunc {
 
     private void initDynamicRuleProperty() {
         NacosDataSource<List<FlowRule>> ruleSource = new NacosDataSource<>(remoteAddress, groupId, flowDataId, new JsonArrayConverter<>(FlowRule.class));
-        FlowRuleManager.register2Property(ruleSource.getProperty());
+        FlowRuleManager.register2Property(ruleSource.getReader().getProperty());
 
         NacosDataSource<List<ParamFlowRule>> paramRuleSource = new NacosDataSource<>(remoteAddress, groupId, paramDataId, new JsonArrayConverter<>(ParamFlowRule.class));
-        ParamFlowRuleManager.register2Property(paramRuleSource.getProperty());
+        ParamFlowRuleManager.register2Property(paramRuleSource.getReader().getProperty());
     }
 
     private void initClientConfigProperty() {
         NacosDataSource<ClusterClientConfig> clientConfigDs = new NacosDataSource<>(remoteAddress, groupId, configDataId, new JsonObjectConverter<>(ClusterClientConfig.class));
-        ClusterClientConfigManager.registerClientConfigProperty(clientConfigDs.getProperty());
+        ClusterClientConfigManager.registerClientConfigProperty(clientConfigDs.getReader().getProperty());
     }
 
     private void initServerTransportConfigProperty() {
@@ -103,7 +103,7 @@ public class DemoClusterInitFunc implements InitFunc {
                                 .orElse(null);
                     }
                 });
-        ClusterServerConfigManager.registerServerTransportProperty(serverTransportDs.getProperty());
+        ClusterServerConfigManager.registerServerTransportProperty(serverTransportDs.getReader().getProperty());
     }
 
     private void registerClusterRuleSupplier() {
@@ -111,12 +111,12 @@ public class DemoClusterInitFunc implements InitFunc {
         // Flow rule dataId format: ${namespace}-flow-rules
         ClusterFlowRuleManager.setPropertySupplier(namespace -> {
             NacosDataSource<List<FlowRule>> ds = new NacosDataSource<>(remoteAddress, groupId, namespace + DemoConstants.FLOW_POSTFIX, new JsonArrayConverter<>(FlowRule.class));
-            return ds.getProperty();
+            return ds.getReader().getProperty();
         });
         // Register cluster parameter flow rule property supplier which creates data source by namespace.
         ClusterParamFlowRuleManager.setPropertySupplier(namespace -> {
             NacosDataSource<List<ParamFlowRule>> ds = new NacosDataSource<>(remoteAddress, groupId, namespace + DemoConstants.PARAM_FLOW_POSTFIX, new JsonArrayConverter<>(ParamFlowRule.class));
-            return ds.getProperty();
+            return ds.getReader().getProperty();
         });
     }
 
@@ -134,7 +134,7 @@ public class DemoClusterInitFunc implements InitFunc {
                             .orElse(null);
                 }
             });
-        ClusterClientConfigManager.registerServerAssignProperty(clientAssignDs.getProperty());
+        ClusterClientConfigManager.registerServerAssignProperty(clientAssignDs.getReader().getProperty());
     }
 
     private void initStateProperty() {
@@ -151,7 +151,7 @@ public class DemoClusterInitFunc implements InitFunc {
                             .orElse(ClusterStateManager.CLUSTER_NOT_STARTED);
             }
         });
-        ClusterStateManager.registerProperty(clusterModeDs.getProperty());
+        ClusterStateManager.registerProperty(clusterModeDs.getReader().getProperty());
     }
 
     private int extractMode(List<ClusterGroupEntity> groupList) {

--- a/sentinel-demo/sentinel-demo-cluster/sentinel-demo-cluster-embedded/src/main/java/com/alibaba/csp/sentinel/demo/cluster/init/DemoClusterInitFunc.java
+++ b/sentinel-demo/sentinel-demo-cluster/sentinel-demo-cluster-embedded/src/main/java/com/alibaba/csp/sentinel/demo/cluster/init/DemoClusterInitFunc.java
@@ -15,10 +15,6 @@
  */
 package com.alibaba.csp.sentinel.demo.cluster.init;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-
 import com.alibaba.csp.sentinel.cluster.ClusterStateManager;
 import com.alibaba.csp.sentinel.cluster.client.config.ClusterClientAssignConfig;
 import com.alibaba.csp.sentinel.cluster.client.config.ClusterClientConfig;
@@ -27,7 +23,8 @@ import com.alibaba.csp.sentinel.cluster.flow.rule.ClusterFlowRuleManager;
 import com.alibaba.csp.sentinel.cluster.flow.rule.ClusterParamFlowRuleManager;
 import com.alibaba.csp.sentinel.cluster.server.config.ClusterServerConfigManager;
 import com.alibaba.csp.sentinel.cluster.server.config.ServerTransportConfig;
-import com.alibaba.csp.sentinel.datasource.ReadableDataSource;
+import com.alibaba.csp.sentinel.datasource.converter.JsonArrayConverter;
+import com.alibaba.csp.sentinel.datasource.converter.JsonObjectConverter;
 import com.alibaba.csp.sentinel.datasource.nacos.NacosDataSource;
 import com.alibaba.csp.sentinel.demo.cluster.DemoConstants;
 import com.alibaba.csp.sentinel.demo.cluster.entity.ClusterGroupEntity;
@@ -41,6 +38,10 @@ import com.alibaba.csp.sentinel.util.AppNameUtil;
 import com.alibaba.csp.sentinel.util.HostNameUtil;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.TypeReference;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 /**
  * @author Eric Zhao
@@ -79,29 +80,29 @@ public class DemoClusterInitFunc implements InitFunc {
     }
 
     private void initDynamicRuleProperty() {
-        ReadableDataSource<String, List<FlowRule>> ruleSource = new NacosDataSource<>(remoteAddress, groupId,
-            flowDataId, source -> JSON.parseObject(source, new TypeReference<List<FlowRule>>() {}));
+        NacosDataSource<List<FlowRule>> ruleSource = new NacosDataSource<>(remoteAddress, groupId, flowDataId, new JsonArrayConverter<>(FlowRule.class));
         FlowRuleManager.register2Property(ruleSource.getProperty());
 
-        ReadableDataSource<String, List<ParamFlowRule>> paramRuleSource = new NacosDataSource<>(remoteAddress, groupId,
-            paramDataId, source -> JSON.parseObject(source, new TypeReference<List<ParamFlowRule>>() {}));
+        NacosDataSource<List<ParamFlowRule>> paramRuleSource = new NacosDataSource<>(remoteAddress, groupId, paramDataId, new JsonArrayConverter<>(ParamFlowRule.class));
         ParamFlowRuleManager.register2Property(paramRuleSource.getProperty());
     }
 
     private void initClientConfigProperty() {
-        ReadableDataSource<String, ClusterClientConfig> clientConfigDs = new NacosDataSource<>(remoteAddress, groupId,
-            configDataId, source -> JSON.parseObject(source, new TypeReference<ClusterClientConfig>() {}));
+        NacosDataSource<ClusterClientConfig> clientConfigDs = new NacosDataSource<>(remoteAddress, groupId, configDataId, new JsonObjectConverter<>(ClusterClientConfig.class));
         ClusterClientConfigManager.registerClientConfigProperty(clientConfigDs.getProperty());
     }
 
     private void initServerTransportConfigProperty() {
-        ReadableDataSource<String, ServerTransportConfig> serverTransportDs = new NacosDataSource<>(remoteAddress, groupId,
-            clusterMapDataId, source -> {
-            List<ClusterGroupEntity> groupList = JSON.parseObject(source, new TypeReference<List<ClusterGroupEntity>>() {});
-            return Optional.ofNullable(groupList)
-                .flatMap(this::extractServerTransportConfig)
-                .orElse(null);
-        });
+        NacosDataSource<ServerTransportConfig> serverTransportDs = new NacosDataSource<>(remoteAddress, groupId, clusterMapDataId,
+                new JsonObjectConverter<String, ServerTransportConfig>(ServerTransportConfig.class) {
+                    @Override
+                    public ServerTransportConfig toSentinel(String source) {
+                        List<ClusterGroupEntity> groupList = JSON.parseObject(source, new TypeReference<List<ClusterGroupEntity>>() {});
+                        return Optional.ofNullable(groupList)
+                                .flatMap(DemoClusterInitFunc.this::extractServerTransportConfig)
+                                .orElse(null);
+                    }
+                });
         ClusterServerConfigManager.registerServerTransportProperty(serverTransportDs.getProperty());
     }
 
@@ -109,14 +110,12 @@ public class DemoClusterInitFunc implements InitFunc {
         // Register cluster flow rule property supplier which creates data source by namespace.
         // Flow rule dataId format: ${namespace}-flow-rules
         ClusterFlowRuleManager.setPropertySupplier(namespace -> {
-            ReadableDataSource<String, List<FlowRule>> ds = new NacosDataSource<>(remoteAddress, groupId,
-                namespace + DemoConstants.FLOW_POSTFIX, source -> JSON.parseObject(source, new TypeReference<List<FlowRule>>() {}));
+            NacosDataSource<List<FlowRule>> ds = new NacosDataSource<>(remoteAddress, groupId, namespace + DemoConstants.FLOW_POSTFIX, new JsonArrayConverter<>(FlowRule.class));
             return ds.getProperty();
         });
         // Register cluster parameter flow rule property supplier which creates data source by namespace.
         ClusterParamFlowRuleManager.setPropertySupplier(namespace -> {
-            ReadableDataSource<String, List<ParamFlowRule>> ds = new NacosDataSource<>(remoteAddress, groupId,
-                namespace + DemoConstants.PARAM_FLOW_POSTFIX, source -> JSON.parseObject(source, new TypeReference<List<ParamFlowRule>>() {}));
+            NacosDataSource<List<ParamFlowRule>> ds = new NacosDataSource<>(remoteAddress, groupId, namespace + DemoConstants.PARAM_FLOW_POSTFIX, new JsonArrayConverter<>(ParamFlowRule.class));
             return ds.getProperty();
         });
     }
@@ -125,13 +124,16 @@ public class DemoClusterInitFunc implements InitFunc {
         // Cluster map format:
         // [{"clientSet":["112.12.88.66@8729","112.12.88.67@8727"],"ip":"112.12.88.68","machineId":"112.12.88.68@8728","port":11111}]
         // machineId: <ip@commandPort>, commandPort for port exposed to Sentinel dashboard (transport module)
-        ReadableDataSource<String, ClusterClientAssignConfig> clientAssignDs = new NacosDataSource<>(remoteAddress, groupId,
-            clusterMapDataId, source -> {
-            List<ClusterGroupEntity> groupList = JSON.parseObject(source, new TypeReference<List<ClusterGroupEntity>>() {});
-            return Optional.ofNullable(groupList)
-                .flatMap(this::extractClientAssignment)
-                .orElse(null);
-        });
+        NacosDataSource<ClusterClientAssignConfig> clientAssignDs = new NacosDataSource<>(remoteAddress, groupId, clusterMapDataId,
+            new JsonObjectConverter<String, ClusterClientAssignConfig>(ClusterClientAssignConfig.class) {
+                @Override
+                public ClusterClientAssignConfig toSentinel(String source) {
+                    List<ClusterGroupEntity> groupList = JSON.parseObject(source, new TypeReference<List<ClusterGroupEntity>>() {});
+                    return Optional.ofNullable(groupList)
+                            .flatMap(DemoClusterInitFunc.this::extractClientAssignment)
+                            .orElse(null);
+                }
+            });
         ClusterClientConfigManager.registerServerAssignProperty(clientAssignDs.getProperty());
     }
 
@@ -139,12 +141,15 @@ public class DemoClusterInitFunc implements InitFunc {
         // Cluster map format:
         // [{"clientSet":["112.12.88.66@8729","112.12.88.67@8727"],"ip":"112.12.88.68","machineId":"112.12.88.68@8728","port":11111}]
         // machineId: <ip@commandPort>, commandPort for port exposed to Sentinel dashboard (transport module)
-        ReadableDataSource<String, Integer> clusterModeDs = new NacosDataSource<>(remoteAddress, groupId,
-            clusterMapDataId, source -> {
-            List<ClusterGroupEntity> groupList = JSON.parseObject(source, new TypeReference<List<ClusterGroupEntity>>() {});
-            return Optional.ofNullable(groupList)
-                .map(this::extractMode)
-                .orElse(ClusterStateManager.CLUSTER_NOT_STARTED);
+        NacosDataSource<Integer> clusterModeDs = new NacosDataSource<>(remoteAddress, groupId,
+            clusterMapDataId, new JsonObjectConverter<String, Integer>(Integer.class) {
+                @Override
+                public Integer toSentinel(String source) {
+                    List<ClusterGroupEntity> groupList = JSON.parseObject(source, new TypeReference<List<ClusterGroupEntity>>() {});
+                    return Optional.ofNullable(groupList)
+                            .map(DemoClusterInitFunc.this::extractMode)
+                            .orElse(ClusterStateManager.CLUSTER_NOT_STARTED);
+            }
         });
         ClusterStateManager.registerProperty(clusterModeDs.getProperty());
     }

--- a/sentinel-demo/sentinel-demo-cluster/sentinel-demo-cluster-server-alone/src/main/java/com/alibaba/csp/sentinel/demo/cluster/init/DemoClusterServerInitFunc.java
+++ b/sentinel-demo/sentinel-demo-cluster/sentinel-demo-cluster-server-alone/src/main/java/com/alibaba/csp/sentinel/demo/cluster/init/DemoClusterServerInitFunc.java
@@ -21,13 +21,16 @@ import com.alibaba.csp.sentinel.cluster.server.config.ClusterServerConfigManager
 import com.alibaba.csp.sentinel.cluster.server.config.ServerTransportConfig;
 import com.alibaba.csp.sentinel.datasource.converter.JsonArrayConverter;
 import com.alibaba.csp.sentinel.datasource.converter.JsonObjectConverter;
+import com.alibaba.csp.sentinel.datasource.converter.JsonSetConverter;
 import com.alibaba.csp.sentinel.datasource.nacos.NacosDataSource;
 import com.alibaba.csp.sentinel.demo.cluster.DemoConstants;
 import com.alibaba.csp.sentinel.init.InitFunc;
+import com.alibaba.csp.sentinel.property.SentinelProperty;
 import com.alibaba.csp.sentinel.slots.block.flow.FlowRule;
 import com.alibaba.csp.sentinel.slots.block.flow.param.ParamFlowRule;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author Eric Zhao
@@ -45,21 +48,21 @@ public class DemoClusterServerInitFunc implements InitFunc {
         ClusterFlowRuleManager.setPropertySupplier(namespace -> {
             NacosDataSource<List<FlowRule>> ds = new NacosDataSource<>(remoteAddress, groupId,
                     namespace + DemoConstants.FLOW_POSTFIX, new JsonArrayConverter<>(FlowRule.class));
-            return ds.getProperty();
+            return ds.getReader().getProperty();
         });
         // Register cluster parameter flow rule property supplier.
         ClusterParamFlowRuleManager.setPropertySupplier(namespace -> {
             NacosDataSource<List<ParamFlowRule>> ds = new NacosDataSource<>(remoteAddress, groupId,
                     namespace + DemoConstants.PARAM_FLOW_POSTFIX, new JsonArrayConverter<>(ParamFlowRule.class));
-            return ds.getProperty();
+            return ds.getReader().getProperty();
         });
 
         // Server namespace set (scope) data source.
-        NacosDataSource<List<String>> namespaceDs = new NacosDataSource<>(remoteAddress, groupId, namespaceSetDataId, new JsonArrayConverter<>(String.class));
-        ClusterServerConfigManager.registerNamespaceSetProperty(namespaceDs.getProperty());
+        NacosDataSource<Set<String>> namespaceDs = new NacosDataSource<>(remoteAddress, groupId, namespaceSetDataId, new JsonSetConverter<>(String.class));
+        ClusterServerConfigManager.registerNamespaceSetProperty(namespaceDs.getReader().getProperty());
         // Server transport configuration data source.
         NacosDataSource<ServerTransportConfig> transportConfigDs = new NacosDataSource<>(remoteAddress,
             groupId, serverTransportDataId, new JsonObjectConverter<>(ServerTransportConfig.class));
-        ClusterServerConfigManager.registerServerTransportProperty(transportConfigDs.getProperty());
+        ClusterServerConfigManager.registerServerTransportProperty(transportConfigDs.getReader().getProperty());
     }
 }

--- a/sentinel-demo/sentinel-demo-nacos-datasource/src/main/java/com/alibaba/csp/sentinel/demo/datasource/nacos/NacosDataSourceDemo.java
+++ b/sentinel-demo/sentinel-demo-nacos-datasource/src/main/java/com/alibaba/csp/sentinel/demo/datasource/nacos/NacosDataSourceDemo.java
@@ -68,7 +68,7 @@ public class NacosDataSourceDemo {
     private static void loadRules() {
         try {
             NacosDataSource<List<FlowRule>> flowRuleDataSource = new NacosDataSource<>(remoteAddress, groupId, dataId, new JsonArrayConverter<>(FlowRule.class));
-            FlowRuleManager.register2Property(flowRuleDataSource.getProperty());
+            FlowRuleManager.register2Property(flowRuleDataSource.getReader().getProperty());
             List<FlowRule> o = flowRuleDataSource.getReader().loadConfig();
             System.out.println(o.size());
         } catch (Exception e) {
@@ -82,7 +82,7 @@ public class NacosDataSourceDemo {
         properties.put(PropertyKeyConst.NAMESPACE, NACOS_NAMESPACE_ID);
 
         NacosDataSource<List<FlowRule>> flowRuleDataSource = new NacosDataSource<>(properties, groupId, dataId, new JsonArrayConverter<>(FlowRule.class));
-        FlowRuleManager.register2Property(flowRuleDataSource.getProperty());
+        FlowRuleManager.register2Property(flowRuleDataSource.getReader().getProperty());
     }
 
     private static void publishRules() {

--- a/sentinel-extension/sentinel-datasource-extension/pom.xml
+++ b/sentinel-extension/sentinel-datasource-extension/pom.xml
@@ -17,6 +17,10 @@
             <groupId>com.alibaba.csp</groupId>
             <artifactId>sentinel-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>fastjson</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/AbstractReadableDataSource.java
+++ b/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/AbstractReadableDataSource.java
@@ -16,6 +16,7 @@
 package com.alibaba.csp.sentinel.datasource;
 
 import com.alibaba.csp.sentinel.datasource.converter.SentinelConverter;
+import com.alibaba.csp.sentinel.property.DynamicSentinelProperty;
 import com.alibaba.csp.sentinel.property.SentinelProperty;
 
 /**
@@ -32,9 +33,12 @@ public abstract class AbstractReadableDataSource<S, T> implements ReadableDataSo
 
     private final SentinelConverter<S, T> sentinelConverter;
 
+    protected final SentinelProperty<T> property;
+
     public AbstractReadableDataSource(DataSourceHolder dataSourceHolder) {
         this.dataSourceHolder = dataSourceHolder;
         this.sentinelConverter = dataSourceHolder.getConverter();
+        this.property = new DynamicSentinelProperty<T>();
     }
 
     @Override
@@ -49,6 +53,6 @@ public abstract class AbstractReadableDataSource<S, T> implements ReadableDataSo
 
     @Override
     public SentinelProperty<T> getProperty() {
-        return dataSourceHolder.getProperty();
+        return this.property;
     }
 }

--- a/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/AbstractReadableDataSource.java
+++ b/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/AbstractReadableDataSource.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.datasource;
+
+import com.alibaba.csp.sentinel.datasource.converter.SentinelConverter;
+import com.alibaba.csp.sentinel.property.SentinelProperty;
+
+/**
+ * The abstract readable data source provides basic functionality for loading and parsing config.
+ *
+ * @param <S> source data type for DataSource
+ * @param <T> target data type for Sentinel
+ *
+ * @author Jiajiangnan
+ */
+public abstract class AbstractReadableDataSource<S, T> implements ReadableDataSource<S, T> {
+
+    protected final DataSourceHolder dataSourceHolder;
+
+    private final SentinelConverter<S, T> sentinelConverter;
+
+    public AbstractReadableDataSource(DataSourceHolder dataSourceHolder) {
+        this.dataSourceHolder = dataSourceHolder;
+        this.sentinelConverter = dataSourceHolder.getConverter();
+    }
+
+    @Override
+    public T loadConfig() throws Exception {
+        return loadConfig(readSource());
+    }
+
+    public T loadConfig(S conf) throws Exception {
+        T value = sentinelConverter.toSentinel(conf);
+        return value;
+    }
+
+    @Override
+    public SentinelProperty<T> getProperty() {
+        return dataSourceHolder.getProperty();
+    }
+}

--- a/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/AbstractWritableDataSource.java
+++ b/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/AbstractWritableDataSource.java
@@ -16,20 +16,18 @@
 package com.alibaba.csp.sentinel.datasource;
 
 /**
- * Convert an object from source type {@code S} to target type {@code T}.
+ * The abstract writable data source provides basic functionality for publish config.
  *
- * @author leyou
- * @author Eric Zhao
+ * @param <T> target data type for Sentinel
+ *
+ * @author Jiajiangnan
  */
-@Deprecated
-public interface Converter<S, T> {
+public abstract class AbstractWritableDataSource<T> implements WritableDataSource<T> {
 
-    /**
-     * Convert {@code source} to the target type.
-     *
-     * @param source the source object
-     * @return the target object
-     */
-    @Deprecated
-    T convert(S source);
+    protected final DataSourceHolder dataSourceHolder;
+
+    public AbstractWritableDataSource(DataSourceHolder dataSourceHolder) {
+        this.dataSourceHolder = dataSourceHolder;
+    }
+
 }

--- a/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/DataSourceHolder.java
+++ b/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/DataSourceHolder.java
@@ -1,8 +1,6 @@
 package com.alibaba.csp.sentinel.datasource;
 
 import com.alibaba.csp.sentinel.datasource.converter.SentinelConverter;
-import com.alibaba.csp.sentinel.property.DynamicSentinelProperty;
-import com.alibaba.csp.sentinel.property.SentinelProperty;
 
 /**
  * DataSourceHolder who holds some Object in Sentinel-Context where be used for ReadableDataSource and WritableDataSource
@@ -16,7 +14,6 @@ public class DataSourceHolder<S, T, C> {
 
     protected final SentinelConverter<S, T> converter;
     protected final DataSourceMode dataSourceMode;
-    protected final SentinelProperty<T> property;
     private C client;
 
     public DataSourceHolder(final SentinelConverter<S, T> converter, final DataSourceMode dataSourceMode) {
@@ -25,7 +22,6 @@ public class DataSourceHolder<S, T, C> {
         }
         this.converter = converter;
         this.dataSourceMode = dataSourceMode;
-        this.property = new DynamicSentinelProperty<T>();
     }
 
     protected void setDataSourceClient(C client) {
@@ -38,10 +34,6 @@ public class DataSourceHolder<S, T, C> {
 
     public SentinelConverter<S, T> getConverter() {
         return this.converter;
-    }
-
-    public SentinelProperty<T> getProperty() {
-        return this.property;
     }
 
 }

--- a/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/DataSourceHolder.java
+++ b/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/DataSourceHolder.java
@@ -14,15 +14,17 @@ import com.alibaba.csp.sentinel.property.SentinelProperty;
  */
 public class DataSourceHolder<S, T, C> {
 
-    private C client;
     protected final SentinelConverter<S, T> converter;
+    protected final DataSourceMode dataSourceMode;
     protected final SentinelProperty<T> property;
+    private C client;
 
-    public DataSourceHolder(SentinelConverter<S, T> converter) {
+    public DataSourceHolder(final SentinelConverter<S, T> converter, final DataSourceMode dataSourceMode) {
         if (converter == null) {
             throw new IllegalArgumentException("parser can't be null");
         }
         this.converter = converter;
+        this.dataSourceMode = dataSourceMode;
         this.property = new DynamicSentinelProperty<T>();
     }
 

--- a/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/DataSourceHolder.java
+++ b/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/DataSourceHolder.java
@@ -1,0 +1,45 @@
+package com.alibaba.csp.sentinel.datasource;
+
+import com.alibaba.csp.sentinel.datasource.converter.SentinelConverter;
+import com.alibaba.csp.sentinel.property.DynamicSentinelProperty;
+import com.alibaba.csp.sentinel.property.SentinelProperty;
+
+/**
+ * DataSourceHolder who holds some Object in Sentinel-Context where be used for ReadableDataSource and WritableDataSource
+ *
+ * @param <S> source data type for DataSource
+ * @param <T> target data type for Sentinel
+ *
+ * @author Jiajiangnan
+ */
+public class DataSourceHolder<S, T, C> {
+
+    private C client;
+    protected final SentinelConverter<S, T> converter;
+    protected final SentinelProperty<T> property;
+
+    public DataSourceHolder(SentinelConverter<S, T> converter) {
+        if (converter == null) {
+            throw new IllegalArgumentException("parser can't be null");
+        }
+        this.converter = converter;
+        this.property = new DynamicSentinelProperty<T>();
+    }
+
+    protected void setDataSourceClient(C client) {
+        this.client = client;
+    }
+
+    public C getDataSourceClient() {
+        return this.client;
+    }
+
+    public SentinelConverter<S, T> getConverter() {
+        return this.converter;
+    }
+
+    public SentinelProperty<T> getProperty() {
+        return this.property;
+    }
+
+}

--- a/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/DataSourceMode.java
+++ b/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/DataSourceMode.java
@@ -1,0 +1,14 @@
+package com.alibaba.csp.sentinel.datasource;
+
+/**
+ * defined mode of DataSource
+ *
+ * @author Jiajiangnan
+ */
+public enum DataSourceMode {
+
+    ALL,
+    READABLE,
+    WRITABLE
+    ;
+}

--- a/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/converter/EmptyConverter.java
+++ b/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/converter/EmptyConverter.java
@@ -1,0 +1,21 @@
+package com.alibaba.csp.sentinel.datasource.converter;
+
+/**
+ * Default Converter when source type for DataSource is the same to type for Sentinel
+ *
+ * @param <T> the same type
+ *
+ * @author Jiajiangnan
+ */
+public class EmptyConverter<T> implements SentinelConverter<T, T>{
+
+    @Override
+    public T toSentinel(T source) {
+        return source;
+    }
+
+    @Override
+    public T fromSentinel(T source) {
+        return source;
+    }
+}

--- a/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/converter/JsonArrayConverter.java
+++ b/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/converter/JsonArrayConverter.java
@@ -13,15 +13,15 @@ import java.util.List;
  */
 public class JsonArrayConverter<T extends Object> extends JsonConverter <String, List<T>> {
 
-    private final Class<T> ruleClass;
+    private final Class<T> sentinelClass;
 
-    public JsonArrayConverter(Class<T> ruleClass) {
-        this.ruleClass = ruleClass;
+    public JsonArrayConverter(Class<T> sentinelClass) {
+        this.sentinelClass = sentinelClass;
     }
 
     @Override
     public List<T> toSentinel(String source) {
-        return JSON.parseArray(source, ruleClass);
+        return JSON.parseArray(source, sentinelClass);
     }
 
 

--- a/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/converter/JsonArrayConverter.java
+++ b/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/converter/JsonArrayConverter.java
@@ -1,0 +1,28 @@
+package com.alibaba.csp.sentinel.datasource.converter;
+
+import com.alibaba.fastjson.JSON;
+
+import java.util.List;
+
+/**
+ * JsonConverter when type for DataSource is String and type for Sentinel is instanceof Collection
+ *
+ * @param <T> type for Sentinel which wrapped by Collection
+ *
+ * @author Jiajiangnan
+ */
+public class JsonArrayConverter<T extends Object> extends JsonConverter <String, List<T>> {
+
+    private final Class<T> ruleClass;
+
+    public JsonArrayConverter(Class<T> ruleClass) {
+        this.ruleClass = ruleClass;
+    }
+
+    @Override
+    public List<T> toSentinel(String source) {
+        return JSON.parseArray(source, ruleClass);
+    }
+
+
+}

--- a/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/converter/JsonConverter.java
+++ b/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/converter/JsonConverter.java
@@ -1,0 +1,19 @@
+package com.alibaba.csp.sentinel.datasource.converter;
+
+import com.alibaba.fastjson.JSON;
+
+/**
+ * super JsonConverter when type for DataSource is String and type for Sentinel is Object
+ *
+ * @param <T> type for Sentinel isObject
+ *
+ * @author Jiajiangnan
+ */
+public abstract class JsonConverter<S, T> implements SentinelConverter<String, T>{
+
+    @Override
+    public String fromSentinel(T source) {
+        return JSON.toJSONString(source);
+    }
+
+}

--- a/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/converter/JsonObjectConverter.java
+++ b/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/converter/JsonObjectConverter.java
@@ -11,15 +11,15 @@ import com.alibaba.fastjson.JSON;
  */
 public class JsonObjectConverter<S, T extends Object> extends JsonConverter <String, T> {
 
-    private final Class<T> ruleClass;
+    private final Class<T> sentinelClass;
 
-    public JsonObjectConverter(Class<T> ruleClass) {
-        this.ruleClass = ruleClass;
+    public JsonObjectConverter(Class<T> sentinelClass) {
+        this.sentinelClass = sentinelClass;
     }
 
     @Override
     public T toSentinel(String source) {
-        return JSON.parseObject(source, ruleClass);
+        return JSON.parseObject(source, sentinelClass);
     }
 
 

--- a/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/converter/JsonObjectConverter.java
+++ b/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/converter/JsonObjectConverter.java
@@ -1,0 +1,26 @@
+package com.alibaba.csp.sentinel.datasource.converter;
+
+import com.alibaba.fastjson.JSON;
+
+/**
+ * JsonConverter when type for DataSource is String and type for Sentinel is instanceof Object which not wrapped by Collection
+ *
+ * @param <T> type for Sentinel is instanceof Object which not wrapped by Collection
+ *
+ * @author Jiajiangnan
+ */
+public class JsonObjectConverter<S, T extends Object> extends JsonConverter <String, T> {
+
+    private final Class<T> ruleClass;
+
+    public JsonObjectConverter(Class<T> ruleClass) {
+        this.ruleClass = ruleClass;
+    }
+
+    @Override
+    public T toSentinel(String source) {
+        return JSON.parseObject(source, ruleClass);
+    }
+
+
+}

--- a/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/converter/JsonSetConverter.java
+++ b/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/converter/JsonSetConverter.java
@@ -1,0 +1,34 @@
+package com.alibaba.csp.sentinel.datasource.converter;
+
+import com.alibaba.fastjson.JSON;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * JsonConverter when type for DataSource is String and type for Sentinel is instanceof Collection
+ *
+ * @param <T> type for Sentinel which wrapped by Collection
+ *
+ * @author Jiajiangnan
+ */
+public class JsonSetConverter<T extends Object> extends JsonConverter <String, Set<T>> {
+
+    private final Class<T> sentinelClass;
+
+    public JsonSetConverter(Class<T> sentinelClass) {
+        this.sentinelClass = sentinelClass;
+    }
+
+    @Override
+    public Set<T> toSentinel(String source) {
+        List<T> list = JSON.parseArray(source, sentinelClass);
+
+        if(list != null && list.size() > 0) {
+            return  new HashSet<>(list);
+        }
+        return null;
+    }
+
+}

--- a/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/converter/SentinelConverter.java
+++ b/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/converter/SentinelConverter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.datasource.converter;
+
+/**
+ * Convert an object from source type for DataSource {@code S} to target type for Sentinel {@code T}.
+ *
+ * @param <S> source data type for DataSource
+ * @param <T> target data type for Sentinel
+ *
+ * @author Jiajiangnan
+ */
+public interface SentinelConverter<S, T> {
+
+    /**
+     * Convert {@code source} to the target type for Sentinel
+     *
+     * @param source the source object for DataSource
+     * @return the target object for Sentinel
+     */
+    default T toSentinel(S source) {
+        throw new UnsupportedOperationException("method toSentinel musted be Overrided!");
+    }
+
+    /**
+     * Convert {@code source} from the target type for Sentinel
+     *
+     * @param source the source for Sentinel
+     * @return the target object for DataSource
+     */
+    default S fromSentinel(T source) {
+        throw new UnsupportedOperationException("method fromSentinel musted be Overrided!");
+    }
+
+}

--- a/sentinel-extension/sentinel-datasource-nacos/README.md
+++ b/sentinel-extension/sentinel-datasource-nacos/README.md
@@ -19,9 +19,19 @@ For instance:
 ```java
 // remoteAddress is the address of Nacos
 // groupId and dataId are concepts of Nacos
-ReadableDataSource<String, List<FlowRule>> flowRuleDataSource = new NacosDataSource<>(remoteAddress, groupId, dataId,
-    source -> JSON.parseObject(source, new TypeReference<List<FlowRule>>() {}));
-FlowRuleManager.register2Property(flowRuleDataSource.getProperty());
+// DataSourceMode is the mode of Nacos, include READABLE,WRITABLE, ALL
+NacosDataSource<List<FlowRule>> flowRuleDataSource = new NacosDataSource<>(remoteAddress, groupId, dataId, new JsonArrayConverter<>(FlowRule.class), DataSourceMode.ALL);
+
+//read from nacos
+FlowRuleManager.register2Property(flowRuleDataSource.getReader().getProperty());
+
+//write to nacos
+FlowRule flowRule = new FlowRule();
+flowRule.setResource("/test");
+flowRule.setCount(5);
+List<FlowRule> list = new ArrayList<>();
+list.add(flowRule);
+flowRuleDataSource.getWriter().write(list);
 ```
 
 We've also provided an example: [sentinel-demo-nacos-datasource](https://github.com/alibaba/Sentinel/tree/master/sentinel-demo/sentinel-demo-nacos-datasource).

--- a/sentinel-extension/sentinel-datasource-nacos/src/main/java/com/alibaba/csp/sentinel/datasource/nacos/NacosDataSource.java
+++ b/sentinel-extension/sentinel-datasource-nacos/src/main/java/com/alibaba/csp/sentinel/datasource/nacos/NacosDataSource.java
@@ -122,4 +122,14 @@ public class NacosDataSource<T> extends DataSourceHolder {
         return this.writableDataSource;
     }
 
+    public void close() {
+        if(DataSourceMode.ALL == dataSourceMode || DataSourceMode.READABLE == dataSourceMode) {
+            this.readableDataSource.close();
+        }
+
+        if(DataSourceMode.ALL == dataSourceMode || DataSourceMode.WRITABLE == dataSourceMode) {
+            this.writableDataSource.close();
+        }
+    }
+
 }

--- a/sentinel-extension/sentinel-datasource-nacos/src/main/java/com/alibaba/csp/sentinel/datasource/nacos/NacosDataSource.java
+++ b/sentinel-extension/sentinel-datasource-nacos/src/main/java/com/alibaba/csp/sentinel/datasource/nacos/NacosDataSource.java
@@ -47,10 +47,10 @@ public class NacosDataSource<T> extends DataSourceHolder {
      * @param serverAddr server address of Nacos, cannot be empty
      * @param groupId    group ID, cannot be empty
      * @param dataId     data ID, cannot be empty
-     * @param parser     customized data parser, cannot be empty
+     * @param converter     customized data converter, cannot be empty
      */
-    public NacosDataSource(final String serverAddr, final String groupId, final String dataId, SentinelConverter<String, T> parser) {
-        this(NacosDataSource.buildProperties(serverAddr), groupId, dataId, parser, DataSourceMode.READABLE);
+    public NacosDataSource(final String serverAddr, final String groupId, final String dataId, SentinelConverter<String, T> converter) {
+        this(serverAddr, groupId, dataId, converter, DataSourceMode.READABLE);
     }
     /**
      * Constructs an read-only DataSource with Nacos backend.
@@ -58,11 +58,11 @@ public class NacosDataSource<T> extends DataSourceHolder {
      * @param serverAddr server address of Nacos, cannot be empty
      * @param groupId    group ID, cannot be empty
      * @param dataId     data ID, cannot be empty
-     * @param parser     customized data parser, cannot be empty
+     * @param converter     customized data converter, cannot be empty
      * @param dataSourceMode     dataSourceMode, cannot be empty
      */
-    public NacosDataSource(final String serverAddr, final String groupId, final String dataId, SentinelConverter<String, T> parser, final DataSourceMode dataSourceMode) {
-        this(NacosDataSource.buildProperties(serverAddr), groupId, dataId, parser, dataSourceMode);
+    public NacosDataSource(final String serverAddr, final String groupId, final String dataId, SentinelConverter<String, T> converter, final DataSourceMode dataSourceMode) {
+        this(NacosDataSource.buildProperties(serverAddr), groupId, dataId, converter, dataSourceMode);
     }
 
     /**
@@ -70,10 +70,10 @@ public class NacosDataSource<T> extends DataSourceHolder {
      * @param properties properties for construct {@link ConfigService} using {@link NacosFactory#createConfigService(Properties)}
      * @param groupId    group ID, cannot be empty
      * @param dataId     data ID, cannot be empty
-     * @param parser     customized data parser, cannot be empty
+     * @param converter     customized data converter, cannot be empty
      */
-    public NacosDataSource(final Properties properties, final String groupId, final String dataId, SentinelConverter<String, T> parser) {
-        this(properties, groupId, dataId, parser, DataSourceMode.READABLE);
+    public NacosDataSource(final Properties properties, final String groupId, final String dataId, SentinelConverter<String, T> converter) {
+        this(properties, groupId, dataId, converter, DataSourceMode.READABLE);
     }
 
     /**
@@ -81,11 +81,11 @@ public class NacosDataSource<T> extends DataSourceHolder {
      * @param properties properties for construct {@link ConfigService} using {@link NacosFactory#createConfigService(Properties)}
      * @param groupId    group ID, cannot be empty
      * @param dataId     data ID, cannot be empty
-     * @param parser     customized data parser, cannot be empty
+     * @param converter     customized data converter, cannot be empty
      * @param dataSourceMode     dataSourceMode, cannot be empty
      */
-    public NacosDataSource(final Properties properties, final String groupId, final String dataId, SentinelConverter<String, T> parser, final DataSourceMode dataSourceMode) {
-        super(parser, dataSourceMode);
+    public NacosDataSource(final Properties properties, final String groupId, final String dataId, SentinelConverter<String, T> converter, final DataSourceMode dataSourceMode) {
+        super(converter, dataSourceMode);
 
         if (StringUtil.isBlank(groupId) || StringUtil.isBlank(dataId)) {
             throw new IllegalArgumentException(String.format("Bad argument: groupId=[%s], dataId=[%s]", groupId, dataId));

--- a/sentinel-extension/sentinel-datasource-nacos/src/main/java/com/alibaba/csp/sentinel/datasource/nacos/NacosDataSource.java
+++ b/sentinel-extension/sentinel-datasource-nacos/src/main/java/com/alibaba/csp/sentinel/datasource/nacos/NacosDataSource.java
@@ -85,7 +85,7 @@ public class NacosDataSource<T> extends DataSourceHolder {
      * @param dataSourceMode     dataSourceMode, cannot be empty
      */
     public NacosDataSource(final Properties properties, final String groupId, final String dataId, SentinelConverter<String, T> parser, final DataSourceMode dataSourceMode) {
-        super(parser);
+        super(parser, dataSourceMode);
 
         if (StringUtil.isBlank(groupId) || StringUtil.isBlank(dataId)) {
             throw new IllegalArgumentException(String.format("Bad argument: groupId=[%s], dataId=[%s]", groupId, dataId));

--- a/sentinel-extension/sentinel-datasource-nacos/src/main/java/com/alibaba/csp/sentinel/datasource/nacos/NacosReadableDataSource.java
+++ b/sentinel-extension/sentinel-datasource-nacos/src/main/java/com/alibaba/csp/sentinel/datasource/nacos/NacosReadableDataSource.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.datasource.nacos;
+
+import com.alibaba.csp.sentinel.concurrent.NamedThreadFactory;
+import com.alibaba.csp.sentinel.datasource.AbstractReadableDataSource;
+import com.alibaba.csp.sentinel.datasource.converter.SentinelConverter;
+import com.alibaba.csp.sentinel.datasource.DataSourceHolder;
+import com.alibaba.csp.sentinel.log.RecordLog;
+import com.alibaba.nacos.api.config.ConfigService;
+import com.alibaba.nacos.api.config.listener.Listener;
+import org.apache.commons.lang3.ObjectUtils;
+
+import java.util.Properties;
+import java.util.concurrent.*;
+
+/**
+ * A read-only {@code DataSource} with Nacos backend. When the data in Nacos backend has been modified,
+ * Nacos will automatically push the new value so that the dynamic configuration can be real-time.
+ *
+ * @param <T> target data type for Sentinel
+ *
+ * @author Eric Zhao
+ * @author Jiajiangnan
+ */
+public class NacosReadableDataSource<T> extends AbstractReadableDataSource<String, T> {
+
+    private static final int DEFAULT_TIMEOUT = 3000;
+
+    /**
+     * Single-thread pool. Once the thread pool is blocked, we throw up the old task.
+     */
+    private final ExecutorService pool = new ThreadPoolExecutor(1, 1, 0, TimeUnit.MILLISECONDS,
+        new ArrayBlockingQueue<Runnable>(1), new NamedThreadFactory("sentinel-nacos-ds-update", true),
+        new ThreadPoolExecutor.DiscardOldestPolicy());
+
+    private final Listener configListener;
+    private final String groupId;
+    private final String dataId;
+    private final Properties properties;
+    private final DataSourceHolder dataSourceHolder;
+
+    private final SentinelConverter<String, T> converter;
+
+    /**
+     * Note: The Nacos config might be null if its initialization failed.
+     */
+    private ConfigService configService;
+
+    public NacosReadableDataSource(final Properties properties, final String groupId, final String dataId, final DataSourceHolder dataSourceHolder) {
+        super(dataSourceHolder);
+        this.groupId = groupId;
+        this.dataId = dataId;
+        this.properties = properties;
+        this.dataSourceHolder = dataSourceHolder;
+        this.converter = dataSourceHolder.getConverter();
+        this.configListener = new Listener() {
+            @Override
+            public Executor getExecutor() {
+                return pool;
+            }
+
+            @Override
+            public void receiveConfigInfo(final String configInfo) {
+                RecordLog.info("[NacosDataSource] New property value received for (properties: {}) (dataId: {}, groupId: {}): {}", properties, dataId, groupId, configInfo);
+                T newValue = converter.toSentinel(configInfo);
+                // Update the new value to the property.
+                getProperty().updateValue(newValue);
+            }
+        };
+        init();
+        initNacosListener();
+        loadInitialConfig();
+    }
+
+    private void init() {
+        this.configService = ObjectUtils.defaultIfNull((ConfigService) dataSourceHolder.getDataSourceClient(), null);
+    }
+
+    private void loadInitialConfig() {
+        try {
+            T newValue = loadConfig();
+            if (newValue == null) {
+                RecordLog.warn("[NacosDataSource] WARN: initial config is null, you may have to check your data source");
+            }
+            getProperty().updateValue(newValue);
+        } catch (Exception ex) {
+            RecordLog.warn("[NacosDataSource] Error when loading initial config", ex);
+        }
+    }
+
+    private void initNacosListener() {
+        try {
+            // Add config listener.
+            configService.addListener(dataId, groupId, configListener);
+        } catch (Exception e) {
+            RecordLog.warn("[NacosDataSource] Error occurred when initializing Nacos data source", e);
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public String readSource() throws Exception {
+        if (configService == null) {
+            throw new IllegalStateException("Nacos config service has not been initialized or error occurred");
+        }
+        return configService.getConfig(dataId, groupId, DEFAULT_TIMEOUT);
+    }
+
+    @Override
+    public void close() {
+        if (configService != null) {
+            configService.removeListener(dataId, groupId, configListener);
+        }
+        pool.shutdownNow();
+    }
+
+}

--- a/sentinel-extension/sentinel-datasource-nacos/src/main/java/com/alibaba/csp/sentinel/datasource/nacos/NacosReadableDataSource.java
+++ b/sentinel-extension/sentinel-datasource-nacos/src/main/java/com/alibaba/csp/sentinel/datasource/nacos/NacosReadableDataSource.java
@@ -17,12 +17,11 @@ package com.alibaba.csp.sentinel.datasource.nacos;
 
 import com.alibaba.csp.sentinel.concurrent.NamedThreadFactory;
 import com.alibaba.csp.sentinel.datasource.AbstractReadableDataSource;
-import com.alibaba.csp.sentinel.datasource.converter.SentinelConverter;
 import com.alibaba.csp.sentinel.datasource.DataSourceHolder;
+import com.alibaba.csp.sentinel.datasource.converter.SentinelConverter;
 import com.alibaba.csp.sentinel.log.RecordLog;
 import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.api.config.listener.Listener;
-import org.apache.commons.lang3.ObjectUtils;
 
 import java.util.Properties;
 import java.util.concurrent.*;

--- a/sentinel-extension/sentinel-datasource-nacos/src/main/java/com/alibaba/csp/sentinel/datasource/nacos/NacosReadableDataSource.java
+++ b/sentinel-extension/sentinel-datasource-nacos/src/main/java/com/alibaba/csp/sentinel/datasource/nacos/NacosReadableDataSource.java
@@ -61,7 +61,7 @@ public class NacosReadableDataSource<T> extends AbstractReadableDataSource<Strin
     private ConfigService configService;
 
     public NacosReadableDataSource(final Properties properties, final String groupId, final String dataId, final DataSourceHolder dataSourceHolder) {
-        this(properties, groupId, dataId, dataSourceHolder, false);
+        this(properties, groupId, dataId, dataSourceHolder, true);
     }
 
     public NacosReadableDataSource(final Properties properties, final String groupId, final String dataId, final DataSourceHolder dataSourceHolder, final boolean autoRefresh) {

--- a/sentinel-extension/sentinel-datasource-nacos/src/main/java/com/alibaba/csp/sentinel/datasource/nacos/NacosReadableDataSource.java
+++ b/sentinel-extension/sentinel-datasource-nacos/src/main/java/com/alibaba/csp/sentinel/datasource/nacos/NacosReadableDataSource.java
@@ -86,7 +86,7 @@ public class NacosReadableDataSource<T> extends AbstractReadableDataSource<Strin
     }
 
     private void  initConfigService() {
-        this.configService = ObjectUtils.defaultIfNull((ConfigService) dataSourceHolder.getDataSourceClient(), null);
+        this.configService = dataSourceHolder.getDataSourceClient() == null ? null : (ConfigService) dataSourceHolder.getDataSourceClient();
     }
 
     private void loadInitialConfig() {

--- a/sentinel-extension/sentinel-datasource-nacos/src/main/java/com/alibaba/csp/sentinel/datasource/nacos/NacosWritableDataSource.java
+++ b/sentinel-extension/sentinel-datasource-nacos/src/main/java/com/alibaba/csp/sentinel/datasource/nacos/NacosWritableDataSource.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.datasource.nacos;
+
+import com.alibaba.csp.sentinel.datasource.AbstractWritableDataSource;
+import com.alibaba.csp.sentinel.datasource.DataSourceHolder;
+import com.alibaba.csp.sentinel.datasource.converter.SentinelConverter;
+import com.alibaba.nacos.api.config.ConfigService;
+import org.apache.commons.lang3.ObjectUtils;
+
+import java.util.Properties;
+
+/**
+ * A write-only {@code DataSource} with Nacos backend. Publish the data to Nacos,
+ * so that Nacos will automatically push the new value so that the dynamic configuration can be real-time.
+ *
+ * @param <T> target data type for Sentinel
+ *
+ * @author Jiajiangnan
+ */
+public class NacosWritableDataSource<T> extends AbstractWritableDataSource<T> {
+
+    private final String groupId;
+    private final String dataId;
+
+    private final SentinelConverter<String, T> converter;
+
+    private ConfigService configService = null;
+
+    public NacosWritableDataSource(final Properties properties, final String groupId, final String dataId, final DataSourceHolder dataSourceHolder) {
+        super(dataSourceHolder);
+        this.groupId = groupId;
+        this.dataId = dataId;
+        this.converter = dataSourceHolder.getConverter();
+
+        init();
+    }
+
+    private void init() {
+        this.configService = ObjectUtils.defaultIfNull((ConfigService)dataSourceHolder.getDataSourceClient(), null);
+    }
+
+    @Override
+    public void write(T value) throws Exception {
+        String content = converter.fromSentinel(value);
+        configService.publishConfig(dataId, groupId, content);
+    }
+
+    @Override
+    public void close() {
+        // Nothing to do
+    }
+
+}

--- a/sentinel-extension/sentinel-datasource-nacos/src/main/java/com/alibaba/csp/sentinel/datasource/nacos/NacosWritableDataSource.java
+++ b/sentinel-extension/sentinel-datasource-nacos/src/main/java/com/alibaba/csp/sentinel/datasource/nacos/NacosWritableDataSource.java
@@ -19,7 +19,6 @@ import com.alibaba.csp.sentinel.datasource.AbstractWritableDataSource;
 import com.alibaba.csp.sentinel.datasource.DataSourceHolder;
 import com.alibaba.csp.sentinel.datasource.converter.SentinelConverter;
 import com.alibaba.nacos.api.config.ConfigService;
-import org.apache.commons.lang3.ObjectUtils;
 
 import java.util.Properties;
 

--- a/sentinel-extension/sentinel-datasource-nacos/src/main/java/com/alibaba/csp/sentinel/datasource/nacos/NacosWritableDataSource.java
+++ b/sentinel-extension/sentinel-datasource-nacos/src/main/java/com/alibaba/csp/sentinel/datasource/nacos/NacosWritableDataSource.java
@@ -50,7 +50,7 @@ public class NacosWritableDataSource<T> extends AbstractWritableDataSource<T> {
     }
 
     private void init() {
-        this.configService = ObjectUtils.defaultIfNull((ConfigService)dataSourceHolder.getDataSourceClient(), null);
+        this.configService = dataSourceHolder.getDataSourceClient() == null ? null : (ConfigService) dataSourceHolder.getDataSourceClient();
     }
 
     @Override


### PR DESCRIPTION
### Describe what this PR does / why we need it

【 ISSUE #904 】【 ISSUE #2520 】
        1、optimize Converter support two-way-converter，and provide some default converter implements
        2、optimize sentinel-datasource-extension support writable.  
【 ISSUE #2521 】
        make sentinel-datasource-nacos support publish config


### Does this pull request fix one issue?

Fixes #904
Fixes #2520
Fixes #2521

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
【 ISSUE #2520 】-- Converter Partition
1、Deprecated the default Converter，defined SentinelConverter which has two function ’toSentinel‘ and 'fromSentinel'
2、Provided some implements of SentinelConverter
            EmptyConverter: sentinel Oject Class-Type is same to DataSource Object
            JsonConverter：an abstract Converter for Json DataSource Object，implemented fromSentinel defined in  SentinelConverter
            JsonArrayConverter：extends from JsonConverter，support Json-Array convert to Sentinel-Collection
            JsonObjectConverter：extends from JsonConverter，support Json-Object convert to Sentinel-Object

【 ISSUE #904 】【 ISSUE #2520 】-- DataSourceMode Partition
1、AbstractDataSource divide to two part of AbstractReadableDataSource and AbstractWritableDataSource，implement ReadableDataSource and WritableDataSource to follow Single responsibility.
2、Defined DataSourceMode to mark the DataSource is readable or writable，or both of them.
3、DataSourceHolder to holds the shared Objects in ReadDataSource and WriteableDataSouce
4、when extends a concrete DataSource like NacosDataSource, should extends DataSourceHolder

【 ISSUE #2521 】
1、Defined NacosReadableDataSource implement AbstractReadableDataSource to extend nacos load-config 
2、Defined NacosWritableDataSource implement AbstractWritableDataSource to extend nacos publish-config 
3、Defined NacosDataSource extends DataSourceHolder to hold the shared Object，and then define AbstractWritableDataSource and AbstractReadableDataSource in it to combine loadConfig and pubish Config. 
4、Through the DataSourceMode in Constructor of NacosDataSource to init AbstractReadableDataSource and AbstractWritableDataSource


### Describe how to verify it
there are some demo in project 'sentinel-demo-nacos-datasource' 


### Special notes for reviews
if this PR was merged ，I will optimize other datasource in this way In the later time

