### PR TITLE
修复了 #1906,热点参数非基本类型会出现NPE的问题。扩展了 RequestProcessor

### DIFF
--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/handler/TokenServerHandler.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/handler/TokenServerHandler.java
@@ -16,6 +16,7 @@
 package com.alibaba.csp.sentinel.cluster.server.handler;
 
 import java.net.InetSocketAddress;
+import java.util.Objects;
 
 import com.alibaba.csp.sentinel.cluster.ClusterConstants;
 import com.alibaba.csp.sentinel.cluster.request.ClusterRequest;
@@ -76,6 +77,12 @@ public class TokenServerHandler extends ChannelInboundHandlerAdapter {
                 writeBadResponse(ctx, request);
             } else {
                 ClusterResponse<?> response = processor.processRequest(request);
+                // if response returns a null, means it cannot be processed
+                if (Objects.isNull(response)){
+                    RecordLog.warn("[RequestProcessor] the processor can‘t handle the request body: " + request.getData());
+                    writeBadResponse(ctx, request);
+                    return;
+                }
                 writeResponse(ctx, response);
             }
         }

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/processor/AbstractRequestProcessor.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/processor/AbstractRequestProcessor.java
@@ -1,0 +1,43 @@
+package com.alibaba.csp.sentinel.cluster.server.processor;
+
+import com.alibaba.csp.sentinel.cluster.request.ClusterRequest;
+import com.alibaba.csp.sentinel.cluster.response.ClusterResponse;
+
+import java.util.Objects;
+
+/**
+ * Abstraction layer fault tolerance
+ *
+ * @param <T> type of request body
+ * @param <R> type of response body
+ * @author howiekang
+ * @since 1.8
+ */
+public abstract class AbstractRequestProcessor<T, R> implements RequestProcessor<T, R> {
+
+    /**
+     * Process the cluster request.
+     *
+     * @param request Sentinel cluster request
+     * @return the response after processed
+     */
+    @Override
+    public ClusterResponse<R> processRequest(ClusterRequest<T> request) {
+        // logical extraction
+        // see issues https://github.com/alibaba/Sentinel/issues/1906
+        T t = request.getData();
+        if (Objects.isNull(t)) {
+            return null;
+        }
+
+        return doProcessRequest(request, t);
+    }
+
+    /**
+     * Process the cluster request.
+     *
+     * @param request Sentinel cluster request
+     * @return the response after processed
+     */
+    public abstract ClusterResponse<R> doProcessRequest(ClusterRequest<T> request, T t);
+}

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/processor/FlowRequestProcessor.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/processor/FlowRequestProcessor.java
@@ -30,15 +30,15 @@ import com.alibaba.csp.sentinel.cluster.server.TokenServiceProvider;
  * @since 1.4.0
  */
 @RequestType(ClusterConstants.MSG_TYPE_FLOW)
-public class FlowRequestProcessor implements RequestProcessor<FlowRequestData, FlowTokenResponseData> {
+public class FlowRequestProcessor extends AbstractRequestProcessor<FlowRequestData, FlowTokenResponseData> {
 
     @Override
-    public ClusterResponse<FlowTokenResponseData> processRequest(ClusterRequest<FlowRequestData> request) {
+    public ClusterResponse<FlowTokenResponseData> doProcessRequest(ClusterRequest<FlowRequestData> request,FlowRequestData data) {
         TokenService tokenService = TokenServiceProvider.getService();
 
-        long flowId = request.getData().getFlowId();
-        int count = request.getData().getCount();
-        boolean prioritized = request.getData().isPriority();
+        long flowId = data.getFlowId();
+        int count = data.getCount();
+        boolean prioritized = data.isPriority();
 
         TokenResult result = tokenService.requestToken(flowId, count, prioritized);
         return toResponse(result, request);

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/processor/ParamFlowRequestProcessor.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/processor/ParamFlowRequestProcessor.java
@@ -32,15 +32,15 @@ import com.alibaba.csp.sentinel.cluster.server.TokenServiceProvider;
  * @since 1.4.0
  */
 @RequestType(ClusterConstants.MSG_TYPE_PARAM_FLOW)
-public class ParamFlowRequestProcessor implements RequestProcessor<ParamFlowRequestData, FlowTokenResponseData> {
+public class ParamFlowRequestProcessor extends AbstractRequestProcessor<ParamFlowRequestData, FlowTokenResponseData> {
 
     @Override
-    public ClusterResponse<FlowTokenResponseData> processRequest(ClusterRequest<ParamFlowRequestData> request) {
+    public ClusterResponse<FlowTokenResponseData> doProcessRequest(ClusterRequest<ParamFlowRequestData> request,ParamFlowRequestData data) {
         TokenService tokenService = TokenServiceProvider.getService();
 
-        long flowId = request.getData().getFlowId();
-        int count = request.getData().getCount();
-        Collection<Object> args = request.getData().getParams();
+        long flowId = data.getFlowId();
+        int count = data.getCount();
+        Collection<Object> args = data.getParams();
 
         TokenResult result = tokenService.requestParamToken(flowId, count, args);
         return toResponse(result, request);

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/StatisticSlot.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/StatisticSlot.java
@@ -148,7 +148,8 @@ public class StatisticSlot extends AbstractLinkedProcessorSlot<DefaultNode> {
             handler.onExit(context, resourceWrapper, count, args);
         }
 
-        fireExit(context, resourceWrapper, count);
+        // fix bug https://github.com/alibaba/Sentinel/issues/2374
+        fireExit(context, resourceWrapper, count, args);
     }
 
     private void recordCompleteFor(Node node, int batchCount, long rt, Throwable error) {


### PR DESCRIPTION
### Describe what this PR does / why we need it
修复了 #1906,热点参数非基本类型会出现NPE的问题。
扩展了 RequestProcessor，增加了 AbstractRequestProcessor类。

为什么要增加 AbstractRequestProcessor 这个类？
1 作为 RequestProcessor 的中间层，容错和处理下层公共逻辑，减少重复逻辑
2 Body作为 参数，代码会更简洁

### Does this pull request fix one issue?
 #1906