### PR TITLE
Fix incorrect comment in LeapArray

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/base/LeapArray.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/base/LeapArray.java
@@ -127,7 +127,7 @@ public abstract class LeapArray<T> {
          *
          * (1) Bucket is absent, then just create a new bucket and CAS update to circular array.
          * (2) Bucket is up-to-date, then just return the bucket.
-         * (3) Bucket is deprecated, then reset current bucket and clean all deprecated buckets.
+         * (3) Bucket is deprecated, then reset current bucket.
          */
         while (true) {
             WindowWrap<T> old = array.get(idx);


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
LeapArray currentWindow 方法注释与逻辑不符

第130行： (3) Bucket is deprecated, then reset current bucket and clean all deprecated buckets.
实际上逻辑是重置了当前bucket，但并没有清理所有其他过期的buckets

### Does this pull request fix one issue?
Fixes #2875

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
删除了描述不正确的注释

### Describe how to verify it
请阅Pr代码，


### Special notes for reviews
