### PR TITLE
Fix when duplication spi class found using SpiLoader

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/spi/SpiLoader.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/spi/SpiLoader.java
@@ -329,11 +329,11 @@ public final class SpiLoader<S> {
         try {
             urls = classLoader.getResources(fullFileName);
         } catch (IOException e) {
-            fail("Error locating SPI configuration file, filename=" + fullFileName + ", classloader=" + classLoader, e);
+            fail("Error locating SPI configuration file,filename=" + fullFileName + ",classloader=" + classLoader, e);
         }
 
         if (urls == null || !urls.hasMoreElements()) {
-            RecordLog.warn("No SPI configuration file, filename=" + fullFileName + ", classloader=" + classLoader);
+            RecordLog.warn("No SPI configuration file,filename=" + fullFileName + ",classloader=" + classLoader);
             return;
         }
 
@@ -371,8 +371,13 @@ public final class SpiLoader<S> {
                         fail("class " + line + " not found", e);
                     }
 
+                    if (classMap.containsValue(clazz)) {
+                        RecordLog.warn("duplicate class found,className=" + clazz.getName() + ",SPI configuration file[" + url + "]");
+                        continue;
+                    }
+
                     if (!service.isAssignableFrom(clazz)) {
-                        fail("class " + clazz.getName() + "is not subtype of " + service.getName() + ",SPI configuration file=" + fullFileName);
+                        fail("class " + clazz.getName() + "is not subtype of " + service.getName() + ",SPI configuration file[" + url + "]");
                     }
 
                     classList.add(clazz);
@@ -381,13 +386,13 @@ public final class SpiLoader<S> {
                     if (classMap.containsKey(aliasName)) {
                         Class<? extends S> existClass = classMap.get(aliasName);
                         fail("Found repeat alias name for " + clazz.getName() + " and "
-                                + existClass.getName() + ",SPI configuration file=" + fullFileName);
+                                + existClass.getName() + ",SPI configuration file[" + url + "]");
                     }
                     classMap.put(aliasName, clazz);
 
                     if (spi != null && spi.isDefault()) {
                         if (defaultClass != null) {
-                            fail("Found more than one default Provider, SPI configuration file=" + fullFileName);
+                            fail("Found more than one default Provider,className=" + clazz.getName() + ",SPI configuration file[" + url + "]");
                         }
                         defaultClass = clazz;
                     }
@@ -400,7 +405,7 @@ public final class SpiLoader<S> {
                             , spi == null ? 0 : spi.order());
                 }
             } catch (IOException e) {
-                fail("error reading SPI configuration file", e);
+                fail("error reading SPI configuration file[" + url + "]", e);
             } finally {
                 closeResources(in, br);
             }


### PR DESCRIPTION
### Describe what this PR does / why we need it

当项目jar依赖包里有重复sentinel包，目前`SpiLoader`加载`META-INF/services`里的SPI扩展类，如果发现有重复的已解析过的扩展类，会抛出异常提示，导致相关功能无法运行。

这种场景可能更好的处理方式是程序不抛异常，在日志中记录该情况便于排查，已解析过的扩展类跳过处理，让程序正常运行。


### Does this pull request fix one issue?

Fixes #3376 

### Describe how you did it

`SpiLoader`里的`classMap`存储了已解析的扩展类，其中value类型为`Class`，可通过value来检查重复。

### Describe how to verify it

1.在spring-webmvc的demo里，添加`META-INF/services`目录，拷贝sentinel-core里的部分配置，启动`WebMvcDemoApplication`类，访问接口测试并检查日志情况。

2.在项目里引用2个不同版本的`sentinel-core`，启动项目进行限流相关测试。

### Special notes for reviews

优化了该类的一些日志打印，打印出SPI扩展文件地址，用于日志排查。