### PR TITLE
修复ThrottlingController大量并发访问时可能流控失效的问题

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/controller/ThrottlingController.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/controller/ThrottlingController.java
@@ -73,12 +73,10 @@ public class ThrottlingController implements TrafficShapingController {
         // Calculate the interval between every two requests.
         final long costTimeNs = Math.round(1.0d * MS_TO_NS_OFFSET * statDurationMs * acquireCount / maxCountPerStat);
 
+        long latestPassedTimeSample = latestPassedTime.get();
         // Expected pass time of this request.
-        long expectedTime = costTimeNs + latestPassedTime.get();
-
-        if (expectedTime <= currentTime) {
-            // Contention may exist here, but it's okay.
-            latestPassedTime.set(currentTime);
+        long expectedTime = costTimeNs + latestPassedTimeSample;
+        if (expectedTime <= currentTime && latestPassedTime.compareAndSet(latestPassedTimeSample, currentTime)) {
             return true;
         } else {
             final long curNanos = System.nanoTime();
@@ -107,12 +105,10 @@ public class ThrottlingController implements TrafficShapingController {
         // Calculate the interval between every two requests.
         long costTime = Math.round(1.0d * statDurationMs * acquireCount / maxCountPerStat);
 
+        long latestPassedTimeSample = latestPassedTime.get();
         // Expected pass time of this request.
-        long expectedTime = costTime + latestPassedTime.get();
-
-        if (expectedTime <= currentTime) {
-            // Contention may exist here, but it's okay.
-            latestPassedTime.set(currentTime);
+        long expectedTime = costTime + latestPassedTimeSample;
+        if (expectedTime <= currentTime && latestPassedTime.compareAndSet(latestPassedTimeSample, currentTime)) {
             return true;
         } else {
             // Calculate the time to wait.


### PR DESCRIPTION




<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
ThrottlingController 窄时间窗口内大量并发访问时可能流控失效

### Does this pull request fix one issue?
feature:https://github.com/alibaba/Sentinel/issues/3091

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
在给latestPassedTime设置最新的时间前，先通过cas判断下值是否被修改过了，如果有则表示已有其他线程设置成功，当前线程需要走后续排队的流程。

### Describe how to verify it
jmeter压测

### Special notes for reviews
