### PR TITLE
If initialized, avoid CAS that is more expensive to execute

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/init/InitExecutor.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/init/InitExecutor.java
@@ -39,6 +39,7 @@ public final class InitExecutor {
      * The initialization will be executed only once.
      */
     public static void doInit() {
+        if(initialized.get()) return;
         if (!initialized.compareAndSet(false, true)) {
             return;
         }


### PR DESCRIPTION

Describe what this PR does / why we need it
这个方法,每次进来都要执行CAS,已经进行了初始化,就不需要进行代价相对高一些的CAS操作
Does this pull request fix one issue?
fix issues 2897
Describe how you did it
1、如果initialized.get()返回true,说明已经进行了或者正在进行初始化,可以直接返回.
2、如果initialized.get()返回false,说明还没有进行初始化,然后尝试进行初始化,这个时候可能有多个线程同时进行初始化,
借助下面的CAS操作,只会有一个线程进入初始化代码,其余线程返回.
3、AtomicBoolean本身已经具备了可见性,所以可以读到其他线程写入的最新值.
Describe how to verify it
human review
Special notes for reviews
nothing