### PR TITLE
Fix Test to Run in Isolation

### DIFF
--- a/sentinel-extension/sentinel-annotation-aspectj/src/test/java/com/alibaba/csp/sentinel/annotation/aspectj/integration/SentinelAnnotationIntegrationTest.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/test/java/com/alibaba/csp/sentinel/annotation/aspectj/integration/SentinelAnnotationIntegrationTest.java
@@ -210,6 +210,7 @@ public class SentinelAnnotationIntegrationTest extends AbstractJUnit4SpringConte
 
     @Test
     public void testFallBackPrivateMethod() throws Exception {
+        assertThat(fooService.fooWithPrivateFallback(1)).isEqualTo("Hello for 1");
         String resourceName = "apiFooWithFallback";
         ClusterNode cn = ClusterBuilderSlot.getClusterNode(resourceName);
 


### PR DESCRIPTION
**Description**
This PR fixes the test `com.alibaba.csp.sentinel.annotation.aspectj.integration.SentinelAnnotationIntegrationTest.testFallBackPrivateMethod` that fails when run by itself.

**Does this pull request fix one issue?**
None

**Describe how to verify it**
Running `mvn test -pl sentinel-extension/sentinel-annotation-aspectj -Dtest=SentinelAnnotationIntegrationTest#testFallBackPrivateMethod` will result in a failure due to a `NullPointerException`.

Running `mvn test -pl sentinel-extension/sentinel-annotation-aspectj -Dtest=SentinelAnnotationIntegrationTest` will have all tests pass, indicating flaky behavior.

**Describe how you did it**
`testFallBackPrivateMethod` fails when run alone due to a `NullPointerException`, where the `ClusterNode` is `null` because the `resourceName` key does exist in the `HashMap` of the `ClusterBuilderSlot`. However, when this test is run with `testFallbackWithNoParams`, both will pass. `testFallbackWithNoParams` calls the function `fooService.fooWithFallBack`, which adds the `resourceName` key into the `ClusterBuilderSlot`'s `HashMap`. Since both tests use the same `resourceName`, `testFallbackWithNoParams` must be run first so that `testFallBackPrivateMethod` passes. I noticed that `fooService.fooWithPrivateFallback` similarly adds the `resourceName` to the key, so I called that method in `testFallBackPrivateMethod` and asserted that it returned the right string to follow the pattern in `testFallbackWithNoParams`. This assertion is not strictly necessary because the test will pass when run alone as long as the function is called before getting the `ClusterNode`.
