### PR TITLE
Spring WebFlux Adapter Support "BEST_MATCHING_PATTERN_ATTRIBUTE"

### DIFF
--- a/sentinel-adapter/sentinel-spring-webflux-adapter/pom.xml
+++ b/sentinel-adapter/sentinel-spring-webflux-adapter/pom.xml
@@ -33,6 +33,12 @@
             <version>${spring.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${spring.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/support/DefaultBestMatchingPatternExtractor.java
+++ b/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/support/DefaultBestMatchingPatternExtractor.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 1999-2022 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.spring.webflux.support;
+
+import com.alibaba.csp.sentinel.util.AssertUtil;
+import org.springframework.web.reactive.HandlerMapping;
+import org.springframework.web.server.ServerWebExchange;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * default extractor for "BEST_MATCHING_HANDLER_ATTRIBUTE"
+ *
+ * @author icodening
+ * @date 2022.03.29
+ */
+public class DefaultBestMatchingPatternExtractor implements Function<ServerWebExchange, String> {
+
+    private final List<HandlerMapping> handlerMappings;
+
+    private final List<HandlerMappingBestMatchingPatternExtractor> handlerMappingBestMatchingPatternExtractors;
+
+    public DefaultBestMatchingPatternExtractor(List<HandlerMapping> handlerMappings,
+                                               List<HandlerMappingBestMatchingPatternExtractor> handlerMappingBestMatchingPatternExtractors) {
+        AssertUtil.notNull(handlerMappings, "handlerMappings cannot be null");
+        AssertUtil.notNull(handlerMappingBestMatchingPatternExtractors, "handlerMappingBestMatchingPatternExtractors cannot be null");
+        this.handlerMappings = handlerMappings;
+        this.handlerMappingBestMatchingPatternExtractors = handlerMappingBestMatchingPatternExtractors;
+    }
+
+    @Override
+    public String apply(ServerWebExchange exchange) {
+        for (HandlerMapping handlerMapping : handlerMappings) {
+            for (HandlerMappingBestMatchingPatternExtractor handlerMappingBestMatchingPatternExtractor : handlerMappingBestMatchingPatternExtractors) {
+                if (!handlerMappingBestMatchingPatternExtractor.supportExtract(handlerMapping)) {
+                    continue;
+                }
+                String bestMatchingPath = handlerMappingBestMatchingPatternExtractor.extract(handlerMapping, exchange);
+                if (bestMatchingPath != null) {
+                    return bestMatchingPath;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/support/HandlerMappingBestMatchingPatternExtractor.java
+++ b/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/support/HandlerMappingBestMatchingPatternExtractor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 1999-2022 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.spring.webflux.support;
+
+import org.springframework.web.reactive.HandlerMapping;
+import org.springframework.web.server.ServerWebExchange;
+
+/**
+ * "BEST_MATCHING_HANDLER_ATTRIBUTE" extractor
+ *
+ * @author icodening
+ * @date 2022.03.29
+ * @see HandlerMapping#BEST_MATCHING_HANDLER_ATTRIBUTE
+ */
+public interface HandlerMappingBestMatchingPatternExtractor {
+
+    /**
+     * whether to process the given HandlerMapping
+     *
+     * @param handlerMapping Spring HandlerMapping
+     * @return "true" is support extract
+     */
+    boolean supportExtract(HandlerMapping handlerMapping);
+
+    /**
+     * extract BEST_MATCHING_HANDLER_ATTRIBUTE for current given ServerWebExchange
+     *
+     * @param handlerMapping current HandlerMapping, eg. RouterFunctionMapping, RequestMappingHandlerMapping, SimpleUrlHandlerMapping
+     * @param exchange       current request and response
+     * @return best matching pattern, return null when if not found , eg. /users/{id}
+     */
+    String extract(HandlerMapping handlerMapping, ServerWebExchange exchange);
+}

--- a/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/support/RequestMappingHandlerMappingBestMatchingPatternExtractor.java
+++ b/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/support/RequestMappingHandlerMappingBestMatchingPatternExtractor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 1999-2022 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.spring.webflux.support;
+
+import org.springframework.web.reactive.HandlerMapping;
+import org.springframework.web.reactive.result.method.annotation.RequestMappingHandlerMapping;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.util.pattern.PathPattern;
+
+/**
+ * best matching pattern extractor for RequestMappingHandlerMapping
+ *
+ * @author icodening
+ * @date 2022.03.29
+ * @see RequestMappingHandlerMapping
+ */
+public class RequestMappingHandlerMappingBestMatchingPatternExtractor implements HandlerMappingBestMatchingPatternExtractor {
+
+    @Override
+    public String extract(HandlerMapping handlerMapping, ServerWebExchange exchange) {
+        RequestMappingHandlerMapping requestMappingHandlerMapping = (RequestMappingHandlerMapping) handlerMapping;
+        requestMappingHandlerMapping.getHandlerInternal(exchange);
+        Object attribute = exchange.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+        if (attribute instanceof PathPattern) {
+            return ((PathPattern) attribute).getPatternString();
+        }
+        return null;
+    }
+
+    @Override
+    public boolean supportExtract(HandlerMapping handlerMapping) {
+        return handlerMapping instanceof RequestMappingHandlerMapping;
+    }
+}

--- a/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/support/RequestPredicateRegistrar.java
+++ b/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/support/RequestPredicateRegistrar.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 1999-2022 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.spring.webflux.support;
+
+import com.alibaba.csp.sentinel.util.AssertUtil;
+import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.support.RouterFunctionMapping;
+
+/**
+ * RequestPredicate registrar for RouterFunction, existing RouterFunction can be record
+ *
+ * @author icodening
+ * @date 2022.03.29
+ */
+public class RequestPredicateRegistrar implements SmartInitializingSingleton {
+
+    private final RouterFunctionRequestPredicateRepository routerFunctionRequestPredicateRepository = new RouterFunctionRequestPredicateRepository();
+
+    private final RouterFunctionMapping routerFunctionMapping;
+
+    public RequestPredicateRegistrar(RouterFunctionMapping routerFunctionMapping) {
+        AssertUtil.notNull(routerFunctionMapping, "routerFunctionMapping cannot be null");
+        this.routerFunctionMapping = routerFunctionMapping;
+    }
+
+    @Override
+    public void afterSingletonsInstantiated() {
+        RouterFunction<?> routerFunction = this.routerFunctionMapping.getRouterFunction();
+        if (routerFunction != null) {
+            routerFunction.accept(new RouterFunctionRequestPredicateRegistrarVisitor(routerFunctionRequestPredicateRepository));
+        }
+    }
+
+    public RouterFunctionRequestPredicateRepository getRouterFunctionRequestPredicateRepository() {
+        return routerFunctionRequestPredicateRepository;
+    }
+}

--- a/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/support/RouterFunctionBestMatchingPatternExtractor.java
+++ b/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/support/RouterFunctionBestMatchingPatternExtractor.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 1999-2022 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.spring.webflux.support;
+
+import org.springframework.web.reactive.HandlerMapping;
+import org.springframework.web.reactive.function.server.RequestPredicate;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.support.RouterFunctionMapping;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.util.pattern.PathPattern;
+
+import java.util.List;
+
+/**
+ * best matching pattern extractor for RouterFunctionMapping
+ *
+ * @author icodening
+ * @date 2022.03.29
+ * @see RouterFunctionMapping
+ */
+public class RouterFunctionBestMatchingPatternExtractor implements HandlerMappingBestMatchingPatternExtractor {
+
+    private final RouterFunctionRequestPredicateRepository routerFunctionRequestPredicateRepository;
+
+    public RouterFunctionBestMatchingPatternExtractor(RouterFunctionRequestPredicateRepository routerFunctionRequestPredicateRepository) {
+        this.routerFunctionRequestPredicateRepository = routerFunctionRequestPredicateRepository;
+    }
+
+    @Override
+    public boolean supportExtract(HandlerMapping handlerMapping) {
+        return handlerMapping instanceof RouterFunctionMapping;
+    }
+
+    @Override
+    public String extract(HandlerMapping handlerMapping, ServerWebExchange exchange) {
+        SentinelServerRequest sentinelServerRequest = new SentinelServerRequest(exchange);
+        List<RequestPredicate> requestPredicates = routerFunctionRequestPredicateRepository.getRequestPredicates();
+        for (RequestPredicate requestPredicate : requestPredicates) {
+            if (requestPredicate.test(sentinelServerRequest)) {
+                Object attribute = exchange.getAttribute(RouterFunctions.MATCHING_PATTERN_ATTRIBUTE);
+                if (attribute instanceof PathPattern) {
+                    exchange.getAttributes().remove(RouterFunctions.MATCHING_PATTERN_ATTRIBUTE);
+                    return ((PathPattern) attribute).getPatternString();
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/support/RouterFunctionRequestPredicateRegistrarVisitor.java
+++ b/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/support/RouterFunctionRequestPredicateRegistrarVisitor.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 1999-2022 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.spring.webflux.support;
+
+import org.springframework.core.io.Resource;
+import org.springframework.web.reactive.function.server.*;
+import reactor.core.publisher.Mono;
+
+import java.util.function.Function;
+
+/**
+ * @author icodening
+ * @date 2022.03.29
+ */
+class RouterFunctionRequestPredicateRegistrarVisitor implements RouterFunctions.Visitor {
+
+    private final RouterFunctionRequestPredicateRepository routerFunctionRequestPredicateRepository;
+
+    RouterFunctionRequestPredicateRegistrarVisitor(RouterFunctionRequestPredicateRepository routerFunctionRequestPredicateRepository) {
+        this.routerFunctionRequestPredicateRepository = routerFunctionRequestPredicateRepository;
+    }
+
+    @Override
+    public void startNested(RequestPredicate predicate) {
+        //ignore
+    }
+
+    @Override
+    public void endNested(RequestPredicate predicate) {
+        //ignore
+    }
+
+    @Override
+    public void route(RequestPredicate predicate, HandlerFunction<?> handlerFunction) {
+        //cache the predicate
+        this.routerFunctionRequestPredicateRepository.addRequestPredicate(predicate);
+    }
+
+    @Override
+    public void resources(Function<ServerRequest, Mono<Resource>> lookupFunction) {
+        //ignore
+    }
+
+    @Override
+    public void unknown(RouterFunction<?> routerFunction) {
+        //ignore
+    }
+}

--- a/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/support/RouterFunctionRequestPredicateRepository.java
+++ b/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/support/RouterFunctionRequestPredicateRepository.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 1999-2022 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.spring.webflux.support;
+
+import org.springframework.web.reactive.function.server.RequestPredicate;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * RequestPredicate cache for RouterFunction
+ *
+ * @author icodening
+ * @date 2022.03.29
+ */
+public class RouterFunctionRequestPredicateRepository {
+
+    private final List<RequestPredicate> requestPredicates = Collections.synchronizedList(new ArrayList<>());
+
+    public RouterFunctionRequestPredicateRepository() {
+    }
+
+    public void addRequestPredicate(RequestPredicate requestPredicate) {
+        this.requestPredicates.add(requestPredicate);
+    }
+
+    public List<RequestPredicate> getRequestPredicates() {
+        return requestPredicates;
+    }
+}

--- a/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/support/SentinelServerRequest.java
+++ b/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/support/SentinelServerRequest.java
@@ -1,0 +1,284 @@
+package com.alibaba.csp.sentinel.adapter.spring.webflux.support;
+
+import com.alibaba.csp.sentinel.util.AssertUtil;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+import org.springframework.http.codec.HttpMessageReader;
+import org.springframework.http.codec.multipart.Part;
+import org.springframework.http.server.PathContainer;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyExtractor;
+import org.springframework.web.reactive.function.BodyExtractors;
+import org.springframework.web.reactive.function.UnsupportedMediaTypeException;
+import org.springframework.web.reactive.function.server.HandlerStrategies;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.UnsupportedMediaTypeStatusException;
+import org.springframework.web.server.WebSession;
+import org.springframework.web.util.UriBuilder;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.charset.Charset;
+import java.security.Principal;
+import java.util.*;
+import java.util.function.Function;
+
+/**
+ * wrap ServerWebExchange as ServerRequest
+ *
+ * @author icodening
+ * @date 2022.03.29
+ */
+public class SentinelServerRequest implements ServerRequest {
+
+    private static final Function<UnsupportedMediaTypeException, UnsupportedMediaTypeStatusException> ERROR_MAPPER = ex -> (ex
+            .getContentType() != null
+            ? new UnsupportedMediaTypeStatusException(ex.getContentType(),
+            ex.getSupportedMediaTypes())
+            : new UnsupportedMediaTypeStatusException(ex.getMessage()));
+
+    private final ServerWebExchange exchange;
+
+    private final Headers headers;
+
+    private final List<HttpMessageReader<?>> messageReaders;
+
+    public SentinelServerRequest(ServerWebExchange exchange) {
+        this(exchange, HandlerStrategies.withDefaults().messageReaders());
+    }
+
+    public SentinelServerRequest(ServerWebExchange exchange,
+                                 List<HttpMessageReader<?>> messageReaders) {
+        AssertUtil.notNull(exchange, "exchange cannot be null");
+        AssertUtil.notNull(messageReaders, "messageReaders cannot be null");
+        this.exchange = exchange;
+        this.messageReaders = Collections
+                .unmodifiableList(new ArrayList<>(messageReaders));
+        this.headers = new DefaultHeaders();
+    }
+
+    @Override
+    public String methodName() {
+        return request().getMethodValue();
+    }
+
+    @Override
+    public URI uri() {
+        return request().getURI();
+    }
+
+    @Override
+    public UriBuilder uriBuilder() {
+        return UriComponentsBuilder.fromHttpRequest(new ServerRequestAdapter());
+    }
+
+    @Override
+    public PathContainer pathContainer() {
+        return request().getPath();
+    }
+
+    @Override
+    public Headers headers() {
+        return this.headers;
+    }
+
+    @Override
+    public MultiValueMap<String, HttpCookie> cookies() {
+        return request().getCookies();
+    }
+
+    @Override
+    public <T> T body(BodyExtractor<T, ? super ServerHttpRequest> extractor) {
+        return body(extractor, Collections.emptyMap());
+    }
+
+    @Override
+    public Optional<InetSocketAddress> remoteAddress() {
+        return Optional.of(request().getRemoteAddress());
+    }
+
+    @Override
+    public List<HttpMessageReader<?>> messageReaders() {
+        return this.messageReaders;
+    }
+
+    @Override
+    public <T> T body(BodyExtractor<T, ? super ServerHttpRequest> extractor,
+                      Map<String, Object> hints) {
+        return extractor.extract(request(), new BodyExtractor.Context() {
+            @Override
+            public List<HttpMessageReader<?>> messageReaders() {
+                return messageReaders;
+            }
+
+            @Override
+            public Optional<ServerHttpResponse> serverResponse() {
+                return Optional.of(exchange().getResponse());
+            }
+
+            @Override
+            public Map<String, Object> hints() {
+                return hints;
+            }
+        });
+    }
+
+    @Override
+    public <T> Mono<T> bodyToMono(Class<? extends T> elementClass) {
+        Mono<T> mono = body(BodyExtractors.toMono(elementClass));
+        return mono.onErrorMap(UnsupportedMediaTypeException.class, ERROR_MAPPER);
+    }
+
+    @Override
+    public <T> Mono<T> bodyToMono(ParameterizedTypeReference<T> typeReference) {
+        Mono<T> mono = body(BodyExtractors.toMono(typeReference));
+        return mono.onErrorMap(UnsupportedMediaTypeException.class, ERROR_MAPPER);
+    }
+
+    @Override
+    public <T> Flux<T> bodyToFlux(Class<? extends T> elementClass) {
+        Flux<T> flux = body(BodyExtractors.toFlux(elementClass));
+        return flux.onErrorMap(UnsupportedMediaTypeException.class, ERROR_MAPPER);
+    }
+
+    @Override
+    public <T> Flux<T> bodyToFlux(ParameterizedTypeReference<T> typeReference) {
+        Flux<T> flux = body(BodyExtractors.toFlux(typeReference));
+        return flux.onErrorMap(UnsupportedMediaTypeException.class, ERROR_MAPPER);
+    }
+
+    @Override
+    public Map<String, Object> attributes() {
+        return this.exchange.getAttributes();
+    }
+
+    @Override
+    public MultiValueMap<String, String> queryParams() {
+        return request().getQueryParams();
+    }
+
+    @Override
+    public Map<String, String> pathVariables() {
+        return this.exchange.getAttributeOrDefault(
+                RouterFunctions.URI_TEMPLATE_VARIABLES_ATTRIBUTE, Collections.emptyMap());
+    }
+
+    @Override
+    public Mono<WebSession> session() {
+        return this.exchange.getSession();
+    }
+
+    @Override
+    public Mono<? extends Principal> principal() {
+        return this.exchange.getPrincipal();
+    }
+
+    @Override
+    public Mono<MultiValueMap<String, String>> formData() {
+        return this.exchange.getFormData();
+    }
+
+    @Override
+    public Mono<MultiValueMap<String, Part>> multipartData() {
+        return this.exchange.getMultipartData();
+    }
+
+    private ServerHttpRequest request() {
+        return this.exchange.getRequest();
+    }
+
+    public ServerWebExchange exchange() {
+        return this.exchange;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s %s", method(), path());
+    }
+
+    private class DefaultHeaders implements Headers {
+
+        private HttpHeaders delegate() {
+            return request().getHeaders();
+        }
+
+        @Override
+        public List<MediaType> accept() {
+            return delegate().getAccept();
+        }
+
+        @Override
+        public List<Charset> acceptCharset() {
+            return delegate().getAcceptCharset();
+        }
+
+        @Override
+        public List<Locale.LanguageRange> acceptLanguage() {
+            return delegate().getAcceptLanguage();
+        }
+
+        @Override
+        public OptionalLong contentLength() {
+            long value = delegate().getContentLength();
+            return (value != -1 ? OptionalLong.of(value) : OptionalLong.empty());
+        }
+
+        @Override
+        public Optional<MediaType> contentType() {
+            return Optional.ofNullable(delegate().getContentType());
+        }
+
+        @Override
+        public InetSocketAddress host() {
+            return delegate().getHost();
+        }
+
+        @Override
+        public List<HttpRange> range() {
+            return delegate().getRange();
+        }
+
+        @Override
+        public List<String> header(String headerName) {
+            List<String> headerValues = delegate().get(headerName);
+            return (headerValues != null ? headerValues : Collections.emptyList());
+        }
+
+        @Override
+        public HttpHeaders asHttpHeaders() {
+            return HttpHeaders.readOnlyHttpHeaders(delegate());
+        }
+
+        @Override
+        public String toString() {
+            return delegate().toString();
+        }
+
+    }
+
+    private final class ServerRequestAdapter implements HttpRequest {
+
+        @Override
+        public String getMethodValue() {
+            return methodName();
+        }
+
+        @Override
+        public URI getURI() {
+            return uri();
+        }
+
+        @Override
+        public HttpHeaders getHeaders() {
+            return request().getHeaders();
+        }
+
+    }
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it
Spring WebFlux下使用Sentinel，支持将Path参数的路径视为同一资源。
如在 /users/{id} 下，/users/1、/users/2将被视为同一个资源 "/users/{id}"

### Does this pull request fix one issue?
Fixes #2627 
### Describe how you did it
在SentinelWebFluxFilter中获取path动作之前加入获取"BEST_MATCHING_PATTERN_ATTRIBUTE"的埋点，如果埋点获取的结果为空，则使用默认的获取资源名逻辑
<img width="916" alt="image" src="https://user-images.githubusercontent.com/42876375/160665201-fefd1f30-cc77-486a-bbbb-a51f85eec784.png">

### Describe how to verify it
需要使用新的方式装配 SentinelWebFluxFilter，方式如下
````java
    @Bean
    public RequestPredicateRegistrar requestPredicateRepository(RouterFunctionMapping routerFunctionMapping) {
        return new RequestPredicateRegistrar(routerFunctionMapping);
    }

    @Bean
    public HandlerMappingBestMatchingPatternExtractor routerFunctionBestMatchingPatternExtractor(RequestPredicateRegistrar registrar) {
        return new RouterFunctionBestMatchingPatternExtractor(registrar.getRouterFunctionRequestPredicateRepository());
    }

    @Bean
    public HandlerMappingBestMatchingPatternExtractor requestMappingHandlerMappingBestMatchingExtractor() {
        return new RequestMappingHandlerMappingBestMatchingPatternExtractor();
    }

    @Bean
    public SentinelWebFluxFilter sentinelWebFluxFilter(List<HandlerMapping> handlerMappings,
                                                       List<HandlerMappingBestMatchingPatternExtractor> handlerMappingBestMatchingExtractors) {
        return new SentinelWebFluxFilter(new DefaultBestMatchingPatternExtractor(handlerMappings, handlerMappingBestMatchingExtractors));
    }
````

### Special notes for reviews
1. HandlerMappingBestMatchingPatternExtractor接口有两个默认实现分别为RequestMappingHandlerMappingBestMatchingPatternExtractor, RouterFunctionBestMatchingPatternExtractor. 两个提取器分别处理RequestMappingHandlerMapping与RouterFunction

2. RequestPredicateRegistrar是一个RouterFunction模式下的断言注册器。因为路由器模式与传统的RequestMappingHandlerMapping的路径匹配方式不一致，路由器模式下需要使用RequestPredicate得知当前的最佳匹配。而该类的主要作用就是在应用启动期间将路由器的predicate进行缓存，方便后续提取Pattern
