### PR TITLE
fix(sec): upgrade org.springframework:spring-core to 5.2.19.RELEASE

### DIFF
--- a/sentinel-adapter/sentinel-zuul-adapter/pom.xml
+++ b/sentinel-adapter/sentinel-zuul-adapter/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>sentinel-adapter</artifactId>
         <groupId>com.alibaba.csp</groupId>
@@ -48,7 +46,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>4.3.20.RELEASE</version>
+            <version>5.2.19.RELEASE</version>
             <scope>provided</scope>
         </dependency>
 

--- a/sentinel-adapter/sentinel-zuul2-adapter/pom.xml
+++ b/sentinel-adapter/sentinel-zuul2-adapter/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>sentinel-adapter</artifactId>
         <groupId>com.alibaba.csp</groupId>
@@ -45,7 +43,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>5.1.18.RELEASE</version>
+            <version>5.2.19.RELEASE</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### What happened？
There are 2 security vulnerabilities found in org.springframework:spring-core 5.1.18.RELEASE
- [CVE-2021-22060](https://www.oscs1024.com/hd/CVE-2021-22060)
- [CVE-2021-22096](https://www.oscs1024.com/hd/CVE-2021-22096)


### What did I do？
Upgrade org.springframework:spring-core from 5.1.18.RELEASE to 5.2.19.RELEASE for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS