### PR TITLE
httpclient-adapter bug

### DIFF
--- a/sentinel-adapter/sentinel-apache-httpclient-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/apache/httpclient/extractor/DefaultApacheHttpClientResourceExtractor.java
+++ b/sentinel-adapter/sentinel-apache-httpclient-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/apache/httpclient/extractor/DefaultApacheHttpClientResourceExtractor.java
@@ -24,6 +24,6 @@ public class DefaultApacheHttpClientResourceExtractor implements ApacheHttpClien
 
     @Override
     public String extractor(HttpRequestWrapper request) {
-        return request.getRequestLine().getUri();
+        return request.getURI().getPath();
     }
 }


### PR DESCRIPTION
GET  http://host:port/path?param1=value1
The result of "request.getRequestLine().getUri()" is "http://host:port/path?param1=value1",
while the result of "request.getURI().getPath()" is "http://host:port/path".