### PR TITLE
修复当FileRefreshableDataSource文件为空时读取异常

### DIFF
--- a/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/FileRefreshableDataSource.java
+++ b/sentinel-extension/sentinel-datasource-extension/src/main/java/com/alibaba/csp/sentinel/datasource/FileRefreshableDataSource.java
@@ -118,6 +118,9 @@ public class FileRefreshableDataSource<T> extends AutoRefreshDataSource<String, 
                     + ", is bigger than bufSize=" + buf.length + ". Can't read");
             }
             int len = inputStream.read(buf);
+            if (len == -1) {
+                return null;
+            }
             return new String(buf, 0, len, charset);
         } finally {
             if (inputStream != null) {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
在使用FileRefreshableDataSource作为规则数据源时，发现如果初始化空规则文件会导致StringIndexOutOfBoundsException异常

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
判断规则文件是否有数据

### Describe how to verify it

加载空的规则文件看是否有异常打印
### Special notes for reviews
