### PR TITLE
fix(sec): upgrade com.google.protobuf:protobuf-java to 3.16.1

### DIFF
--- a/sentinel-cluster/sentinel-cluster-server-envoy-rls/pom.xml
+++ b/sentinel-cluster/sentinel-cluster-server-envoy-rls/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>sentinel-cluster</artifactId>
         <groupId>com.alibaba.csp</groupId>
@@ -15,7 +13,7 @@
         <java.source.version>1.8</java.source.version>
         <java.target.version>1.8</java.target.version>
 
-        <protobuf.version>3.10.0</protobuf.version>
+        <protobuf.version>3.16.1</protobuf.version>
         <grpc.version>1.30.2</grpc.version>
 
         <maven.shade.version>3.2.1</maven.shade.version>
@@ -141,14 +139,12 @@
                                 <configuration>
                                     <finalName>sentinel-envoy-rls-token-server</finalName>
                                     <transformers>
-                                        <transformer
-                                                implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                             <mainClass>
                                                 com.alibaba.csp.sentinel.cluster.server.envoy.rls.SentinelEnvoyRlsServer
                                             </mainClass>
                                         </transformer>
-                                        <transformer
-                                                implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                     </transformers>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.google.protobuf:protobuf-java 3.10.0
- [CVE-2021-22569](https://www.oscs1024.com/hd/CVE-2021-22569)


### What did I do？
Upgrade com.google.protobuf:protobuf-java from 3.10.0 to 3.16.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS