### PR TITLE
chore: remove junit-dep for fast build and stable build

### DIFF
--- a/sentinel-dashboard/pom.xml
+++ b/sentinel-dashboard/pom.xml
@@ -130,10 +130,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-        	<groupId>com.github.stefanbirkner</groupId>
-        	<artifactId>system-rules</artifactId>
-        	<version>1.16.1</version>
-        	<scope>test</scope>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <version>1.16.1</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                   <groupId>junit</groupId>
+                   <artifactId>junit-dep</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
system-rules 依赖的junit-dep是一个版本范围，导致构建时会定期从maven仓库查找最新版本junit-dep 这会影响我们构建的稳定性和速度， 而且最新的junit已不再需要junit-dep。
再依赖除了影响构建没什么用处.

本次变更前构建时加参数’-U'大家看到问题所在了(每次找网络上查找junit/junit-dep/maven-metadata.xml)

try 'mvn compile -U' you will see the issue.

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
