### PR TITLE
Use getParameterCount() in place of getParameterTypes().length #3186

### DIFF
--- a/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/AbstractSentinelAspectSupport.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/AbstractSentinelAspectSupport.java
@@ -93,7 +93,7 @@ public abstract class AbstractSentinelAspectSupport {
         Method fallbackMethod = extractFallbackMethod(pjp, fallback, fallbackClass);
         if (fallbackMethod != null) {
             // Construct args.
-            int paramCount = fallbackMethod.getParameterTypes().length;
+            int paramCount = fallbackMethod.getParameterCount();
             Object[] args;
             if (paramCount == originArgs.length) {
                 args = originArgs;
@@ -114,7 +114,7 @@ public abstract class AbstractSentinelAspectSupport {
         Method fallbackMethod = extractDefaultFallbackMethod(pjp, defaultFallback, fallbackClass);
         if (fallbackMethod != null) {
             // Construct args.
-            Object[] args = fallbackMethod.getParameterTypes().length == 0 ? new Object[0] : new Object[] {ex};
+            Object[] args = fallbackMethod.getParameterCount() == 0 ? new Object[0] : new Object[] {ex};
             return invoke(pjp, fallbackMethod, args);
         }
 

--- a/sentinel-extension/sentinel-annotation-cdi-interceptor/src/main/java/com/alibaba/csp/sentinel/annotation/cdi/interceptor/AbstractSentinelInterceptorSupport.java
+++ b/sentinel-extension/sentinel-annotation-cdi-interceptor/src/main/java/com/alibaba/csp/sentinel/annotation/cdi/interceptor/AbstractSentinelInterceptorSupport.java
@@ -93,7 +93,7 @@ public abstract class AbstractSentinelInterceptorSupport {
         Method fallbackMethod = extractFallbackMethod(ctx, fallback, fallbackClass);
         if (fallbackMethod != null) {
             // Construct args.
-            int paramCount = fallbackMethod.getParameterTypes().length;
+            int paramCount = fallbackMethod.getParameterCount();
             Object[] args;
             if (paramCount == originArgs.length) {
                 args = originArgs;
@@ -122,7 +122,7 @@ public abstract class AbstractSentinelInterceptorSupport {
         Method fallbackMethod = extractDefaultFallbackMethod(ctx, defaultFallback, fallbackClass);
         if (fallbackMethod != null) {
             // Construct args.
-            Object[] args = fallbackMethod.getParameterTypes().length == 0 ? new Object[0] : new Object[] {ex};
+            Object[] args = fallbackMethod.getParameterCount() == 0 ? new Object[0] : new Object[] {ex};
             try {
                 if (isStatic(fallbackMethod)) {
                     return fallbackMethod.invoke(null, args);


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Replaces usages of `getParameterTypes().length` with `getParameterCount()`, as `getParameterTypes().length` is inefficient because it creates an array clone, while `getParameterCount()` directly returns the length.

### Does this pull request fix one issue?
Fixes #3186 

