### PR TITLE
Fix expired api for lettuce

### DIFF
--- a/sentinel-extension/sentinel-datasource-redis/src/main/java/com/alibaba/csp/sentinel/datasource/redis/RedisDataSource.java
+++ b/sentinel-extension/sentinel-datasource-redis/src/main/java/com/alibaba/csp/sentinel/datasource/redis/RedisDataSource.java
@@ -160,7 +160,7 @@ public class RedisDataSource<T> extends AbstractDataSource<String, T> {
             sentinelRedisUriBuilder.withClientName(clientName);
         }
         sentinelRedisUriBuilder.withSentinelMasterId(connectionConfig.getRedisSentinelMasterId())
-            .withTimeout(connectionConfig.getTimeout(), TimeUnit.MILLISECONDS);
+            .withTimeout(Duration.ofMillis(connectionConfig.getTimeout()));
         return RedisClient.create(sentinelRedisUriBuilder.build());
     }
 


### PR DESCRIPTION
sentinel-datasource-redis 使用了lettuce 5.x的已经标记过期的api,当手动升级lettuce到6.x,删除了这个过期api后这里就会报错
