### PR TITLE
Fix concurrent error in sentinel cluster client 

### DIFF
--- a/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/handler/TokenPromise.java
+++ b/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/handler/TokenPromise.java
@@ -1,0 +1,50 @@
+package com.alibaba.csp.sentinel.cluster.client.handler;
+
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.TimeUnit;
+import com.alibaba.csp.sentinel.cluster.client.config.ClusterClientConfigManager;
+import com.alibaba.csp.sentinel.cluster.response.ClusterResponse;
+import io.netty.channel.ChannelPromise;
+
+/**
+ * @author Shako Xie
+ */
+public class TokenPromise {
+
+    private volatile long waiting = ClusterClientConfigManager.getRequestTimeout();
+    private SynchronousQueue<Object> channel = new SynchronousQueue<>();
+
+    public boolean setPromiseValue(ChannelPromise promise) throws InterruptedException {
+        long nanoTime = System.nanoTime();
+        boolean offered = channel.offer(promise, this.waiting, TimeUnit.MILLISECONDS);
+        if (!offered) {
+            this.waiting = 0;
+        } else {
+            this.waiting -= TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - nanoTime);
+        }
+        return offered;
+    }
+
+    public ClusterResponse getResponseValue() throws InterruptedException {
+        if (this.waiting <= 0) {
+            return null;
+        }
+        Object promise = channel.poll(this.waiting, TimeUnit.MILLISECONDS);
+        if (promise != null) {
+            return (ClusterResponse) promise;
+        }
+        return null;
+    }
+
+    public ChannelPromise getPromiseValue() throws InterruptedException {
+        if (this.waiting <= 0) {
+            return null;
+        }
+        return (ChannelPromise) channel.poll(this.waiting, TimeUnit.MILLISECONDS);
+    }
+
+    public boolean setResponseValue(ClusterResponse response) throws InterruptedException {
+        return channel.offer(response, this.waiting, TimeUnit.MILLISECONDS);
+    }
+
+}

--- a/sentinel-cluster/sentinel-cluster-client-default/src/test/java/com/alibaba/csp/sentinel/cluster/client/codec/data/TokenPromiseTest.java
+++ b/sentinel-cluster/sentinel-cluster-client-default/src/test/java/com/alibaba/csp/sentinel/cluster/client/codec/data/TokenPromiseTest.java
@@ -1,0 +1,98 @@
+package com.alibaba.csp.sentinel.cluster.client.codec.data;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Assert;
+import org.junit.Test;
+import com.alibaba.csp.sentinel.cluster.client.config.ClusterClientConfigManager;
+import com.alibaba.csp.sentinel.cluster.client.handler.TokenPromise;
+import com.alibaba.csp.sentinel.cluster.response.ClusterResponse;
+import io.netty.channel.DefaultChannelPromise;
+import io.netty.channel.socket.nio.NioSocketChannel;
+
+/**
+ * @author Shako Xie
+ */
+public class TokenPromiseTest {
+
+    @Test
+    public void normalTest() throws InterruptedException {
+        final TokenPromise promise = new TokenPromise();
+        final AtomicBoolean providerResult = new AtomicBoolean(false);
+        final AtomicBoolean consumerResult = new AtomicBoolean(false);
+        Thread provider = genProvider(promise, providerResult);
+        Thread consumer = genConsumer(promise, consumerResult);
+        provider.start();
+        // remote cost, TP99:3ms
+        Thread.sleep(3);
+        consumer.start();
+        provider.join();
+        consumer.join();
+        Assert.assertTrue(providerResult.get() && consumerResult.get());
+    }
+
+    @Test
+    public void FastConsumerTest() throws InterruptedException {
+        final TokenPromise promise = new TokenPromise();
+        final AtomicBoolean providerResult = new AtomicBoolean(false);
+        final AtomicBoolean consumerResult = new AtomicBoolean(false);
+        Thread provider = genProvider(promise, providerResult);
+        Thread consumer = genConsumer(promise, consumerResult);
+        // remote cost, 0ms
+        consumer.start();
+        provider.start();
+        provider.join();
+        consumer.join();
+        Assert.assertTrue(providerResult.get() && consumerResult.get());
+    }
+
+    @Test
+    public void timeoutTest() throws InterruptedException {
+        final TokenPromise promise = new TokenPromise();
+        final AtomicBoolean providerResult = new AtomicBoolean(false);
+        final AtomicBoolean consumerResult = new AtomicBoolean(false);
+        Thread provider = genProvider(promise, providerResult);
+        Thread consumer = genConsumer(promise, consumerResult);
+        provider.start();
+        // remote cost and timeout
+        Thread.sleep(ClusterClientConfigManager.getRequestTimeout());
+        consumer.start();
+        provider.join();
+        consumer.join();
+        Assert.assertTrue(!providerResult.get());
+    }
+
+    private Thread genProvider(TokenPromise promise, AtomicBoolean ret) {
+        return new Thread(() -> {
+            try {
+                if (promise.setPromiseValue(new DefaultChannelPromise(new NioSocketChannel()))) {
+                    ret.set(true);
+                } else {
+                    return;
+                }
+                Thread.sleep(ThreadLocalRandom.current().nextInt(5));
+                if (null != promise.getResponseValue()) {
+                    ret.set(true);
+                }
+            } catch (Exception e) {
+            }
+        });
+    }
+
+    private Thread genConsumer(TokenPromise promise, AtomicBoolean ret) {
+        return new Thread(() -> {
+            try {
+                if (null != promise.getPromiseValue()) {
+                    ret.set(true);
+                } else {
+                    return;
+                }
+                Thread.sleep(ThreadLocalRandom.current().nextInt(5));
+                if (promise.setResponseValue(new ClusterResponse<>())) {
+                    ret.set(true);
+                }
+            } catch (InterruptedException e) {
+            }
+        });
+    }
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->
### Describe what this PR does / why we need it
In `TokenClientPromiseHolder.completePromise(int xid, ClusterResponse<T> response)`, we get the `promise` from `PROMISE_MAP`, and the `promise` may be null. There are two possible situations:
* The response is timeout and `NettyTransportClient` remove it through `TokenClientPromiseHolder.remove(xid)`(OK) 
* The response is received but `NettyTransportClient` haven't invoke `putPromise(xid, promise)`(concurrent error, mostly GC hanppens)
 
This PR will fix it to avoid client getting timeout exception in `promise.await`
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
### Does this pull request fix one issue?
Fixes #2852 
### Describe how you did it
1. `TokenPromise` use `SynchronousQueue` to avoid concurrent error (like chan in golang)
2. `TokenPromise` use `startTime` and `poll` to avoid client blocking too long
3. `TokenClientPromiseHolder` use `ThreadPool` to avoid `TokenClientHandler` blocking too long in `channelRead`
### Describe how to verify it
In `TokenPromiseTest`, there are three unit test cases
* normalTest : rt is 3ms
* FastConsumerTest : rt is 0ms, response is received before put promise
* timeoutTest : rt is 20ms