### PR TITLE
Fix order dependent tests in SofaRpcFallbackRegistryTest

### DIFF
--- a/sentinel-adapter/sentinel-sofa-rpc-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/sofa/rpc/fallback/SofaRpcFallbackRegistryTest.java
+++ b/sentinel-adapter/sentinel-sofa-rpc-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/sofa/rpc/fallback/SofaRpcFallbackRegistryTest.java
@@ -70,5 +70,9 @@ public class SofaRpcFallbackRegistryTest {
         SofaResponse consumerResponse = SofaRpcFallbackRegistry.getConsumerFallback().handle(null, null, null);
         assertNotNull(consumerResponse);
         assertEquals("test consumer response", consumerResponse.getAppResponse());
+
+        // Reset to default provider and consumer fallback
+        SofaRpcFallbackRegistry.setProviderFallback(new DefaultSofaRpcFallback());
+        SofaRpcFallbackRegistry.setConsumerFallback(new DefaultSofaRpcFallback());
     }
 }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

- In `sentinel-adapter/sentinel-sofa-rpc-adapter`, the unit test `SofaRpcFallbackRegistryTest.testDefaultFallback()` will fail when run after the unit test `SofaRpcFallbackRegistryTest.testCustomFallback()` because it pollutes state shared among tests.
- It may be good to clean this state pollution so that this tests and some other tests do not fail in the future due to the shared state polluted by this test.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #3281

### Describe how you did it

- As mentioned in the [issue](https://github.com/alibaba/Sentinel/issues/3281), I have cleaned the polluted states `SofaRpcFallback.providerFallback` and `SofaRpcFallback.consumerFallback` to its default value after the test `SofaRpcFallbackRegistryTest.testCustomFallback()` is executed.

### Describe how to verify it

- With the proposed fix, the test does not pollute the shared state.
- All the tests pass when run in the any order.

