### PR TITLE
Fix thread safe bug of WindowWrap (#2949)

### DIFF
--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/statistic/metric/ClusterMetricLeapArray.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/statistic/metric/ClusterMetricLeapArray.java
@@ -15,12 +15,12 @@
  */
 package com.alibaba.csp.sentinel.cluster.flow.statistic.metric;
 
-import java.util.concurrent.atomic.LongAdder;
-
 import com.alibaba.csp.sentinel.cluster.flow.statistic.data.ClusterFlowEvent;
 import com.alibaba.csp.sentinel.cluster.flow.statistic.data.ClusterMetricBucket;
 import com.alibaba.csp.sentinel.slots.statistic.base.LeapArray;
 import com.alibaba.csp.sentinel.slots.statistic.base.WindowWrap;
+
+import java.util.concurrent.atomic.LongAdder;
 
 /**
  * @author Eric Zhao
@@ -46,11 +46,9 @@ public class ClusterMetricLeapArray extends LeapArray<ClusterMetricBucket> {
     }
 
     @Override
-    protected WindowWrap<ClusterMetricBucket> resetWindowTo(WindowWrap<ClusterMetricBucket> w, long startTime) {
-        w.resetTo(startTime);
-        w.value().reset();
-        transferOccupyToBucket(w.value());
-        return w;
+    protected void resetWindowValue(ClusterMetricBucket windowValue, long startTime) {
+        windowValue.reset();
+        transferOccupyToBucket(windowValue);
     }
 
     private void transferOccupyToBucket(/*@Valid*/ ClusterMetricBucket bucket) {

--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/statistic/metric/ClusterParameterLeapArray.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/statistic/metric/ClusterParameterLeapArray.java
@@ -16,7 +16,6 @@
 package com.alibaba.csp.sentinel.cluster.flow.statistic.metric;
 
 import com.alibaba.csp.sentinel.slots.statistic.base.LeapArray;
-import com.alibaba.csp.sentinel.slots.statistic.base.WindowWrap;
 import com.alibaba.csp.sentinel.slots.statistic.cache.CacheMap;
 import com.alibaba.csp.sentinel.slots.statistic.cache.ConcurrentLinkedHashMapWrapper;
 import com.alibaba.csp.sentinel.util.AssertUtil;
@@ -42,10 +41,8 @@ public class ClusterParameterLeapArray<C> extends LeapArray<CacheMap<Object, C>>
     }
 
     @Override
-    protected WindowWrap<CacheMap<Object, C>> resetWindowTo(WindowWrap<CacheMap<Object, C>> w, long startTime) {
-        w.resetTo(startTime);
-        w.value().clear();
-        return w;
+    protected void resetWindowValue(CacheMap<Object, C> windowValue, long startTime) {
+        windowValue.clear();
     }
 
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ExceptionCircuitBreaker.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ExceptionCircuitBreaker.java
@@ -15,15 +15,14 @@
  */
 package com.alibaba.csp.sentinel.slots.block.degrade.circuitbreaker;
 
-import java.util.List;
-import java.util.concurrent.atomic.LongAdder;
-
 import com.alibaba.csp.sentinel.Entry;
 import com.alibaba.csp.sentinel.context.Context;
 import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRule;
 import com.alibaba.csp.sentinel.slots.statistic.base.LeapArray;
-import com.alibaba.csp.sentinel.slots.statistic.base.WindowWrap;
 import com.alibaba.csp.sentinel.util.AssertUtil;
+
+import java.util.List;
+import java.util.concurrent.atomic.LongAdder;
 
 import static com.alibaba.csp.sentinel.slots.block.RuleConstant.DEGRADE_GRADE_EXCEPTION_COUNT;
 import static com.alibaba.csp.sentinel.slots.block.RuleConstant.DEGRADE_GRADE_EXCEPTION_RATIO;
@@ -156,11 +155,8 @@ public class ExceptionCircuitBreaker extends AbstractCircuitBreaker {
         }
 
         @Override
-        protected WindowWrap<SimpleErrorCounter> resetWindowTo(WindowWrap<SimpleErrorCounter> w, long startTime) {
-            // Update the start time and reset value.
-            w.resetTo(startTime);
-            w.value().reset();
-            return w;
+        protected void resetWindowValue(SimpleErrorCounter windowValue, long startTime) {
+            windowValue.reset();
         }
     }
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ResponseTimeCircuitBreaker.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/degrade/circuitbreaker/ResponseTimeCircuitBreaker.java
@@ -15,17 +15,16 @@
  */
 package com.alibaba.csp.sentinel.slots.block.degrade.circuitbreaker;
 
-import java.util.List;
-import java.util.concurrent.atomic.LongAdder;
-
 import com.alibaba.csp.sentinel.Entry;
 import com.alibaba.csp.sentinel.context.Context;
 import com.alibaba.csp.sentinel.slots.block.RuleConstant;
 import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRule;
 import com.alibaba.csp.sentinel.slots.statistic.base.LeapArray;
-import com.alibaba.csp.sentinel.slots.statistic.base.WindowWrap;
 import com.alibaba.csp.sentinel.util.AssertUtil;
 import com.alibaba.csp.sentinel.util.TimeUtil;
+
+import java.util.List;
+import java.util.concurrent.atomic.LongAdder;
 
 /**
  * @author Eric Zhao
@@ -161,10 +160,8 @@ public class ResponseTimeCircuitBreaker extends AbstractCircuitBreaker {
         }
 
         @Override
-        protected WindowWrap<SlowRequestCounter> resetWindowTo(WindowWrap<SlowRequestCounter> w, long startTime) {
-            w.resetTo(startTime);
-            w.value().reset();
-            return w;
+        protected void resetWindowValue(SlowRequestCounter windowValue, long startTime) {
+            windowValue.reset();
         }
     }
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/base/UnaryLeapArray.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/base/UnaryLeapArray.java
@@ -32,9 +32,7 @@ public class UnaryLeapArray extends LeapArray<LongAdder> {
     }
 
     @Override
-    protected WindowWrap<LongAdder> resetWindowTo(WindowWrap<LongAdder> windowWrap, long startTime) {
-        windowWrap.resetTo(startTime);
-        windowWrap.value().reset();
-        return windowWrap;
+    protected void resetWindowValue(LongAdder windowValue, long startTime) {
+        windowValue.reset();
     }
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/base/WindowWrap.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/base/WindowWrap.java
@@ -32,12 +32,12 @@ public class WindowWrap<T> {
     /**
      * Start timestamp of the window in milliseconds.
      */
-    private long windowStart;
+    private volatile long windowStart;
 
     /**
      * Statistic data.
      */
-    private T value;
+    private volatile T value;
 
     /**
      * @param windowLengthInMs a single window bucket's time length in milliseconds.

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/metric/BucketLeapArray.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/metric/BucketLeapArray.java
@@ -16,7 +16,6 @@
 package com.alibaba.csp.sentinel.slots.statistic.metric;
 
 import com.alibaba.csp.sentinel.slots.statistic.base.LeapArray;
-import com.alibaba.csp.sentinel.slots.statistic.base.WindowWrap;
 import com.alibaba.csp.sentinel.slots.statistic.data.MetricBucket;
 
 /**
@@ -38,10 +37,7 @@ public class BucketLeapArray extends LeapArray<MetricBucket> {
     }
 
     @Override
-    protected WindowWrap<MetricBucket> resetWindowTo(WindowWrap<MetricBucket> w, long startTime) {
-        // Update the start time and reset value.
-        w.resetTo(startTime);
-        w.value().reset();
-        return w;
+    protected void resetWindowValue(MetricBucket windowValue, long startTime) {
+        windowValue.reset();
     }
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/metric/occupy/FutureBucketLeapArray.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/metric/occupy/FutureBucketLeapArray.java
@@ -38,11 +38,8 @@ public class FutureBucketLeapArray extends LeapArray<MetricBucket> {
     }
 
     @Override
-    protected WindowWrap<MetricBucket> resetWindowTo(WindowWrap<MetricBucket> w, long startTime) {
-        // Update the start time and reset value.
-        w.resetTo(startTime);
-        w.value().reset();
-        return w;
+    protected void resetWindowValue(MetricBucket windowValue, long startTime) {
+        windowValue.reset();
     }
 
     @Override

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/metric/occupy/OccupiableBucketLeapArray.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/metric/occupy/OccupiableBucketLeapArray.java
@@ -49,18 +49,14 @@ public class OccupiableBucketLeapArray extends LeapArray<MetricBucket> {
     }
 
     @Override
-    protected WindowWrap<MetricBucket> resetWindowTo(WindowWrap<MetricBucket> w, long time) {
-        // Update the start time and reset value.
-        w.resetTo(time);
-        MetricBucket borrowBucket = borrowArray.getWindowValue(time);
+    protected void resetWindowValue(MetricBucket windowValue, long startTime) {
+        MetricBucket borrowBucket = borrowArray.getWindowValue(startTime);
         if (borrowBucket != null) {
-            w.value().reset();
-            w.value().addPass((int)borrowBucket.pass());
+            windowValue.reset();
+            windowValue.addPass((int)borrowBucket.pass());
         } else {
-            w.value().reset();
+            windowValue.reset();
         }
-
-        return w;
     }
 
     @Override

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/TimeUtil.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/TimeUtil.java
@@ -15,14 +15,14 @@
  */
 package com.alibaba.csp.sentinel.util;
 
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.LongAdder;
-
 import com.alibaba.csp.sentinel.log.RecordLog;
 import com.alibaba.csp.sentinel.slots.statistic.base.LeapArray;
 import com.alibaba.csp.sentinel.slots.statistic.base.WindowWrap;
 import com.alibaba.csp.sentinel.util.function.Tuple2;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
 
 /**
  * <p>Provides millisecond-level time of OS.</p>
@@ -88,12 +88,9 @@ public final class TimeUtil implements Runnable {
             }
 
             @Override
-            protected WindowWrap<Statistic> resetWindowTo(WindowWrap<Statistic> windowWrap, long startTime) {
-                Statistic val = windowWrap.value();
-                val.getReads().reset();
-                val.getWrites().reset();
-                windowWrap.resetTo(startTime);
-                return windowWrap;
+            protected void resetWindowValue(Statistic windowValue, long startTime) {
+                windowValue.getReads().reset();
+                windowValue.getWrites().reset();
             }
         };
         this.currentTimeMillis = System.currentTimeMillis();

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/statistic/base/LeapArrayTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/statistic/base/LeapArrayTest.java
@@ -15,13 +15,12 @@
  */
 package com.alibaba.csp.sentinel.slots.statistic.base;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
+import com.alibaba.csp.sentinel.test.AbstractTimeBasedTest;
 import org.junit.Test;
 
-import com.alibaba.csp.sentinel.test.AbstractTimeBasedTest;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertSame;
 
 /**
  * @author Eric Zhao
@@ -40,10 +39,8 @@ public class LeapArrayTest extends AbstractTimeBasedTest {
             }
 
             @Override
-            protected WindowWrap<AtomicInteger> resetWindowTo(WindowWrap<AtomicInteger> windowWrap, long startTime) {
-                windowWrap.resetTo(startTime);
-                windowWrap.value().set(0);
-                return windowWrap;
+            protected void resetWindowValue(AtomicInteger windowValue, long startTime) {
+                windowValue.set(0);
             }
         };
         


### PR DESCRIPTION
Describe what this PR does / why we need it
解决WindowWrap的线程安全问题，字段windowStart和value更新没有保障原子性，会被其他线程观察到不一致的状态
Does this pull request fix one issue?
fix #2949 
Describe how you did it
（1）把类WindowWrap的两个属性，windowStart和value加上volatile修饰，这一点的改动是必须的，根据jvm内存模型的规则，要保证可见性。
（2）修改抽象方法com.alibaba.csp.sentinel.slots.statistic.base.LeapArray#resetWindowTo的所有实现方法，调整w.resetTo(startTime)和w.value().reset()这两个动作的执行顺序，也就是先resetTo然后再value().reset，进行了value().reset作为windowStart == old.windowStart()的一个前提，反过来说如果进入了windowStart == old.windowStart()这个分支，那么必定已经进行了value().reset，思想有点类似于ConcurrentLinkedQueue的入队操作，对象可能会存在一个中间状态，但是不会导致业务逻辑的错误
Describe how to verify it
human review
Special notes for reviews
nothing