### PR TITLE
Remove exception throwing when prioritized is true and grade is fast fail

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/controller/DefaultController.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/controller/DefaultController.java
@@ -58,9 +58,7 @@ public class DefaultController implements TrafficShapingController {
                     node.addWaitingRequest(currentTime + waitInMs, acquireCount);
                     node.addOccupiedPass(acquireCount);
                     sleep(waitInMs);
-
-                    // PriorityWaitException indicates that the request will pass after waiting for {@link @waitInMs}.
-                    throw new PriorityWaitException(waitInMs);
+                    return true;
                 }
             }
             return false;


### PR DESCRIPTION


<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
If the current priority is true and the flow control mode is fast failure, exceptions should not be thrown, otherwise this priority setting is meaningless.

### Does this pull request fix one issue?

Fixes #3261

### Describe how you did it
I took the initiative to remove the exception throwing
