### PR TITLE
resource rules (flow/degrade/param/authority) support regex matching

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/AbstractRule.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/AbstractRule.java
@@ -15,6 +15,8 @@
  */
 package com.alibaba.csp.sentinel.slots.block;
 
+import java.util.Objects;
+
 /**
  * Abstract rule entity.
  *
@@ -44,6 +46,11 @@ public abstract class AbstractRule implements Rule {
      */
     private String limitApp;
 
+    /**
+     * Whether to match resource names according to regular rules
+     */
+    private boolean regex;
+
     public Long getId() {
         return id;
     }
@@ -72,6 +79,15 @@ public abstract class AbstractRule implements Rule {
         return this;
     }
 
+    public boolean isRegex() {
+        return regex;
+    }
+
+    public AbstractRule setRegex(boolean regex) {
+        this.regex = regex;
+        return this;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -83,7 +99,10 @@ public abstract class AbstractRule implements Rule {
 
         AbstractRule that = (AbstractRule)o;
 
-        if (resource != null ? !resource.equals(that.resource) : that.resource != null) {
+        if (!Objects.equals(resource, that.resource)) {
+            return false;
+        }
+        if (regex != that.regex) {
             return false;
         }
         if (!limitAppEquals(limitApp, that.limitApp)) {
@@ -114,6 +133,7 @@ public abstract class AbstractRule implements Rule {
         if (!("".equals(limitApp) || RuleConstant.LIMIT_APP_DEFAULT.equals(limitApp) || limitApp == null)) {
             result = 31 * result + limitApp.hashCode();
         }
+        result = 31 * result + (regex ? 1 : 0);
         return result;
     }
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/RuleManager.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/RuleManager.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.slots.block;
+
+import com.alibaba.csp.sentinel.util.function.Function;
+import com.alibaba.csp.sentinel.util.function.Predicate;
+
+import java.util.*;
+import java.util.regex.Pattern;
+
+/**
+ * Unified rule management tool, mainly used for matching and caching of regular rules and simple rules.
+ * @author quguai
+ * @date 2023/10/9 20:35
+ */
+public class RuleManager<R> {
+
+    private Map<String, List<R>> originalRules = new HashMap<>();
+    private Map<Pattern, List<R>> regexRules = new HashMap<>();
+    private Map<String, List<R>> regexCacheRules = new HashMap<>();
+    private Map<String, List<R>> simpleRules = new HashMap<>();
+    private Function<List<R>, List<R>> generator = Function.identity();
+
+    private final Predicate<R> predicate;
+
+    public RuleManager() {
+        predicate = r -> r instanceof AbstractRule && ((AbstractRule) r).isRegex();
+    }
+
+    public RuleManager(Function<List<R>, List<R>> generator, Predicate<R> predicate) {
+        this.generator = generator;
+        this.predicate = predicate;
+    }
+
+    /**
+     * Update rules from datasource, split rules map by regex,
+     * rebuild the regex rule cache to reduce the performance loss caused by publish rules.
+     *
+     * @param rulesMap origin rules map
+     */
+    public void updateRules(Map<String, List<R>> rulesMap) {
+        originalRules = rulesMap;
+        Map<Pattern, List<R>> regexRules = new HashMap<>();
+        Map<String, List<R>> simpleRules = new HashMap<>();
+        for (Map.Entry<String, List<R>> entry : rulesMap.entrySet()) {
+            String resource = entry.getKey();
+            List<R> rules = entry.getValue();
+
+            List<R> rulesOfSimple = new ArrayList<>();
+            List<R> rulesOfRegex = new ArrayList<>();
+            for (R rule : rules) {
+                if (predicate.test(rule)) {
+                    rulesOfRegex.add(rule);
+                } else {
+                    rulesOfSimple.add(rule);
+                }
+            }
+            if (!rulesOfRegex.isEmpty()) {
+                regexRules.put(Pattern.compile(resource), rulesOfRegex);
+            }
+            if (!rulesOfSimple.isEmpty()) {
+                simpleRules.put(resource, rulesOfSimple);
+            }
+        }
+        // rebuild regex cache rules
+        setRules(regexRules, simpleRules);
+    }
+
+    /**
+     * Get rules by resource name, save the rule list after regular matching to improve performance
+     * @param resource resource name
+     * @return matching rule list
+     */
+    public List<R> getRules(String resource) {
+        List<R> result = new ArrayList<>(simpleRules.getOrDefault(resource, Collections.emptyList()));
+        if (regexRules.isEmpty()) {
+            return result;
+        }
+        if (regexCacheRules.containsKey(resource)) {
+            result.addAll(regexCacheRules.get(resource));
+            return result;
+        }
+        synchronized (this) {
+            if (regexCacheRules.containsKey(resource)) {
+                result.addAll(regexCacheRules.get(resource));
+                return result;
+            }
+            List<R> compilers = matcherFromRegexRules(resource);
+            regexCacheRules.put(resource, compilers);
+            result.addAll(compilers);
+            return result;
+        }
+    }
+
+    /**
+     * Get rules from regex rules and simple rules
+     * @return rule list
+     */
+    public List<R> getRules() {
+        List<R> rules = new ArrayList<>();
+        for (Map.Entry<Pattern, List<R>> entry : regexRules.entrySet()) {
+            rules.addAll(entry.getValue());
+        }
+        for (Map.Entry<String, List<R>> entry : simpleRules.entrySet()) {
+            rules.addAll(entry.getValue());
+        }
+        return rules;
+    }
+
+    /**
+     * Get origin rules, includes regex and simple rules
+     * @return original rules
+     */
+    public Map<String, List<R>> getOriginalRules() {
+        return originalRules;
+    }
+
+    /**
+     * Determine whether has rule based on the resource name
+     * @param resource resource name
+     * @return whether
+     */
+
+    public boolean hasConfig(String resource) {
+        if (resource == null) {
+            return false;
+        }
+        return !getRules(resource).isEmpty();
+    }
+
+    /**
+     * Is valid regex rules
+     * @param rule rule
+     * @return weather valid regex rule
+     */
+    public static boolean checkRegexResourceField(AbstractRule rule) {
+        if (!rule.isRegex()) {
+            return true;
+        }
+        String resourceName = rule.getResource();
+        try {
+            Pattern.compile(resourceName);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private List<R> matcherFromRegexRules(String resource) {
+        List<R> compilers = new ArrayList<>();
+        for (Map.Entry<Pattern, List<R>> entry : regexRules.entrySet()) {
+            if (entry.getKey().matcher(resource).matches()) {
+                compilers.addAll(generator.apply(entry.getValue()));
+            }
+        }
+        return compilers;
+    }
+
+    private synchronized void setRules(Map<Pattern, List<R>> regexRules, Map<String, List<R>> simpleRules) {
+        this.regexRules = regexRules;
+        this.simpleRules = simpleRules;
+        if (regexRules.isEmpty()) {
+            this.regexCacheRules = Collections.emptyMap();
+            return;
+        }
+        // rebuild from regex cache rules
+        Map<String, List<R>> rebuildCacheRule = new HashMap<>(regexCacheRules.size());
+        for (String resource : regexCacheRules.keySet()) {
+            rebuildCacheRule.put(resource, matcherFromRegexRules(resource));
+        }
+        this.regexCacheRules = rebuildCacheRule;
+    }
+}

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/authority/AuthoritySlot.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/authority/AuthoritySlot.java
@@ -15,8 +15,7 @@
  */
 package com.alibaba.csp.sentinel.slots.block.authority;
 
-import java.util.Map;
-import java.util.Set;
+import java.util.List;
 
 import com.alibaba.csp.sentinel.Constants;
 import com.alibaba.csp.sentinel.context.Context;
@@ -48,13 +47,8 @@ public class AuthoritySlot extends AbstractLinkedProcessorSlot<DefaultNode> {
     }
 
     void checkBlackWhiteAuthority(ResourceWrapper resource, Context context) throws AuthorityException {
-        Map<String, Set<AuthorityRule>> authorityRules = AuthorityRuleManager.getAuthorityRules();
 
-        if (authorityRules == null) {
-            return;
-        }
-
-        Set<AuthorityRule> rules = authorityRules.get(resource.getName());
+        List<AuthorityRule> rules = AuthorityRuleManager.getRules(resource.getName());
         if (rules == null) {
             return;
         }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleUtil.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleUtil.java
@@ -18,6 +18,7 @@ package com.alibaba.csp.sentinel.slots.block.flow;
 import com.alibaba.csp.sentinel.log.RecordLog;
 import com.alibaba.csp.sentinel.slots.block.ClusterRuleConstant;
 import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+import com.alibaba.csp.sentinel.slots.block.RuleManager;
 import com.alibaba.csp.sentinel.slots.block.flow.controller.DefaultController;
 import com.alibaba.csp.sentinel.slots.block.flow.controller.ThrottlingController;
 import com.alibaba.csp.sentinel.slots.block.flow.controller.WarmUpController;
@@ -170,6 +171,9 @@ public final class FlowRuleUtil {
         if (!baseValid) {
             return false;
         }
+        if (!checkRegexField(rule)) {
+            return false;
+        }
         if (rule.getGrade() == RuleConstant.FLOW_GRADE_QPS) {
             // Check strategy and control (shaping) behavior.
             return checkClusterField(rule) && checkStrategyField(rule) && checkControlBehaviorField(rule);
@@ -233,6 +237,16 @@ public final class FlowRuleUtil {
     private static boolean checkStrategyField(/*@NonNull*/ FlowRule rule) {
         if (rule.getStrategy() == RuleConstant.STRATEGY_RELATE || rule.getStrategy() == RuleConstant.STRATEGY_CHAIN) {
             return StringUtil.isNotBlank(rule.getRefResource());
+        }
+        return true;
+    }
+
+    private static boolean checkRegexField(FlowRule rule) {
+        if (!RuleManager.checkRegexResourceField(rule)) {
+            return false;
+        }
+        if (rule.isRegex()) {
+            return !rule.isClusterMode() && rule.getControlBehavior() == RuleConstant.CONTROL_BEHAVIOR_DEFAULT;
         }
         return true;
     }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowSlot.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowSlot.java
@@ -26,8 +26,6 @@ import com.alibaba.csp.sentinel.util.AssertUtil;
 import com.alibaba.csp.sentinel.util.function.Function;
 
 import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 
 /**
  * <p>
@@ -179,9 +177,7 @@ public class FlowSlot extends AbstractLinkedProcessorSlot<DefaultNode> {
     private final Function<String, Collection<FlowRule>> ruleProvider = new Function<String, Collection<FlowRule>>() {
         @Override
         public Collection<FlowRule> apply(String resource) {
-            // Flow rule map should not be null.
-            Map<String, List<FlowRule>> flowRules = FlowRuleManager.getFlowRuleMap();
-            return flowRules.get(resource);
+            return FlowRuleManager.getFlowRules(resource);
         }
     };
 }

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/function/Function.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/function/Function.java
@@ -27,4 +27,14 @@ public interface Function<T, R> {
      * @return the function result
      */
     R apply(T t);
+
+    /**
+     * Returns a function that always returns its input argument.
+     *
+     * @param <T> the type of the input and output objects to the function
+     * @return a function that always returns its input argument
+     */
+    static <T> Function<T, T> identity() {
+        return t -> t;
+    }
 }

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/RuleManagerTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/RuleManagerTest.java
@@ -1,0 +1,112 @@
+package com.alibaba.csp.sentinel.slots.block;
+
+import com.alibaba.csp.sentinel.slots.block.flow.FlowRule;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.*;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+public class RuleManagerTest {
+
+    private RuleManager<FlowRule> ruleManager;
+
+    @Before
+    public void setUp() throws Exception {
+        ruleManager = new RuleManager<>();
+    }
+
+    @Test
+    public void testUpdateRules() throws Exception {
+        // Setup
+        final Map<String, List<FlowRule>> rulesMap = generateFlowRules(true);
+
+        // Run the test
+        ruleManager.updateRules(rulesMap);
+
+        // Verify the results
+        assertEquals(ruleManager.getRules().size(), 2);
+        Field regexRules = RuleManager.class.getDeclaredField("regexRules");
+        regexRules.setAccessible(true);
+        assertEquals(((Map)regexRules.get(ruleManager)).size(), 1);
+        Field simpleRules = RuleManager.class.getDeclaredField("simpleRules");
+        simpleRules.setAccessible(true);
+        assertEquals(((Map)simpleRules.get(ruleManager)).size(), 1);
+    }
+
+    @Test
+    public void testGetRulesWithCache() throws Exception {
+        // Setup
+        final Map<String, List<FlowRule>> rulesMap = generateFlowRules(true);
+
+        // Run the test
+        ruleManager.updateRules(rulesMap);
+
+        // Verify the results
+        Field regexCacheRules = RuleManager.class.getDeclaredField("regexCacheRules");
+        regexCacheRules.setAccessible(true);
+        assertEquals(((Map)regexCacheRules.get(ruleManager)).size(), 0);
+        ruleManager.getRules("rule2");
+        assertEquals(((Map)regexCacheRules.get(ruleManager)).size(), 1);
+    }
+
+    @Test
+    public void testRebuildRulesWhenUpdateRules() throws Exception {
+        // Setup
+        final Map<String, List<FlowRule>> rulesMap = generateFlowRules(true);
+
+        // Run the test
+        ruleManager.updateRules(rulesMap);
+        ruleManager.getRules("rule2");
+        ruleManager.updateRules(generateFlowRules(true));
+
+        // Verify the results
+        Field regexCacheRules = RuleManager.class.getDeclaredField("regexCacheRules");
+        regexCacheRules.setAccessible(true);
+        assertEquals(((Map)regexCacheRules.get(ruleManager)).size(), 1);
+
+        // Clean up regular rules
+        ruleManager.updateRules(generateFlowRules(false));
+        // Verify the results
+        assertEquals(((Map)regexCacheRules.get(ruleManager)).size(), 0);
+    }
+    @Test
+    public void testValidRegexRule() {
+        // Setup
+        FlowRule flowRule = new FlowRule();
+        flowRule.setRegex(true);
+        flowRule.setResource("{}");
+        // Run the test and verify
+        Assert.assertFalse(RuleManager.checkRegexResourceField(flowRule));
+
+        flowRule.setResource(".*");
+        // Run the test and verify
+        Assert.assertTrue(RuleManager.checkRegexResourceField(flowRule));
+    }
+
+    @Test
+    public void testHasConfig() {
+        // Setup
+        final Map<String, List<FlowRule>> rulesMap = generateFlowRules(true);
+
+        // Run the test and verify the results
+        ruleManager.updateRules(rulesMap);
+        assertTrue(ruleManager.hasConfig("rule1"));
+        assertFalse(ruleManager.hasConfig("rule3"));
+    }
+
+    private Map<String, List<FlowRule>> generateFlowRules(boolean withRegex) {
+        Map<String, List<FlowRule>> result = new HashMap<>(2);
+        FlowRule flowRule1 = new FlowRule("rule1");
+        flowRule1.setRegex(withRegex);
+        result.put(flowRule1.getResource(), Collections.singletonList(flowRule1));
+        FlowRule flowRule2 = new FlowRule("rule2");
+        result.put(flowRule2.getResource(), Collections.singletonList(flowRule2));
+        return result;
+    }
+}

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/authority/AuthorityPartialIntegrationTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/authority/AuthorityPartialIntegrationTest.java
@@ -1,0 +1,49 @@
+package com.alibaba.csp.sentinel.slots.block.authority;
+
+import com.alibaba.csp.sentinel.Entry;
+import com.alibaba.csp.sentinel.SphU;
+import com.alibaba.csp.sentinel.context.ContextUtil;
+import com.alibaba.csp.sentinel.slots.block.BlockException;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author quguai
+ * @date 2023/10/27 11:48
+ */
+public class AuthorityPartialIntegrationTest {
+
+    @Test
+    public void testRegex() {
+        AuthorityRule authorityRule = new AuthorityRule();
+        authorityRule.setRegex(true);
+        authorityRule.setStrategy(1);
+        authorityRule.setLimitApp("appA");
+        authorityRule.setResource(".*");
+        AuthorityRuleManager.loadRules(Collections.singletonList(authorityRule));
+        verifyFlow("testRegex_1", "appA", false);
+        verifyFlow("testRegex_2", "appA", false);
+        verifyFlow("testRegex_1", "appB", true);
+        verifyFlow("testRegex_2", "appB", true);
+    }
+
+    private void verifyFlow(String resource, String origin, boolean shouldPass) {
+        ContextUtil.enter("a", origin);
+        Entry e = null;
+        try {
+            e = SphU.entry(resource);
+            assertTrue(shouldPass);
+        } catch (BlockException e1) {
+            assertFalse(shouldPass);
+        } finally {
+            if (e != null) {
+                e.exit();
+            }
+            ContextUtil.exit();
+        }
+    }
+}

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradePartialIntegrationTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/degrade/DegradePartialIntegrationTest.java
@@ -1,0 +1,73 @@
+package com.alibaba.csp.sentinel.slots.block.degrade;
+
+import com.alibaba.csp.sentinel.Entry;
+import com.alibaba.csp.sentinel.SphU;
+import com.alibaba.csp.sentinel.Tracer;
+import com.alibaba.csp.sentinel.context.ContextUtil;
+import com.alibaba.csp.sentinel.slots.block.BlockException;
+import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author quguai
+ * @date 2023/10/27 13:56
+ */
+public class DegradePartialIntegrationTest {
+
+    @Before
+    public void setUp() throws Exception {
+        DegradeRuleManager.loadRules(new ArrayList<>());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        DegradeRuleManager.loadRules(new ArrayList<>());
+    }
+
+    @Test
+    public void testDegradeRegex() {
+        DegradeRule rule = new DegradeRule(".*")
+                .setCount(0.5d)
+                .setGrade(RuleConstant.DEGRADE_GRADE_EXCEPTION_RATIO)
+                .setStatIntervalMs(20 * 1000)
+                .setTimeWindow(10)
+                .setMinRequestAmount(1);
+        rule.setRegex(true);
+        DegradeRuleManager.loadRules(Collections.singletonList(rule));
+
+        verifyDegradeFlow("testDegradeRegex_1", true, true);
+        verifyDegradeFlow("testDegradeRegex_1", true, false);
+
+        verifyDegradeFlow("testDegradeRegex_2", true, true);
+        verifyDegradeFlow("testDegradeRegex_2", true, false);
+
+    }
+
+    private void verifyDegradeFlow(String resource, boolean error, boolean shouldPass) {
+        Entry entry = null;
+        try {
+            entry = SphU.entry(resource);
+            assertTrue(shouldPass);
+            if (error) {
+                int i = 10 / 0;
+            }
+        } catch (BlockException e1) {
+            assertFalse(shouldPass);
+        } catch (Exception ex) {
+            Tracer.traceEntry(ex, entry);
+        } finally {
+            if (entry != null) {
+                entry.exit();
+            }
+        }
+    }
+}

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/FlowPartialIntegrationTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/FlowPartialIntegrationTest.java
@@ -15,9 +15,6 @@
  */
 package com.alibaba.csp.sentinel.slots.block.flow;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -31,6 +28,8 @@ import com.alibaba.csp.sentinel.SphU;
 import com.alibaba.csp.sentinel.context.ContextUtil;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
 import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+
+import static org.junit.Assert.*;
 
 /**
  * @author jialiang.linjl
@@ -112,6 +111,21 @@ public class FlowPartialIntegrationTest {
 
         SphU.entry("testThreadGrade");
         System.out.println("done");
+    }
+
+    @Test
+    public void testQpsRegex() {
+        FlowRule flowRule = new FlowRule();
+        String resource = ".*";
+        flowRule.setResource(resource);
+        flowRule.setGrade(RuleConstant.FLOW_GRADE_QPS);
+        flowRule.setRegex(true);
+        flowRule.setCount(1);
+        FlowRuleManager.loadRules(Collections.singletonList(flowRule));
+        verifyFlow("testQpsRegex_1", true);
+        verifyFlow("testQpsRegex_2", true);
+        verifyFlow("testQpsRegex_1", false);
+        verifyFlow("testQpsRegex_2", false);
     }
 
     @Test
@@ -254,5 +268,19 @@ public class FlowPartialIntegrationTest {
         e.exit();
 
         ContextUtil.exit();
+    }
+
+    private void verifyFlow(String resource, boolean shouldPass) {
+        Entry e = null;
+        try {
+            e = SphU.entry(resource);
+            assertTrue(shouldPass);
+        } catch (BlockException e1) {
+            assertFalse(shouldPass);
+        } finally {
+            if (e != null) {
+                e.exit();
+            }
+        }
     }
 }

--- a/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowRuleUtil.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowRuleUtil.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import com.alibaba.csp.sentinel.log.RecordLog;
 import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+import com.alibaba.csp.sentinel.slots.block.RuleManager;
 import com.alibaba.csp.sentinel.slots.block.flow.FlowRuleUtil;
 import com.alibaba.csp.sentinel.util.AssertUtil;
 import com.alibaba.csp.sentinel.util.StringUtil;
@@ -48,7 +49,7 @@ public final class ParamFlowRuleUtil {
             && rule.getGrade() >= 0 && rule.getParamIdx() != null
             && rule.getBurstCount() >= 0 && rule.getControlBehavior() >= 0
             && rule.getDurationInSec() > 0 && rule.getMaxQueueingTimeMs() >= 0
-            && checkCluster(rule);
+            && checkCluster(rule) & checkRegexField(rule);
     }
 
     private static boolean checkCluster(/*@PreChecked*/ ParamFlowRule rule) {
@@ -63,6 +64,16 @@ public final class ParamFlowRuleUtil {
             return false;
         }
         return validClusterRuleId(clusterConfig.getFlowId());
+    }
+
+    private static boolean checkRegexField(ParamFlowRule rule) {
+        if (!RuleManager.checkRegexResourceField(rule)) {
+            return false;
+        }
+        if (rule.isRegex()) {
+            return !rule.isClusterMode() && rule.getControlBehavior() == RuleConstant.CONTROL_BEHAVIOR_DEFAULT;
+        }
+        return true;
     }
 
     public static boolean validClusterRuleId(Long id) {

--- a/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowPartialIntegrationTest.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowPartialIntegrationTest.java
@@ -1,0 +1,68 @@
+package com.alibaba.csp.sentinel.slots.block.flow.param;
+
+import com.alibaba.csp.sentinel.Entry;
+import com.alibaba.csp.sentinel.EntryType;
+import com.alibaba.csp.sentinel.SphU;
+import com.alibaba.csp.sentinel.slots.block.BlockException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author quguai
+ * @date 2023/10/27 13:44
+ */
+public class ParamFlowPartialIntegrationTest {
+
+    @Before
+    public void setUp() throws Exception {
+        ParamFlowRuleManager.loadRules(new ArrayList<>());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        ParamFlowRuleManager.loadRules(new ArrayList<>());
+    }
+
+    @Test
+    public void testParamFlowRegex() {
+        ParamFlowRule rule = new ParamFlowRule(".*")
+                .setParamIdx(0)
+                .setCount(1);
+        rule.setRegex(true);
+        ParamFlowRuleManager.loadRules(Collections.singletonList(rule));
+        verifyFlow("testParamFlowRegex_1", true, "args");
+        verifyFlow("testParamFlowRegex_1", true, "args_1");
+
+        verifyFlow("testParamFlowRegex_1", false, "args");
+        verifyFlow("testParamFlowRegex_1", false, "args_1");
+
+        verifyFlow("testParamFlowRegex_2", true, "args");
+        verifyFlow("testParamFlowRegex_2", true, "args_1");
+
+        verifyFlow("testParamFlowRegex_2", false, "args");
+        verifyFlow("testParamFlowRegex_2", false, "args_1");
+    }
+
+
+    private void verifyFlow(String resource, boolean shouldPass, String... args) {
+        Entry e = null;
+        try {
+            e = SphU.entry(resource, 1, EntryType.IN, args);
+            assertTrue(shouldPass);
+        } catch (BlockException e1) {
+            assertFalse(shouldPass);
+        } finally {
+            if (e != null) {
+                e.exit(1, args);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it
Resource rules support matching resource names according to regular rules, allowing users to configure traffic limiting rules or batch configuration.
When adding/deleting interfaces, there is no need to manually create/delete rules.

资源规则支持按照正则匹配资源名称，允许用户按照配置兜底限流规则或批量配置的能力。
当新增/删除接口时，无需手动创建/删除规则。

### Does this pull request fix one issue?
Fixes #3247 

### Describe how you did it
Add a RuleManger to uniformly manage ordinary rules and regular rules. In order to reduce the performance loss caused by regular parsing/matching, the following two methods are used:
1. Add a cache to cache the current limiting rules after regular parsing. When matching the current limiting rules, first search from the cache;
2. Rebuild the cache. When the current limiting rule is updated, new cache data is rebuilt based on the old cache data to reduce the performance loss caused by cache failure after the rule is updated;

增加一个 RuleManger 统一管理普通规则和正则规则，为了减少正则解析/匹配所带来的性能损耗，使用下面两种方式：
1. 增加缓存，缓存正则解析后的限流规则，匹配限流规则时先从缓存中去查找；
2. 重建缓存，当限流规则出现更新时，依据旧缓存数据重建新的缓存数据，减少由于更新规则后，缓存失效带来的性能损耗；

### Describe how to verify it

Regular unit tests have been added to each of the four rules to ensure normal performance; if regular rules are turned on, current limiting rules that meet regular matching but have different resource names will take effect.

对四种规则分别增加了正则的单元测试，用于保证表现正常；如果开启了正则规则，满足正则匹配但资源名称不同的限流规则均会生效。
1. Authority Rule：com.alibaba.csp.sentinel.slots.block.authority.AuthorityPartialIntegrationTest
2. Degrade Rule：com.alibaba.csp.sentinel.slots.block.degrade.DegradePartialIntegrationTest
4. Flow Rule：com.alibaba.csp.sentinel.slots.block.flow.FlowPartialIntegrationTest
6. Hot Pram Rule：com.alibaba.csp.sentinel.slots.block.flow.param.ParamFlowPartialIntegrationTest

### Special notes for reviews
None