### PR TITLE
fix repeat reset bucket

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/base/LeapArray.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/base/LeapArray.java
@@ -185,6 +185,10 @@ public abstract class LeapArray<T> {
                  */
                 if (updateLock.tryLock()) {
                     try {
+                        // double check to avoid repeat reset the bucket
+                        if (windowStart <= old.windowStart()){
+                          continue;
+                        }
                         // Successfully get the update lock, now we reset the bucket.
                         return resetWindowTo(old, windowStart);
                     } finally {


### PR DESCRIPTION
### Describe what this PR does / why we need it

现有实现方式存在重复重置 bucket 的可能

1. 假设有 a, b 两个线程，同时满足 `windowStart > old.windowStart()` 条件
2. a 线程获取锁成功，并完成重置，释放锁
3. 此时b线程开始尝试获取锁，由于a线程已释放，所以可以获取成功，重置bucket
综上，会发生重复重置 bucket 的可能

### Does this pull request fix one issue?

None 

### Describe how you did it

double check，当发现不满足时通过 `continue` 跳过重置逻辑，在下一轮即可获取正确的 bucket
