### PR TITLE
Fix order dependent tests in ProviderFilterTest and ClientFilterTest

### DIFF
--- a/sentinel-adapter/sentinel-jax-rs-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/jaxrs/ClientFilterTest.java
+++ b/sentinel-adapter/sentinel-jax-rs-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/jaxrs/ClientFilterTest.java
@@ -18,6 +18,7 @@ package com.alibaba.csp.sentinel.adapter.jaxrs;
 import com.alibaba.csp.sentinel.Constants;
 import com.alibaba.csp.sentinel.CtSph;
 import com.alibaba.csp.sentinel.adapter.jaxrs.config.SentinelJaxRsConfig;
+import com.alibaba.csp.sentinel.adapter.jaxrs.fallback.DefaultSentinelJaxRsFallback;
 import com.alibaba.csp.sentinel.adapter.jaxrs.fallback.SentinelJaxRsFallback;
 import com.alibaba.csp.sentinel.context.Context;
 import com.alibaba.csp.sentinel.context.ContextUtil;
@@ -107,6 +108,7 @@ public class ClientFilterTest {
     public void cleanUp() {
         FlowRuleManager.loadRules(null);
         ClusterBuilderSlot.resetClusterNodes();
+        SentinelJaxRsConfig.setJaxRsFallback(new DefaultSentinelJaxRsFallback());
     }
 
     @Test

--- a/sentinel-adapter/sentinel-jax-rs-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/jaxrs/ProviderFilterTest.java
+++ b/sentinel-adapter/sentinel-jax-rs-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/jaxrs/ProviderFilterTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.FutureTask;
 
 import com.alibaba.csp.sentinel.Constants;
 import com.alibaba.csp.sentinel.adapter.jaxrs.config.SentinelJaxRsConfig;
+import com.alibaba.csp.sentinel.adapter.jaxrs.fallback.DefaultSentinelJaxRsFallback;
 import com.alibaba.csp.sentinel.adapter.jaxrs.fallback.SentinelJaxRsFallback;
 import com.alibaba.csp.sentinel.adapter.jaxrs.request.RequestOriginParser;
 import com.alibaba.csp.sentinel.node.ClusterNode;
@@ -77,6 +78,7 @@ public class ProviderFilterTest {
     public void cleanUp() {
         FlowRuleManager.loadRules(null);
         ClusterBuilderSlot.resetClusterNodes();
+        SentinelJaxRsConfig.setJaxRsFallback(new DefaultSentinelJaxRsFallback());
     }
 
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

- In `sentinel-adapter/sentinel-reactor-adapter`, the unit tests `ProviderFilterTest.testDefaultFallback()`, `ProviderFilterTest.testCustomRequestOriginParser()`, and `ClientFilterTest.testClientFallback()` will fail when run after the unit tests `ProviderFilterTest.testCustomFallback()` or `ClientFilterTest.testClientCustomFallback()` because it pollutes state shared among tests.
- It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #3271

### Describe how you did it

- As mentioned in the [issue](https://github.com/alibaba/Sentinel/issues/3267), I have cleaned up the polluted state `SentinelJaxRsConfig.jaxRsFallback` to its default value in the `cleanUp()` method of the respective test classes.

### Describe how to verify it

- With the proposed fix, the test does not pollute the shared state.
- All the tests pass when run in the any order.

