### PR TITLE
Remove duplicate declaration of quarkus-arc-deployment dependency in pom.xml

### DIFF
--- a/sentinel-adapter/sentinel-quarkus-adapter/sentinel-annotation-quarkus-adapter-deployment/pom.xml
+++ b/sentinel-adapter/sentinel-quarkus-adapter/sentinel-annotation-quarkus-adapter-deployment/pom.xml
@@ -44,10 +44,6 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-arc-deployment</artifactId>
-        </dependency>
 
     </dependencies>
 


### PR DESCRIPTION

### Describe what this PR does / why we need it
Removes second declaration of `quarkus-arc-deployment` dependency in `sentinel-adapter/sentinel-quarkus-adapter/sentinel-annotation-quarkus-adapter-deployment/pom.xml`.

### Does this pull request fix one issue?
Fixes #3100 
