### PR TITLE
Use unified entrance context name in Spring WebFlux adapter

### DIFF
--- a/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/SentinelWebFluxFilter.java
+++ b/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/SentinelWebFluxFilter.java
@@ -36,6 +36,8 @@ import reactor.core.publisher.Mono;
  */
 public class SentinelWebFluxFilter implements WebFilter {
 
+    public static final String SENTINEL_SPRING_WEBFLUX_CONTEXT_NAME = "sentinel_spring_webflux_context";
+
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
         // Maybe we can get the URL pattern elsewhere via:
@@ -56,7 +58,11 @@ public class SentinelWebFluxFilter implements WebFilter {
             .orElse(EMPTY_ORIGIN);
 
         return new SentinelReactorTransformer<>(new EntryConfig(finalPath, ResourceTypeConstants.COMMON_WEB,
-            EntryType.IN, new ContextConfig(finalPath, origin)));
+            EntryType.IN, new ContextConfig(getContextName(exchange), origin)));
+    }
+
+    protected String getContextName(ServerWebExchange exchange){
+        return SENTINEL_SPRING_WEBFLUX_CONTEXT_NAME;
     }
 
     private static final String EMPTY_ORIGIN = "";


### PR DESCRIPTION
### Describe what this PR does / why we need it
fix the issue of wrong context name on "spring webflux"

### Does this pull request fix one issue?
Fixes #2592 

### Describe how you did it
modify the context name of "ContextConfig" in SentinelWebFluxFilter

### Describe how to verify it
use webflux adapter to verify
````java
<dependency>
    <groupId>com.alibaba.csp</groupId>
    <artifactId>sentinel-spring-webflux-adapter</artifactId>
</dependency>
````
### Special notes for reviews
