### PR TITLE
Add global fallback support for AspectJ annotation extension

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/annotation/SentinelResource.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/annotation/SentinelResource.java
@@ -16,6 +16,8 @@
 package com.alibaba.csp.sentinel.annotation;
 
 import com.alibaba.csp.sentinel.EntryType;
+import com.alibaba.csp.sentinel.fallback.DefaultGlobalFallback;
+import com.alibaba.csp.sentinel.fallback.IGlobalFallback;
 
 import java.lang.annotation.*;
 
@@ -76,6 +78,9 @@ public @interface SentinelResource {
      * @since 1.6.0
      */
     String defaultFallback() default "";
+
+    Class<? extends IGlobalFallback> globalFallback() default DefaultGlobalFallback.class;
+
 
     /**
      * The {@code fallback} is located in the same class with the original method by default.

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/fallback/DefaultGlobalFallback.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/fallback/DefaultGlobalFallback.java
@@ -1,0 +1,16 @@
+package com.alibaba.csp.sentinel.fallback;
+
+import java.lang.reflect.Method;
+
+/**
+ * @author luffy
+ * @version 1.0
+ * @date 2023/5/5 11:02 下午
+ */
+public class DefaultGlobalFallback implements IGlobalFallback {
+
+    @Override
+    public Object handle(Method originalMethod, Object[] args, Throwable t) throws Throwable{
+        throw t;
+    }
+}

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/fallback/IGlobalFallback.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/fallback/IGlobalFallback.java
@@ -1,0 +1,15 @@
+package com.alibaba.csp.sentinel.fallback;
+
+import java.lang.reflect.Method;
+
+/**
+ * @author luffy
+ * @version 1.0
+ * @date 2023/5/5 10:56 上午
+ */
+public interface IGlobalFallback {
+
+
+     Object handle(Method originalMethod, Object[] args, Throwable t) throws Throwable;
+
+}

--- a/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/SentinelResourceAspect.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/SentinelResourceAspect.java
@@ -68,8 +68,8 @@ public class SentinelResourceAspect extends AbstractSentinelAspectSupport {
                 return handleFallback(pjp, annotation, ex);
             }
 
-            // No fallback function can handle the exception, so throw it out.
-            throw ex;
+            //  Global fallback function handle the exception.
+            return handleGlobalFallback(pjp,annotation.globalFallback(),ex);
         } finally {
             if (entry != null) {
                 entry.exit(1, pjp.getArgs());

--- a/sentinel-extension/sentinel-annotation-aspectj/src/test/java/com/alibaba/csp/sentinel/annotation/aspectj/ResourceMetadataRegistryTest.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/test/java/com/alibaba/csp/sentinel/annotation/aspectj/ResourceMetadataRegistryTest.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.csp.sentinel.annotation.aspectj;
 
+import com.alibaba.csp.sentinel.annotation.aspectj.integration.fallback.AnnotationGlobalFallback;
 import com.alibaba.csp.sentinel.annotation.aspectj.integration.service.FooService;
 import org.junit.After;
 import org.junit.Before;
@@ -71,6 +72,16 @@ public class ResourceMetadataRegistryTest {
         MethodWrapper wrapper = ResourceMetadataRegistry.lookupBlockHandler(clazz, methodName);
         assertThat(wrapper.isPresent()).isTrue();
         assertThat(wrapper.getMethod()).isSameAs(method);
+    }
+
+    @Test
+    public void testUpdateThenLookupGlobalFallback() {
+        Class clazz = AnnotationGlobalFallback.class;
+        assertThat(ResourceMetadataRegistry.lookupGlobalHandler(clazz)).isNull();
+
+        ResourceMetadataRegistry.updateGlobalFallBackFor(clazz);
+        assertThat(ResourceMetadataRegistry.lookupGlobalHandler(clazz)).isNotNull();
+
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/sentinel-extension/sentinel-annotation-aspectj/src/test/java/com/alibaba/csp/sentinel/annotation/aspectj/integration/SentinelAnnotationIntegrationTest.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/test/java/com/alibaba/csp/sentinel/annotation/aspectj/integration/SentinelAnnotationIntegrationTest.java
@@ -230,6 +230,19 @@ public class SentinelAnnotationIntegrationTest extends AbstractJUnit4SpringConte
         assertThat(fooService.fooWithPrivateFallback(2221)).isEqualTo("Oops, 2221");
     }
 
+    @Test
+    public void testAnnotationGlobalFallback() throws Exception {
+        assertThat(fooService.fooWithAnnotationGlobalFallback(1)).isEqualTo("Hello for 1");
+        // Fallback should take effect.
+        assertThat(fooService.fooWithAnnotationGlobalFallback(5758)).isEqualTo("AnnotationGlobalFallback");
+
+    }
+
+    @Test(expected = IllegalAccessException.class)
+    public void testDefaultGlobalFallback() throws Exception {
+        fooService.fooWithDefaultGlobalFallback(5758);
+    }
+
     @Before
     public void setUp() throws Exception {
         FlowRuleManager.loadRules(new ArrayList<FlowRule>());

--- a/sentinel-extension/sentinel-annotation-aspectj/src/test/java/com/alibaba/csp/sentinel/annotation/aspectj/integration/fallback/AnnotationGlobalFallback.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/test/java/com/alibaba/csp/sentinel/annotation/aspectj/integration/fallback/AnnotationGlobalFallback.java
@@ -1,0 +1,18 @@
+package com.alibaba.csp.sentinel.annotation.aspectj.integration.fallback;
+
+import com.alibaba.csp.sentinel.fallback.IGlobalFallback;
+
+import java.lang.reflect.Method;
+
+/**
+ * @author luffy
+ * @version 1.0
+ * @date 2023/5/5 5:18 下午
+ */
+public class AnnotationGlobalFallback implements IGlobalFallback {
+
+    @Override
+    public Object handle(Method originalMethod, Object[] args, Throwable t) throws Throwable{
+        return "AnnotationGlobalFallback";
+    }
+}

--- a/sentinel-extension/sentinel-annotation-aspectj/src/test/java/com/alibaba/csp/sentinel/annotation/aspectj/integration/service/FooService.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/test/java/com/alibaba/csp/sentinel/annotation/aspectj/integration/service/FooService.java
@@ -16,8 +16,8 @@
 package com.alibaba.csp.sentinel.annotation.aspectj.integration.service;
 
 import com.alibaba.csp.sentinel.annotation.SentinelResource;
+import com.alibaba.csp.sentinel.annotation.aspectj.integration.fallback.AnnotationGlobalFallback;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
-import com.alibaba.csp.sentinel.slots.block.degrade.DegradeException;
 
 import org.springframework.stereotype.Service;
 
@@ -52,6 +52,25 @@ public class FooService {
         }
         return "Hello for " + i;
     }
+
+    @SentinelResource(value = "apiFooWithFallback", globalFallback = AnnotationGlobalFallback.class,
+            exceptionsToTrace = {IllegalArgumentException.class})
+    public String fooWithAnnotationGlobalFallback(int i) throws Exception {
+        if (i == 5758) {
+            throw new IllegalAccessException();
+        }
+        return "Hello for " + i;
+    }
+
+    @SentinelResource(value = "apiFooWithDefaultFallback",exceptionsToTrace = {IllegalArgumentException.class})
+    public String fooWithDefaultGlobalFallback(int i) throws Exception {
+        if (i == 5758) {
+            throw new IllegalAccessException();
+        }
+        return "Hello for " + i;
+    }
+
+
 
     @SentinelResource(value = "apiAnotherFooWithDefaultFallback", defaultFallback = "globalDefaultFallback",
         fallbackClass = {FooUtil.class})


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Add global fallback support for AspectJ annotation extension

### Does this pull request fix one issue?
Fixes #3110 

### Describe how you did it
add global fallback interface and let it as the member of @SentinelResource,
cache and call the global fallback instance in the aspect  when origin method throws Throwable

### Describe how to verify it
Use unit test to verify the correctness 

### Special notes for reviews
NONE