### PR TITLE
Fix spelling mistakes(#2930)

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/eagleeye/EagleEye.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/eagleeye/EagleEye.java
@@ -198,7 +198,7 @@ public final class EagleEye {
         return new StatLoggerBuilder(loggerName);
     }
 
-    static void setEagelEyeSelfAppender(EagleEyeAppender appender) {
+    static void setEagleEyeSelfAppender(EagleEyeAppender appender) {
         selfAppender = appender;
     }
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

A typo exists in the `EagleEye.class` method name `setEagelEyeSelfAppender()`

```java
public final class EagleEye {
    ...
    static void setEagelEyeSelfAppender(EagleEyeAppender appender) {
        selfAppender = appender;
    }
}
```
### Does this pull request fix one issue?

Fixes #2930 

### Describe how you did it

fix it to eagle