### PR TITLE
update protobuf & grpc version, fix mac-os aarch64 compile error

### DIFF
--- a/sentinel-adapter/sentinel-grpc-adapter/pom.xml
+++ b/sentinel-adapter/sentinel-grpc-adapter/pom.xml
@@ -12,7 +12,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <grpc.version>1.30.2</grpc.version>
+        <protobuf.version>3.21.9</protobuf.version>
+        <grpc.version>1.51.0</grpc.version>
     </properties>
 
     <dependencies>
@@ -79,7 +80,7 @@
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>0.5.1</version>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.5.1-1:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
                     <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}
                     </pluginArtifact>

--- a/sentinel-cluster/sentinel-cluster-server-envoy-rls/pom.xml
+++ b/sentinel-cluster/sentinel-cluster-server-envoy-rls/pom.xml
@@ -15,8 +15,8 @@
         <java.source.version>1.8</java.source.version>
         <java.target.version>1.8</java.target.version>
 
-        <protobuf.version>3.10.0</protobuf.version>
-        <grpc.version>1.30.2</grpc.version>
+        <protobuf.version>3.21.9</protobuf.version>
+        <grpc.version>1.51.0</grpc.version>
 
         <maven.shade.version>3.2.1</maven.shade.version>
     </properties>


### PR DESCRIPTION
grpc 1.30.2 & protobuf:protoc 3.5.1 not support maxos aarch64, update version.