### PR TITLE
修复移除TokenServer失败的问题

### DIFF
--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/util/ClusterEntityUtils.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/util/ClusterEntityUtils.java
@@ -130,7 +130,8 @@ public final class ClusterEntityUtils {
             if (mode == ClusterStateManager.CLUSTER_SERVER) {
                 String serverAddress = getIp(ip);
                 int port = stateVO.getState().getServer().getPort();
-                map.computeIfAbsent(serverAddress, v -> new ClusterGroupEntity()
+                String targetAddress = serverAddress + ":" + port;
+                map.computeIfAbsent(targetAddress, v -> new ClusterGroupEntity()
                     .setBelongToApp(true).setMachineId(ip + '@' + stateVO.getCommandPort())
                     .setIp(ip).setPort(port)
                 );
@@ -145,8 +146,8 @@ public final class ClusterEntityUtils {
                 if (StringUtil.isBlank(targetServer) || targetPort == null || targetPort <= 0) {
                     continue;
                 }
-
-                ClusterGroupEntity group = map.computeIfAbsent(targetServer,
+                String targetAddress = targetServer + ":" + targetPort;
+                ClusterGroupEntity group = map.computeIfAbsent(targetAddress,
                     v -> new ClusterGroupEntity()
                         .setBelongToApp(true).setMachineId(targetServer)
                         .setIp(targetServer).setPort(targetPort)


### PR DESCRIPTION
### Describe what this PR does / why we need it
Bug fix #2590 

### Does this pull request fix one issue?
Fixes #2590 


### Describe how you did it
原本 com.alibaba.csp.sentinel.dashboard.util.ClusterEntityUtils的wrapToClusterGroup 中的map中的Key用的是实例的ip，并非ip:port，导致同机器下不同端口时，同IP的信息会被覆盖。
只需修改 com.alibaba.csp.sentinel.dashboard.util.ClusterEntityUtils的wrapToClusterGroup方法，将Key改为ip port，使其可以正常返回结果

### Describe how to verify it
部署Dashboard之后无论先从哪个实例删除均成功即可

### Special notes for reviews
