### PR TITLE
修复了 StatisticSlot类中fireExit参数传递丢失args 的问题

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/StatisticSlot.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/StatisticSlot.java
@@ -148,7 +148,8 @@ public class StatisticSlot extends AbstractLinkedProcessorSlot<DefaultNode> {
             handler.onExit(context, resourceWrapper, count, args);
         }
 
-        fireExit(context, resourceWrapper, count);
+        // fix bug https://github.com/alibaba/Sentinel/issues/2374
+        fireExit(context, resourceWrapper, count, args);
     }
 
     private void recordCompleteFor(Node node, int batchCount, long rt, Throwable error) {


### PR DESCRIPTION
### Describe what this PR does / why we need it
修复了 StatisticSlot类中fireExit参数传递丢失args 的问题

### Does this pull request fix one issue?
#2374
