### PR TITLE
Add docker build and push(multi archs both arm64 and amd64) ci process when tag release a version

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -45,7 +45,7 @@ jobs:
         with:
           context: build
           platforms: linux/amd64,linux/arm64
-          file: sentinel-dashboard/Dockerfile.Slim
+          file: sentinel-dashboard/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,52 @@
+name: Docker Image
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  push_to_multi_platforms_registry:
+    name: Build and Push Docker Image (Multi Archs)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract Version
+        id: version_step
+        run: |
+          echo "##[set-output name=version;]NACOS_VERSION=${GITHUB_REF#$"refs/tags/v"}"
+      - name: Check out the repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: sentinel/sentinel-dashboard
+          flavor: |
+            latest=true
+          tags: |
+            type=semver,pattern={{raw}}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2.3.0
+        with:
+          context: build
+          platforms: linux/amd64,linux/arm64
+          file: sentinel-dashboard/Dockerfile.Slim
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{steps.version_step.outputs.version}}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Extract Version
         id: version_step
         run: |
-          echo "##[set-output name=version;]NACOS_VERSION=${GITHUB_REF#$"refs/tags/v"}"
+          echo "##[set-output name=version;]SENTINEL_VERSION=${GITHUB_REF#$"refs/tags/v"}"
       - name: Check out the repo
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
### Describe what this PR does / why we need it
People can use docker image for sentinel dashboard easily and directly.

### Does this pull request fix one issue?
#2978 

### Describe how you did it
Add a ci process when create a tag start with v.

### Describe how to verify it
Try to triger it.

### Special notes for reviews
@sczyh30 please help create a docker hub project, name is: sentinel or something else we can update the yaml later, and set the username and password to github secrets used by below:
```
username: ${{ secrets.DOCKER_USERNAME }}
password: ${{ secrets.DOCKER_PASSWORD }}
```