### PR TITLE
replacing deprecated config key for Dashboard

### DIFF
--- a/sentinel-dashboard/src/main/resources/application.properties
+++ b/sentinel-dashboard/src/main/resources/application.properties
@@ -1,14 +1,14 @@
 #spring settings
-spring.http.encoding.force=true
-spring.http.encoding.charset=UTF-8
-spring.http.encoding.enabled=true
+server.servlet.encoding.force=true
+server.servlet.encoding.charset=UTF-8
+server.servlet.encoding.enabled=true
 
 #cookie name setting
 server.servlet.session.cookie.name=sentinel_dashboard_cookie
 
 #logging settings
 logging.level.org.springframework.web=INFO
-logging.file=${user.home}/logs/csp/sentinel-dashboard.log
+logging.file.name=${user.home}/logs/csp/sentinel-dashboard.log
 logging.pattern.file= %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
 #logging.pattern.console= %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
 


### PR DESCRIPTION
### Describe what this PR does / why we need it
replacing deprecated config key

### Does this pull request fix one issue?
Fixes #2712 

### Describe how you did it
replace key

### Describe how to verify it
``logging.file`` The specified directory did not generate logs
``logging.file.name`` The specified directory generate logs

refer ``spring.http.*`` https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.3-Release-Notes#deprecations-in-spring-boot-23
refer ``logging.*``https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.2-Release-Notes#deprecations-in-spring-boot-22