### PR TITLE
When CommandCenter not start completely, invoke stop method will throw a null point exception

### DIFF
--- a/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/command/SimpleHttpCommandCenter.java
+++ b/sentinel-transport/sentinel-transport-simple-http/src/main/java/com/alibaba/csp/sentinel/transport/command/SimpleHttpCommandCenter.java
@@ -158,7 +158,10 @@ public class SimpleHttpCommandCenter implements CommandCenter {
                 CommandCenterLog.warn("Error when releasing the server socket", e);
             }
         }
-        bizExecutor.shutdownNow();
+
+        if (bizExecutor != null) {
+            bizExecutor.shutdownNow();
+        }
         executor.shutdownNow();
         TransportConfig.setRuntimePort(PORT_UNINITIALIZED);
         handlerMap.clear();

--- a/sentinel-transport/sentinel-transport-simple-http/src/test/java/com/alibaba/csp/sentinel/transport/command/http/CommandCenterTest.java
+++ b/sentinel-transport/sentinel-transport-simple-http/src/test/java/com/alibaba/csp/sentinel/transport/command/http/CommandCenterTest.java
@@ -1,0 +1,42 @@
+package com.alibaba.csp.sentinel.transport.command.http;
+
+import com.alibaba.csp.sentinel.command.CommandCenterProvider;
+import com.alibaba.csp.sentinel.transport.CommandCenter;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Created by danebrown on 2022/4/1
+ * mail: tain198127@163.com
+ *
+ * @author danebrown
+ */
+public class CommandCenterTest {
+    @Test
+    public void stopCommandCenter(){
+        CommandCenter commandCenter =  CommandCenterProvider.getCommandCenter();
+        try {
+            commandCenter.stop();
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
+    @Test
+    public void startCommandCenter(){
+        CommandCenter commandCenter =  CommandCenterProvider.getCommandCenter();
+        try {
+            commandCenter.start();
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
+    @Test
+    public void beforeStartCommandCenter(){
+        CommandCenter commandCenter =  CommandCenterProvider.getCommandCenter();
+        try {
+            commandCenter.beforeStart();
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
+}

--- a/sentinel-transport/sentinel-transport-simple-http/src/test/java/com/alibaba/csp/sentinel/transport/command/http/CommandCenterTest.java
+++ b/sentinel-transport/sentinel-transport-simple-http/src/test/java/com/alibaba/csp/sentinel/transport/command/http/CommandCenterTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.csp.sentinel.transport.command.http;
 
 import com.alibaba.csp.sentinel.command.CommandCenterProvider;
@@ -5,12 +20,6 @@ import com.alibaba.csp.sentinel.transport.CommandCenter;
 import org.junit.Assert;
 import org.junit.Test;
 
-/**
- * Created by danebrown on 2022/4/1
- * mail: tain198127@163.com
- *
- * @author danebrown
- */
 public class CommandCenterTest {
     @Test
     public void stopCommandCenter(){


### PR DESCRIPTION


<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
When CommandCenter not start completely, invoke stop method will throw a null point exception

### Does this pull request fix one issue?
Fix
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

In com.alibaba.csp.sentinel.transport.command.SimpleHttpCommandCenter#stop method, I check bizExecutor is not null before invoke it's shutdownNow

### Describe how to verify it
```java
public class CommandCenterTest {
    @Test
    public void stopCommandCenter(){
        CommandCenter commandCenter =  CommandCenterProvider.getCommandCenter();
        try {
            commandCenter.stop();
        } catch (Exception e) {
            Assert.fail();
        }
    }
    @Test
    public void startCommandCenter(){
        CommandCenter commandCenter =  CommandCenterProvider.getCommandCenter();
        try {
            commandCenter.start();
        } catch (Exception e) {
            Assert.fail();
        }
    }
    @Test
    public void beforeStartCommandCenter(){
        CommandCenter commandCenter =  CommandCenterProvider.getCommandCenter();
        try {
            commandCenter.beforeStart();
        } catch (Exception e) {
            Assert.fail();
        }
    }
}
```
And test case below
<img width="494" alt="image" src="https://user-images.githubusercontent.com/1415402/161111407-c0df1511-406b-44db-99df-e3af994dbc23.png">

### Special notes for reviews
