### PR TITLE
fix rule id conflict

### DIFF
--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/repository/gateway/InMemApiDefinitionStore.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/repository/gateway/InMemApiDefinitionStore.java
@@ -19,6 +19,7 @@ import com.alibaba.csp.sentinel.dashboard.datasource.entity.gateway.ApiDefinitio
 import com.alibaba.csp.sentinel.dashboard.repository.rule.InMemoryRuleRepositoryAdapter;
 import org.springframework.stereotype.Component;
 
+import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -34,6 +35,6 @@ public class InMemApiDefinitionStore extends InMemoryRuleRepositoryAdapter<ApiDe
 
     @Override
     protected long nextId() {
-        return ids.incrementAndGet();
+        return Long.valueOf(System.currentTimeMillis() + String.valueOf(new Random().nextInt(1000)) + ids.incrementAndGet());
     }
 }

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/repository/gateway/InMemGatewayFlowRuleStore.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/repository/gateway/InMemGatewayFlowRuleStore.java
@@ -19,6 +19,7 @@ import com.alibaba.csp.sentinel.dashboard.datasource.entity.gateway.GatewayFlowR
 import com.alibaba.csp.sentinel.dashboard.repository.rule.InMemoryRuleRepositoryAdapter;
 import org.springframework.stereotype.Component;
 
+import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -34,6 +35,6 @@ public class InMemGatewayFlowRuleStore extends InMemoryRuleRepositoryAdapter<Gat
 
     @Override
     protected long nextId() {
-        return ids.incrementAndGet();
+        return Long.valueOf(System.currentTimeMillis() + String.valueOf(new Random().nextInt(1000)) + ids.incrementAndGet());
     }
 }

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/repository/rule/InMemAuthorityRuleStore.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/repository/rule/InMemAuthorityRuleStore.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.csp.sentinel.dashboard.repository.rule;
 
+import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.AuthorityRuleEntity;
@@ -34,6 +35,6 @@ public class InMemAuthorityRuleStore extends InMemoryRuleRepositoryAdapter<Autho
 
     @Override
     protected long nextId() {
-        return ids.incrementAndGet();
+        return Long.valueOf(System.currentTimeMillis() + String.valueOf(new Random().nextInt(1000)) + ids.incrementAndGet());
     }
 }

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/repository/rule/InMemDegradeRuleStore.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/repository/rule/InMemDegradeRuleStore.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.csp.sentinel.dashboard.repository.rule;
 
+import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.DegradeRuleEntity;
@@ -31,6 +32,6 @@ public class InMemDegradeRuleStore extends InMemoryRuleRepositoryAdapter<Degrade
 
     @Override
     protected long nextId() {
-        return ids.incrementAndGet();
+        return Long.valueOf(System.currentTimeMillis() + String.valueOf(new Random().nextInt(1000)) + ids.incrementAndGet());
     }
 }

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/repository/rule/InMemFlowRuleStore.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/repository/rule/InMemFlowRuleStore.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.csp.sentinel.dashboard.repository.rule;
 
+import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.FlowRuleEntity;
@@ -34,7 +35,7 @@ public class InMemFlowRuleStore extends InMemoryRuleRepositoryAdapter<FlowRuleEn
 
     @Override
     protected long nextId() {
-        return ids.incrementAndGet();
+        return Long.valueOf(System.currentTimeMillis() + String.valueOf(new Random().nextInt(1000)) + ids.incrementAndGet());
     }
 
     @Override

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/repository/rule/InMemParamFlowRuleStore.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/repository/rule/InMemParamFlowRuleStore.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.csp.sentinel.dashboard.repository.rule;
 
+import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.ParamFlowRuleEntity;
@@ -33,7 +34,7 @@ public class InMemParamFlowRuleStore extends InMemoryRuleRepositoryAdapter<Param
 
     @Override
     protected long nextId() {
-        return ids.incrementAndGet();
+        return Long.valueOf(System.currentTimeMillis() + String.valueOf(new Random().nextInt(1000)) + ids.incrementAndGet());
     }
 
     @Override

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/repository/rule/InMemSystemRuleStore.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/repository/rule/InMemSystemRuleStore.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.csp.sentinel.dashboard.repository.rule;
 
+import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.SystemRuleEntity;
@@ -31,6 +32,6 @@ public class InMemSystemRuleStore extends InMemoryRuleRepositoryAdapter<SystemRu
 
     @Override
     protected long nextId() {
-        return ids.incrementAndGet();
+        return Long.valueOf(System.currentTimeMillis() + String.valueOf(new Random().nextInt(1000)) + ids.incrementAndGet());
     }
 }

--- a/sentinel-extension/sentinel-metric-exporter/src/main/java/com/alibaba/csp/sentinel/metric/exporter/jmx/MetricBeanWriter.java
+++ b/sentinel-extension/sentinel-metric-exporter/src/main/java/com/alibaba/csp/sentinel/metric/exporter/jmx/MetricBeanWriter.java
@@ -68,8 +68,9 @@ public class MetricBeanWriter {
         long version = System.currentTimeMillis();
         // set or update the new value
         for (MetricNode metricNode : map.values()) {
-            final String mBeanName = "Sentinel:type=" + appName + ",name=\"" + metricNode.getResource()
-                    +"\",classification=\"" + metricNode.getClassification() +"\"";
+            final String mBeanName = "Sentinel:type=metric,resource=" + metricNode.getResource()
+                    +",classification=" + metricNode.getClassification()
+                    +",appName=" + appName;
             MetricBean metricBean = mBeanRegistry.findMBean(mBeanName);
             if (metricBean != null) {
                 metricBean.setValueFromNode(metricNode);

--- a/sentinel-extension/sentinel-metric-exporter/src/main/java/com/alibaba/csp/sentinel/metric/exporter/jmx/MetricBeanWriter.java
+++ b/sentinel-extension/sentinel-metric-exporter/src/main/java/com/alibaba/csp/sentinel/metric/exporter/jmx/MetricBeanWriter.java
@@ -68,9 +68,8 @@ public class MetricBeanWriter {
         long version = System.currentTimeMillis();
         // set or update the new value
         for (MetricNode metricNode : map.values()) {
-            final String mBeanName = "Sentinel:type=metric,resource=" + metricNode.getResource()
-                    +",classification=" + metricNode.getClassification()
-                    +",appName=" + appName;
+            final String mBeanName = "Sentinel:type=" + appName + ",name=\"" + metricNode.getResource()
+                    +"\",classification=\"" + metricNode.getClassification() +"\"";
             MetricBean metricBean = mBeanRegistry.findMBean(mBeanName);
             if (metricBean != null) {
                 metricBean.setValueFromNode(metricNode);


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
dashboard 接入外接数据源后，当dashboard重启后id自增会被重置，或dashboard为多副本时规则id会出现相同的自增数字id，导致生成重复的规则id。

### Does this pull request fix one issue?
Fixes #2932
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
采用雪花算法，做到尽可能小的概率id冲突。
尽可能小的原因是雪花算法中间的机器位数，需要借助中间件如mysql或zk来分配机房，机器等ID，或者借助配置文件自己分配，为了不引入中间件，所以机器位数这里采用了随机数，为了不超出long的限制，这里取了0-999随机数。