### PR TITLE
Fix the method isValidRule in GatewayRuleManager.class has a invalid check. ControlBehavior should be checked here, not grade. (#2595)

### DIFF
--- a/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/rule/GatewayRuleManager.java
+++ b/sentinel-adapter/sentinel-api-gateway-adapter-common/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/common/rule/GatewayRuleManager.java
@@ -119,7 +119,7 @@ public final class GatewayRuleManager {
                 || rule.getGrade() < 0 || rule.getCount() < 0 || rule.getBurst() < 0 || rule.getControlBehavior() < 0) {
             return false;
         }
-        if (rule.getGrade() == RuleConstant.CONTROL_BEHAVIOR_RATE_LIMITER
+        if (rule.getControlBehavior() == RuleConstant.CONTROL_BEHAVIOR_RATE_LIMITER
                 && rule.getMaxQueueingTimeoutMs() < 0) {
             return false;
         }


### PR DESCRIPTION
### Describe what this PR does / why we need it
Fix the method isValidRule in GatewayRuleManager.class has a invalid check. ControlBehavior should be checked here, not grade. 
https://github.com/alibaba/Sentinel/issues/2595

### Does this pull request fix one issue?
Fixes #2595 