### PR TITLE
fix issues/1463 : Make default JUL-based logging asynchronous

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/ConsoleHandler.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/ConsoleHandler.java
@@ -15,6 +15,8 @@
  */
 package com.alibaba.csp.sentinel.log.jul;
 
+import com.alibaba.csp.sentinel.concurrent.NamedThreadFactory;
+
 import java.io.UnsupportedEncodingException;
 import java.util.logging.*;
 import java.util.concurrent.ExecutorService;
@@ -45,8 +47,9 @@ class ConsoleHandler extends Handler {
      * A Handler which publishes log records to System.err.
      */
     private StreamHandler stderrHandler;
-
-    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    @SuppressWarnings("PMD.ThreadPoolCreationRule")
+    private final ExecutorService executor = Executors.newSingleThreadExecutor(
+            new NamedThreadFactory("sentinel-log-executor", true));
 
     public ConsoleHandler() {
         this.stdoutHandler = new StreamHandler(System.out, new CspFormatter());

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/ConsoleHandler.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/ConsoleHandler.java
@@ -119,8 +119,8 @@ class ConsoleHandler extends Handler {
         private final Queue<Long> recordTimestamp;
 
         public LogRejectedExecutionHandler() {
-            String DEFAULT_REJECTED_RECORD_MAX_NUM = "5";
-            String DEFAULT_REJECTED_RECORD_PERIOD = "30000";
+            String DEFAULT_REJECTED_RECORD_MAX_NUM = "1";
+            String DEFAULT_REJECTED_RECORD_PERIOD = "60000";
             String REJECTED_RECORD_MAX_NUM_KEY = "sentinel.rejected.record.max.num";
             String REJECTED_RECORD_PERIOD_KEY = "sentinel.rejected.record.period";
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/ConsoleHandler.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/ConsoleHandler.java
@@ -104,7 +104,7 @@ class ConsoleHandler extends Handler {
 
     static class LogRejectedExecutionHandler implements RejectedExecutionHandler {
         public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
-            System.err.println("Failed to log record: " + ((DateFileLogHandler.LogTask) r).getRecord() + " with console, rejected");
+            System.err.println("Failed to log sentinel record: " + ((DateFileLogHandler.LogTask) r).getRecord() + " with console, rejected");
         }
     }
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/ConsoleHandler.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/ConsoleHandler.java
@@ -121,11 +121,11 @@ class ConsoleHandler extends Handler {
         public LogRejectedExecutionHandler() {
             String DEFAULT_REJECTED_RECORD_MAX_NUM = "5";
             String DEFAULT_REJECTED_RECORD_PERIOD = "30000";
-            String DEFAULT_REJECTED_RECORD_MAX_NUM_KEY = "sentinel.rejected.record.max.num";
-            String DEFAULT_REJECTED_RECORD_PERIOD_KEY = "sentinel.rejected.record.period";
+            String REJECTED_RECORD_MAX_NUM_KEY = "sentinel.rejected.record.max.num";
+            String REJECTED_RECORD_PERIOD_KEY = "sentinel.rejected.record.period";
 
-            maxRecordNum = Integer.parseInt(System.getProperty(DEFAULT_REJECTED_RECORD_MAX_NUM_KEY, DEFAULT_REJECTED_RECORD_MAX_NUM));
-            recordPeriod = Integer.parseInt(System.getProperty(DEFAULT_REJECTED_RECORD_PERIOD_KEY, DEFAULT_REJECTED_RECORD_PERIOD));
+            maxRecordNum = Integer.parseInt(System.getProperty(REJECTED_RECORD_MAX_NUM_KEY, DEFAULT_REJECTED_RECORD_MAX_NUM));
+            recordPeriod = Integer.parseInt(System.getProperty(REJECTED_RECORD_PERIOD_KEY, DEFAULT_REJECTED_RECORD_PERIOD));
 
             recordTimestamp = new ArrayDeque<>(2 * maxRecordNum);
         }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/ConsoleHandler.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/ConsoleHandler.java
@@ -107,45 +107,27 @@ class ConsoleHandler extends Handler {
     static class LogRejectedExecutionHandler implements RejectedExecutionHandler {
 
         /**
-         * Max number to log rejected records in given period.
-         */
-        private final Integer maxRecordNum;
-
-        /**
          * The period of logged rejected records.
          */
-        private final Integer recordPeriod;
+        private final long recordPeriod;
 
-        private final Queue<Long> recordTimestamp;
+        private Long lastRecordTime;
 
         public LogRejectedExecutionHandler() {
-            String DEFAULT_REJECTED_RECORD_MAX_NUM = "1";
             String DEFAULT_REJECTED_RECORD_PERIOD = "60000";
-            String REJECTED_RECORD_MAX_NUM_KEY = "sentinel.rejected.record.max.num";
             String REJECTED_RECORD_PERIOD_KEY = "sentinel.rejected.record.period";
-
-            maxRecordNum = Integer.parseInt(System.getProperty(REJECTED_RECORD_MAX_NUM_KEY, DEFAULT_REJECTED_RECORD_MAX_NUM));
-            recordPeriod = Integer.parseInt(System.getProperty(REJECTED_RECORD_PERIOD_KEY, DEFAULT_REJECTED_RECORD_PERIOD));
-
-            recordTimestamp = new ArrayDeque<>(2 * maxRecordNum);
+            lastRecordTime = null;
+            recordPeriod = Long.parseLong(System.getProperty(REJECTED_RECORD_PERIOD_KEY, DEFAULT_REJECTED_RECORD_PERIOD));
         }
 
         public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
             long currentTimestamp = System.currentTimeMillis();
-            int recordNum = recordedNumber(currentTimestamp);
-            if (recordNum <= maxRecordNum) {
-                System.err.println("Failed to log sentinel record: " + ((DateFileLogHandler.LogTask) r).getRecord() + " with console, rejected");
+            if (lastRecordTime == null || currentTimestamp - lastRecordTime > recordPeriod) {
+                System.err.println("Failed to log sentinel record with console, rejected");
+                lastRecordTime = currentTimestamp;
             }
         }
 
-        public int recordedNumber(long currentTimestamp) {
-            recordTimestamp.add(currentTimestamp);
-            long start = currentTimestamp - recordPeriod;
-            while (recordTimestamp.peek() != null && recordTimestamp.peek() < start) {
-                recordTimestamp.poll();
-            }
-            return recordTimestamp.size();
-        }
     }
 
     static class LogTask implements Runnable {

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/DateFileLogHandler.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/DateFileLogHandler.java
@@ -184,8 +184,8 @@ class DateFileLogHandler extends Handler {
         private final Queue<Long> recordTimestamp;
 
         public LogRejectedExecutionHandler() {
-            String DEFAULT_REJECTED_RECORD_MAX_NUM = "5";
-            String DEFAULT_REJECTED_RECORD_PERIOD = "30000";
+            String DEFAULT_REJECTED_RECORD_MAX_NUM = "1";
+            String DEFAULT_REJECTED_RECORD_PERIOD = "60000";
             String REJECTED_RECORD_MAX_NUM_KEY = "sentinel.rejected.record.max.num";
             String REJECTED_RECORD_PERIOD_KEY = "sentinel.rejected.record.period";
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/DateFileLogHandler.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/DateFileLogHandler.java
@@ -192,13 +192,13 @@ class DateFileLogHandler extends Handler {
             maxRecordNum = Integer.parseInt(System.getProperty(REJECTED_RECORD_MAX_NUM_KEY, DEFAULT_REJECTED_RECORD_MAX_NUM));
             recordPeriod = Integer.parseInt(System.getProperty(REJECTED_RECORD_PERIOD_KEY, DEFAULT_REJECTED_RECORD_PERIOD));
 
-            recordTimestamp = new ArrayDeque<>(2*maxRecordNum);
+            recordTimestamp = new ArrayDeque<>(2 * maxRecordNum);
         }
 
         public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
             long currentTimestamp = System.currentTimeMillis();
             int recordNum = recordedNumber(currentTimestamp);
-            if(recordNum <= maxRecordNum) {
+            if (recordNum <= maxRecordNum) {
                 System.err.println("Failed to log sentinel record: " + ((DateFileLogHandler.LogTask) r).getRecord() + " with datafile, rejected");
             }
         }
@@ -206,7 +206,7 @@ class DateFileLogHandler extends Handler {
         public int recordedNumber(long currentTimestamp) {
             recordTimestamp.add(currentTimestamp);
             long start = currentTimestamp - recordPeriod;
-            while(recordTimestamp.peek() != null && recordTimestamp.peek() < start){
+            while (recordTimestamp.peek() != null && recordTimestamp.peek() < start) {
                 recordTimestamp.poll();
             }
             return recordTimestamp.size();

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/DateFileLogHandler.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/DateFileLogHandler.java
@@ -169,7 +169,7 @@ class DateFileLogHandler extends Handler {
 
     static class LogRejectedExecutionHandler implements RejectedExecutionHandler {
         public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
-            System.err.println("Failed to log record: " + ((LogTask) r).getRecord() + " with datafile, rejected");
+            System.err.println("Failed to log sentinel record: " + ((LogTask) r).getRecord() + " with datafile, rejected");
         }
     }
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/DateFileLogHandler.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/DateFileLogHandler.java
@@ -78,12 +78,8 @@ class DateFileLogHandler extends Handler {
 
     @Override
     public void close() throws SecurityException {
+        /**not need to record log if process is killed.*/
         executor.shutdown();
-        try {
-            executor.awaitTermination(1, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
         handler.close();
     }
 

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/DateFileLogHandler.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/DateFileLogHandler.java
@@ -186,11 +186,11 @@ class DateFileLogHandler extends Handler {
         public LogRejectedExecutionHandler() {
             String DEFAULT_REJECTED_RECORD_MAX_NUM = "5";
             String DEFAULT_REJECTED_RECORD_PERIOD = "30000";
-            String DEFAULT_REJECTED_RECORD_MAX_NUM_KEY = "sentinel.rejected.record.max.num";
-            String DEFAULT_REJECTED_RECORD_PERIOD_KEY = "sentinel.rejected.record.period";
+            String REJECTED_RECORD_MAX_NUM_KEY = "sentinel.rejected.record.max.num";
+            String REJECTED_RECORD_PERIOD_KEY = "sentinel.rejected.record.period";
 
-            maxRecordNum = Integer.parseInt(System.getProperty(DEFAULT_REJECTED_RECORD_MAX_NUM_KEY, DEFAULT_REJECTED_RECORD_MAX_NUM));
-            recordPeriod = Integer.parseInt(System.getProperty(DEFAULT_REJECTED_RECORD_PERIOD_KEY, DEFAULT_REJECTED_RECORD_PERIOD));
+            maxRecordNum = Integer.parseInt(System.getProperty(REJECTED_RECORD_MAX_NUM_KEY, DEFAULT_REJECTED_RECORD_MAX_NUM));
+            recordPeriod = Integer.parseInt(System.getProperty(REJECTED_RECORD_PERIOD_KEY, DEFAULT_REJECTED_RECORD_PERIOD));
 
             recordTimestamp = new ArrayDeque<>(2*maxRecordNum);
         }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/DateFileLogHandler.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/jul/DateFileLogHandler.java
@@ -15,6 +15,8 @@
  */
 package com.alibaba.csp.sentinel.log.jul;
 
+import com.alibaba.csp.sentinel.concurrent.NamedThreadFactory;
+
 import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
@@ -37,7 +39,9 @@ class DateFileLogHandler extends Handler {
         }
     };
 
-    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    @SuppressWarnings("PMD.ThreadPoolCreationRule")
+    private final ExecutorService executor = Executors.newSingleThreadExecutor(
+            new NamedThreadFactory("sentinel-log-executor", true));
 
     private volatile FileHandler handler;
 

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/log/jul/ConsoleHandlerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/log/jul/ConsoleHandlerTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.*;
 public class ConsoleHandlerTest {
 
     @Test
-    public void testPublish() {
+    public void testInfoPublish() {
         ByteArrayOutputStream baosOut = new ByteArrayOutputStream();
         System.setOut(new PrintStream(baosOut));
 
@@ -50,35 +50,81 @@ public class ConsoleHandlerTest {
         // Test INFO level, should log to stdout
         logRecord = new LogRecord(Level.INFO, "test info message");
         consoleHandler.publish(logRecord);
+        consoleHandler.close();
         assertEquals(cspFormatter.format(logRecord), baosOut.toString());
         assertEquals("", baosErr.toString());
         baosOut.reset();
         baosErr.reset();
+    }
+
+    @Test
+    public void testWarnPublish() {
+        ByteArrayOutputStream baosOut = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(baosOut));
+
+        ByteArrayOutputStream baosErr = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(baosErr));
+
+        CspFormatter cspFormatter = new CspFormatter();
+        ConsoleHandler consoleHandler = new ConsoleHandler();
+
+        LogRecord logRecord;
 
         // Test INFO level, should log to stderr
         logRecord = new LogRecord(Level.WARNING, "test warning message");
         consoleHandler.publish(logRecord);
+        consoleHandler.close();
         assertEquals(cspFormatter.format(logRecord), baosErr.toString());
         assertEquals("", baosOut.toString());
         baosOut.reset();
         baosErr.reset();
+    }
+
+    @Test
+    public void testFinePublish() {
+        ByteArrayOutputStream baosOut = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(baosOut));
+
+        ByteArrayOutputStream baosErr = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(baosErr));
+
+        CspFormatter cspFormatter = new CspFormatter();
+        ConsoleHandler consoleHandler = new ConsoleHandler();
+
+        LogRecord logRecord;
 
         // Test FINE level, no log by default
         // Default log level is INFO, to log FINE message to stdout, add following config in $JAVA_HOME/jre/lib/logging.properties
         // java.util.logging.StreamHandler.level=FINE
         logRecord = new LogRecord(Level.FINE, "test fine message");
         consoleHandler.publish(logRecord);
+        consoleHandler.close();
         assertEquals("", baosOut.toString());
         assertEquals("", baosErr.toString());
         baosOut.reset();
         baosErr.reset();
+    }
 
+    @Test
+    public void testSeverePublish() {
+        ByteArrayOutputStream baosOut = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(baosOut));
+
+        ByteArrayOutputStream baosErr = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(baosErr));
+
+        CspFormatter cspFormatter = new CspFormatter();
+        ConsoleHandler consoleHandler = new ConsoleHandler();
+
+        LogRecord logRecord;
         // Test SEVERE level, should log to stderr
         logRecord = new LogRecord(Level.SEVERE, "test severe message");
         consoleHandler.publish(logRecord);
+        consoleHandler.close();
         assertEquals(cspFormatter.format(logRecord), baosErr.toString());
         assertEquals("", baosOut.toString());
         baosOut.reset();
         baosErr.reset();
     }
+
 }

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/log/jul/ConsoleHandlerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/log/jul/ConsoleHandlerTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
@@ -50,6 +51,12 @@ public class ConsoleHandlerTest {
         // Test INFO level, should log to stdout
         logRecord = new LogRecord(Level.INFO, "test info message");
         consoleHandler.publish(logRecord);
+        try {
+            consoleHandler.getExecutor().shutdown();
+            consoleHandler.getExecutor().awaitTermination(1, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
         consoleHandler.close();
         assertEquals(cspFormatter.format(logRecord), baosOut.toString());
         assertEquals("", baosErr.toString());
@@ -73,6 +80,12 @@ public class ConsoleHandlerTest {
         // Test INFO level, should log to stderr
         logRecord = new LogRecord(Level.WARNING, "test warning message");
         consoleHandler.publish(logRecord);
+        try {
+            consoleHandler.getExecutor().shutdown();
+            consoleHandler.getExecutor().awaitTermination(1, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
         consoleHandler.close();
         assertEquals(cspFormatter.format(logRecord), baosErr.toString());
         assertEquals("", baosOut.toString());
@@ -98,6 +111,12 @@ public class ConsoleHandlerTest {
         // java.util.logging.StreamHandler.level=FINE
         logRecord = new LogRecord(Level.FINE, "test fine message");
         consoleHandler.publish(logRecord);
+        try {
+            consoleHandler.getExecutor().shutdown();
+            consoleHandler.getExecutor().awaitTermination(1, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
         consoleHandler.close();
         assertEquals("", baosOut.toString());
         assertEquals("", baosErr.toString());
@@ -120,6 +139,12 @@ public class ConsoleHandlerTest {
         // Test SEVERE level, should log to stderr
         logRecord = new LogRecord(Level.SEVERE, "test severe message");
         consoleHandler.publish(logRecord);
+        try {
+            consoleHandler.getExecutor().shutdown();
+            consoleHandler.getExecutor().awaitTermination(1, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
         consoleHandler.close();
         assertEquals(cspFormatter.format(logRecord), baosErr.toString());
         assertEquals("", baosOut.toString());


### PR DESCRIPTION
### Describe what this PR does / why we need it
Make default JUL-based logging asynchronous

### Does this pull request fix one issue?
Fixes #1463

### Describe how you did it
use java.util.concurrent.Executor, submit the log task into single thread.

### Describe how to verify it


### Special notes for reviews
