### PR TITLE
登录密码验证逻辑可扩展

### DIFF
--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/auth/AuthService.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/auth/AuthService.java
@@ -24,6 +24,15 @@ package com.alibaba.csp.sentinel.dashboard.auth;
 public interface AuthService<R> {
 
     /**
+     * Do login with username and password.
+     *
+     * @param username the username 
+     * @param password the password
+     * @return
+     */
+    boolean doLogin(String username, String password);
+
+    /**
      * Get the authentication user.
      *
      * @param request the request contains the user information

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/auth/FakeAuthServiceImpl.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/auth/FakeAuthServiceImpl.java
@@ -35,6 +35,11 @@ public class FakeAuthServiceImpl implements AuthService<HttpServletRequest> {
     }
 
     @Override
+    public boolean doLogin(String username, String password) {
+       return true;
+    }
+
+    @Override
     public AuthUser getAuthUser(HttpServletRequest request) {
         return new AuthUserImpl();
     }

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/auth/SimpleWebAuthServiceImpl.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/auth/SimpleWebAuthServiceImpl.java
@@ -18,6 +18,11 @@ package com.alibaba.csp.sentinel.dashboard.auth;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
+import org.apache.commons.lang.StringUtils;
+
+import com.alibaba.csp.sentinel.dashboard.config.AuthProperties;
+import com.alibaba.csp.sentinel.dashboard.config.DashboardConfig;
+
 /**
  * @author cdfive
  * @since 1.6.0
@@ -25,6 +30,41 @@ import javax.servlet.http.HttpSession;
 public class SimpleWebAuthServiceImpl implements AuthService<HttpServletRequest> {
 
     public static final String WEB_SESSION_KEY = "session_sentinel_admin";
+
+    private final AuthProperties authProperties;
+
+    public SimpleWebAuthServiceImpl(AuthProperties authProperties) {
+        super();
+        this.authProperties = authProperties;
+    }
+
+    public boolean doLogin(String username, String password) {
+        final String authUsername;
+        if (StringUtils.isNotBlank(DashboardConfig.getAuthUsername())) {
+            authUsername = DashboardConfig.getAuthUsername();
+        } else {
+            authUsername = authProperties.getUsername();
+        }
+        final String authPassword;
+        if (StringUtils.isNotBlank(DashboardConfig.getAuthPassword())) {
+            authPassword = DashboardConfig.getAuthPassword();
+        } else {
+            authPassword = authProperties.getPassword();
+        }
+        
+        /*
+         * If auth.username or auth.password is blank(set in application.properties or VM arguments),
+         * auth will pass, as the front side validate the input which can't be blank,
+         * so user can input any username or password(both are not blank) to login in that case.
+         */
+        return doLogin(authUsername, authPassword, username, password);
+    }
+
+    protected boolean doLogin(final String authUsername, final String authPassword,
+            final String username, final String password) {
+        return StringUtils.isNotBlank(authUsername) && !authUsername.equals(username)
+                || StringUtils.isNotBlank(authPassword) && !authPassword.equals(password);
+    }
 
     @Override
     public AuthUser getAuthUser(HttpServletRequest request) {

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/config/AuthConfiguration.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/config/AuthConfiguration.java
@@ -37,7 +37,7 @@ public class AuthConfiguration {
     @ConditionalOnMissingBean
     public AuthService<HttpServletRequest> httpServletRequestAuthService() {
         if (this.authProperties.isEnabled()) {
-            return new SimpleWebAuthServiceImpl();
+            return new SimpleWebAuthServiceImpl(authProperties);
         }
         return new FakeAuthServiceImpl();
     }

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/config/AuthProperties.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/config/AuthProperties.java
@@ -22,6 +22,10 @@ public class AuthProperties {
 
     private boolean enabled = true;
 
+    private String username;
+
+    private String password;
+
     public boolean isEnabled() {
         return enabled;
     }
@@ -30,4 +34,19 @@ public class AuthProperties {
         this.enabled = enabled;
     }
 
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
 }

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/AuthController.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/AuthController.java
@@ -17,13 +17,10 @@ package com.alibaba.csp.sentinel.dashboard.controller;
 
 import com.alibaba.csp.sentinel.dashboard.auth.AuthService;
 import com.alibaba.csp.sentinel.dashboard.auth.SimpleWebAuthServiceImpl;
-import com.alibaba.csp.sentinel.dashboard.config.DashboardConfig;
 import com.alibaba.csp.sentinel.dashboard.domain.Result;
-import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -40,32 +37,13 @@ public class AuthController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AuthController.class);
 
-    @Value("${auth.username:sentinel}")
-    private String authUsername;
-
-    @Value("${auth.password:sentinel}")
-    private String authPassword;
-
     @Autowired
     private AuthService<HttpServletRequest> authService;
 
     @PostMapping("/login")
     public Result<AuthService.AuthUser> login(HttpServletRequest request, String username, String password) {
-        if (StringUtils.isNotBlank(DashboardConfig.getAuthUsername())) {
-            authUsername = DashboardConfig.getAuthUsername();
-        }
 
-        if (StringUtils.isNotBlank(DashboardConfig.getAuthPassword())) {
-            authPassword = DashboardConfig.getAuthPassword();
-        }
-
-        /*
-         * If auth.username or auth.password is blank(set in application.properties or VM arguments),
-         * auth will pass, as the front side validate the input which can't be blank,
-         * so user can input any username or password(both are not blank) to login in that case.
-         */
-        if (StringUtils.isNotBlank(authUsername) && !authUsername.equals(username)
-                || StringUtils.isNotBlank(authPassword) && !authPassword.equals(password)) {
+        if (authService.doLogin(username, password)) {
             LOGGER.error("Login failed: Invalid username or password, username=" + username);
             return Result.ofFail(-1, "Invalid username or password");
         }


### PR DESCRIPTION
登录密码验证逻辑可扩展，扩展SimpleWebAuthServiceImpl后重写doLogin方法，然后配置替换默认的配置即可
ie:
```
    @Bean("httpServletRequestAuthService")
    public AuthService<HttpServletRequest> httpServletRequestAuthService1(
            final AuthProperties authProperties) {
        if (authProperties.isEnabled()) {
            return new CustomSimpleWebAuthServiceImpl(authProperties);
        }
        return new FakeAuthServiceImpl();
    }

```

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
