### PR TITLE
bugfix: Refactor IP verify logic in  MachineRegistryController of the dashboard

### DIFF
--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/MachineRegistryController.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/controller/MachineRegistryController.java
@@ -21,6 +21,7 @@ import com.alibaba.csp.sentinel.util.StringUtil;
 import com.alibaba.csp.sentinel.dashboard.discovery.MachineInfo;
 import com.alibaba.csp.sentinel.dashboard.domain.Result;
 
+import org.apache.http.conn.util.InetAddressUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,7 +30,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
-import sun.net.util.IPAddressUtil;
 
 @Controller
 @RequestMapping(value = "/registry", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -52,7 +52,7 @@ public class MachineRegistryController {
         if (StringUtil.isBlank(ip) || ip.length() > 128) {
             return Result.ofFail(-1, "invalid ip: " + ip);
         }
-        if (!IPAddressUtil.isIPv4LiteralAddress(ip) && !IPAddressUtil.isIPv6LiteralAddress(ip)) {
+        if (!InetAddressUtils.isIPv4Address(ip) && !InetAddressUtils.isIPv6Address(ip)) {
             return Result.ofFail(-1, "invalid ip: " + ip);
         }
         if (port == null || port < -1) {


### PR DESCRIPTION
### Describe what this PR does / why we need it
修复了在JDK17的环境下``IPAddressUtil``报错的问题

### Does this pull request fix one issue?
Fixes #2691 

### Describe how you did it
使用``httpclient ``所提供的工具类``org.apache.http.conn.util.InetAddressUtils``, 该工具类使用正则的方式校验IP的正确性，不依赖JDK内部实现

### Describe how to verify it
不再报错

### Special notes for reviews
已在本机复现并测试修复的有效性。
以下为JDK17的复现图
<img width="1082" alt="image" src="https://user-images.githubusercontent.com/42876375/164987416-08a2f753-c57f-4b1a-b6ec-4cb85dbf9eab.png">