### PR TITLE
Support Spring MVC asynchronous requests,fix https://github.com/aliba…

### DIFF
--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/AbstractSentinelInterceptor.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/AbstractSentinelInterceptor.java
@@ -15,28 +15,29 @@
  */
 package com.alibaba.csp.sentinel.adapter.spring.webmvc;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import com.alibaba.csp.sentinel.Entry;
-import com.alibaba.csp.sentinel.EntryType;
-import com.alibaba.csp.sentinel.ResourceTypeConstants;
-import com.alibaba.csp.sentinel.SphU;
-import com.alibaba.csp.sentinel.Tracer;
+import com.alibaba.csp.sentinel.*;
 import com.alibaba.csp.sentinel.adapter.spring.webmvc.config.BaseWebMvcConfig;
 import com.alibaba.csp.sentinel.context.ContextUtil;
 import com.alibaba.csp.sentinel.log.RecordLog;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
 import com.alibaba.csp.sentinel.util.AssertUtil;
 import com.alibaba.csp.sentinel.util.StringUtil;
-
-import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.web.context.request.async.DeferredResult;
+import org.springframework.web.context.request.async.WebAsyncTask;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.AsyncHandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionStage;
 
 /**
  * Since request may be reprocessed in flow if any forwarding or including or other action
- * happened (see {@link javax.servlet.ServletRequest#getDispatcherType()}) we will only 
- * deal with the initial request. So we use <b>reference count</b> to track in 
+ * happened (see {@link javax.servlet.ServletRequest#getDispatcherType()}) we will only
+ * deal with the initial request. So we use <b>reference count</b> to track in
  * dispathing "onion" though which we could figure out whether we are in initial type "REQUEST".
  * That means the sub-requests which we rarely meet in practice will NOT be recorded in Sentinel.
  * <p>
@@ -48,11 +49,11 @@ import org.springframework.web.servlet.ModelAndView;
  *     return mav;
  * }
  * </pre>
- * 
+ *
  * @author kaizi2009
  * @since 1.7.1
  */
-public abstract class AbstractSentinelInterceptor implements HandlerInterceptor {
+public abstract class AbstractSentinelInterceptor implements AsyncHandlerInterceptor {
 
     public static final String SENTINEL_SPRING_WEB_CONTEXT_NAME = "sentinel_spring_web_context";
     private static final String EMPTY_ORIGIN = "";
@@ -64,54 +65,76 @@ public abstract class AbstractSentinelInterceptor implements HandlerInterceptor 
         AssertUtil.assertNotBlank(config.getRequestAttributeName(), "requestAttributeName should not be blank");
         this.baseWebMvcConfig = config;
     }
-    
+
     /**
      * @param request
      * @param rcKey
      * @param step
-     * @return reference count after increasing (initial value as zero to be increased) 
+     * @return reference count after increasing (initial value as zero to be increased)
      */
     private Integer increaseReferece(HttpServletRequest request, String rcKey, int step) {
         Object obj = request.getAttribute(rcKey);
-        
+
         if (obj == null) {
             // initial
             obj = Integer.valueOf(0);
         }
-        
+
         Integer newRc = (Integer)obj + step;
         request.setAttribute(rcKey, newRc);
         return newRc;
     }
-    
+
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
-        throws Exception {
+            throws Exception {
+        if (isAsyncHandlerMethod(handler)) {
+            return true;
+        }
+
+        afterConcurrentHandlingStarted(request, response, handler);
+        return true;
+    }
+
+    /**
+     * Called instead of {@code postHandle} and {@code afterCompletion}
+     * when the handler is being executed concurrently.
+     * <p>Implementations may use the provided request and response but should
+     * avoid modifying them in ways that would conflict with the concurrent
+     * execution of the handler. A typical use of this method would be to
+     * clean up thread-local variables.
+     *
+     * @param request  the current request
+     * @param response the current response
+     * @param handler  the handler (or {@link HandlerMethod}) that started async
+     *                 execution, for type and/or instance examination
+     * @throws Exception in case of errors
+     */
+    @Override
+    public void afterConcurrentHandlingStarted(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         try {
             String resourceName = getResourceName(request);
 
             if (StringUtil.isEmpty(resourceName)) {
-                return true;
+                return;
             }
-            
+
             if (increaseReferece(request, this.baseWebMvcConfig.getRequestRefName(), 1) != 1) {
-                return true;
+                return;
             }
-            
+
             // Parse the request origin using registered origin parser.
             String origin = parseOrigin(request);
             String contextName = getContextName(request);
             ContextUtil.enter(contextName, origin);
             Entry entry = SphU.entry(resourceName, ResourceTypeConstants.COMMON_WEB, EntryType.IN);
             request.setAttribute(baseWebMvcConfig.getRequestAttributeName(), entry);
-            return true;
         } catch (BlockException e) {
             try {
                 handleBlockException(request, response, e);
             } finally {
                 ContextUtil.exit();
             }
-            return false;
         }
     }
 
@@ -139,7 +162,7 @@ public abstract class AbstractSentinelInterceptor implements HandlerInterceptor 
         if (increaseReferece(request, this.baseWebMvcConfig.getRequestRefName(), -1) != 0) {
             return;
         }
-        
+
         Entry entry = getEntryInRequest(request, baseWebMvcConfig.getRequestAttributeName());
         if (entry == null) {
             // should not happen
@@ -147,7 +170,7 @@ public abstract class AbstractSentinelInterceptor implements HandlerInterceptor 
                     getClass().getSimpleName(), baseWebMvcConfig.getRequestAttributeName());
             return;
         }
-        
+
         traceExceptionAndExit(entry, ex);
         removeEntryInRequest(request);
         ContextUtil.exit();
@@ -197,4 +220,17 @@ public abstract class AbstractSentinelInterceptor implements HandlerInterceptor 
         return origin;
     }
 
+    protected boolean isAsyncHandlerMethod(Object handler) {
+        if (!(handler instanceof HandlerMethod)) {
+            return false;
+        }
+
+        HandlerMethod handlerMethod = (HandlerMethod) handler;
+        Class<?> returnType = handlerMethod.getReturnType().getParameterType();
+        return WebAsyncTask.class.isAssignableFrom(returnType) ||
+                Callable.class.isAssignableFrom(returnType) ||
+                DeferredResult.class.isAssignableFrom(returnType) ||
+                ListenableFuture.class.isAssignableFrom(returnType) ||
+                CompletionStage.class.isAssignableFrom(returnType);
+    }
 }

--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/SentinelSpringMvcIntegrationTest.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/SentinelSpringMvcIntegrationTest.java
@@ -61,7 +61,18 @@ public class SentinelSpringMvcIntegrationTest {
 
         ClusterNode cn = ClusterBuilderSlot.getClusterNode(url);
         assertNotNull(cn);
-        assertEquals(1, cn.passQps(), 0.01);
+        assertEquals(1, cn.totalPass(), 0.01);
+    }
+
+    @Test
+    public void testBaseAsync() throws Exception {
+        String url = "/hello/async";
+        this.mvc.perform(get(url))
+                .andExpect(status().isOk());
+
+        ClusterNode cn = ClusterBuilderSlot.getClusterNode(url);
+        assertNotNull(cn);
+        assertEquals(1, cn.totalPass(), 0.01);
     }
 
     @Test

--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/controller/TestController.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/controller/TestController.java
@@ -20,6 +20,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.concurrent.Callable;
+
 /**
  * @author kaizi2009
  */
@@ -29,6 +31,11 @@ public class TestController {
     @GetMapping("/hello")
     public String apiHello() {
         return "Hello!";
+    }
+
+    @GetMapping("/hello/async")
+    public Callable<String> apiAsyncHello() {
+        return ()-> "Hello!";
     }
 
     @GetMapping("/err")


### PR DESCRIPTION
…ba/Sentinel/issues/2716

### Describe what this PR does / why we need it
支持Spring MVC的异步请求

### Does this pull request fix one issue?
(https://github.com/alibaba/Sentinel/issues/2716)

### Describe how you did it
1 更改了 `AbstractSentinelInterceptor `的继承接口为 `AsyncHandlerInterceptor `将限流的逻辑移动到了afterConcurrentHandlingStarted 中实现。

异步请求的拦截逻辑 request -> afterConcurrentHandlingStarted -> preHandle -> afterCompletion -> resopnse
其中preHandle 做了方法返回值判断，如果是异步方法就不会执行了。

同步请求的拦截逻辑 request -> preHandle -> afterConcurrentHandlingStarted  -> afterCompletion -> resopnse

支持的异步返回值，与Spring的 handleReturnValue 中的一致，WebAsyncTask、Callable、DeferredResult、ListenableFuture、CompletionStage
### Describe how to verify it
test case
### Special notes for reviews
@sczyh30 