### PR TITLE
fix(sec): upgrade org.apache.dubbo:dubbo to 3.1.6

### DIFF
--- a/sentinel-demo/sentinel-demo-apache-dubbo/pom.xml
+++ b/sentinel-demo/sentinel-demo-apache-dubbo/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo</artifactId>
-            <version>2.7.18</version>
+            <version>3.1.6</version>
         </dependency>
 
         <!-- Dubbo provides qos plugin and is enable by default. -->


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.dubbo:dubbo 2.7.18
- [CVE-2023-23638](https://www.oscs1024.com/hd/CVE-2023-23638)


### What did I do？
Upgrade org.apache.dubbo:dubbo from 2.7.18 to 3.1.6 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS