### PR TITLE
fix: an inaccurate error message when parsing a log level from a string

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/LogBase.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/log/LogBase.java
@@ -115,7 +115,7 @@ public class LogBase {
             try {
                 logLevel = Level.parse(logLevelString);
             } catch (IllegalArgumentException e) {
-                System.out.println("Log level : " + logLevel + " is invalid. Use default : " + LOG_DEFAULT_LEVEL.toString());
+                System.out.println("Log level : " + logLevelString + " is invalid. Use default : " + LOG_DEFAULT_LEVEL.toString());
             }
         }
         System.out.println("INFO: Sentinel log level is: " + logLevel);


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Fix a bug where an inaccurate error message is displayed when parsing a log level from a string due to the incorrect use of the `logLevel` variable instead of `logLevelString` in the error message.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #3192 

### Describe how you did it

Replace `logLevel` with `logLevelString`.
