### PR TITLE
降级规则配置时，熔断策略设置为：异常比例，比例阈值设置为：1，满足条件没有触发熔断问题解决

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ExceptionCircuitBreaker.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ExceptionCircuitBreaker.java
@@ -107,7 +107,7 @@ public class ExceptionCircuitBreaker extends AbstractCircuitBreaker {
             // Use errorRatio
             curCount = errCount * 1.0d / totalCount;
         }
-        if (curCount > threshold) {
+        if (curCount >= threshold) {
             transformToOpen(curCount);
         }
     }


### PR DESCRIPTION
降级规则配置时，熔断策略设置为：异常比例，比例阈值设置为：1，满足条件没有触发熔断的问题解决