### PR TITLE
chore: fatjar with classifer and can be off (-P!fatjar)

### DIFF
--- a/sentinel-dashboard/pom.xml
+++ b/sentinel-dashboard/pom.xml
@@ -195,4 +195,31 @@
             </resource>
         </resources>
     </build>
+    <profiles>
+        <profile>
+            <id>fatjar</id>
+            <activation><activeByDefault>true</activeByDefault></activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-maven-plugin</artifactId>
+                        <version>${spring.boot.version}</version>
+                        <configuration>
+                            <fork>true</fork>
+                            <mainClass>com.alibaba.csp.sentinel.dashboard.DashboardApplication</mainClass>
+                            <classifier>fatjar</classifier>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>repackage</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
make easy for developers to extend the sentinel-dashboard with maven the maven dependency.
英文表述有点生硬，改用中文说一下，此PR的目的吧：
此PR后sentinel-dashboard pom.xml应发布到公网maven仓库上，
以便第三方可以方便的引用sentinel-dashboard依赖进行功能扩展。

另外还可考虑fatjar profile改为不启动，这样就可仅在需要时才能过-Pfatjar, 以减少maven仓库的未必要的fatjar.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
