### PR TITLE
Use CopyOnWriteArraySet for ConnectionGroup#connectionSet to avoid iterator fast-fail

### DIFF
--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/connection/ConnectionGroup.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/server/connection/ConnectionGroup.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.alibaba.csp.sentinel.cluster.server.ServerConstants;
@@ -34,7 +35,7 @@ public class ConnectionGroup {
 
     private final String namespace;
 
-    private final Set<ConnectionDescriptor> connectionSet = Collections.synchronizedSet(new HashSet<ConnectionDescriptor>());
+    private final Set<ConnectionDescriptor> connectionSet = new CopyOnWriteArraySet<>();
     private final AtomicInteger connectedCount = new AtomicInteger();
 
     public ConnectionGroup(String namespace) {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
利用 CopyOnWriteArraySet解决并发修改会存在集合快速失败问题

### Does this pull request fix one issue?
参考PR#2519

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
使用CopyOnWriteArraySet
