### PR TITLE
fix: DefaultBlockRequestHandler Adapt to SpringBoot 3

### DIFF
--- a/sentinel-adapter/sentinel-spring-cloud-gateway-adapter/pom.xml
+++ b/sentinel-adapter/sentinel-spring-cloud-gateway-adapter/pom.xml
@@ -18,6 +18,7 @@
         <spring.cloud.gateway.version>2.1.1.RELEASE</spring.cloud.gateway.version>
         <spring.boot.version>2.5.12</spring.boot.version>
         <spring.version>5.3.18</spring.version>
+        <reactor.version>3.4.16</reactor.version>
     </properties>
 
     <dependencies>
@@ -75,6 +76,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <version>${reactor.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/sentinel-adapter/sentinel-spring-cloud-gateway-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/sc/callback/DefaultBlockRequestHandler.java
+++ b/sentinel-adapter/sentinel-spring-cloud-gateway-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/sc/callback/DefaultBlockRequestHandler.java
@@ -42,13 +42,13 @@ public class DefaultBlockRequestHandler implements BlockRequestHandler {
             return htmlErrorResponse(ex);
         }
         // JSON result by default.
-        return ServerResponse.status(HttpStatus.TOO_MANY_REQUESTS)
+        return ServerResponse.status(HttpStatus.TOO_MANY_REQUESTS.value())
             .contentType(MediaType.APPLICATION_JSON_UTF8)
             .body(fromObject(buildErrorResult(ex)));
     }
 
     private Mono<ServerResponse> htmlErrorResponse(Throwable ex) {
-        return ServerResponse.status(HttpStatus.TOO_MANY_REQUESTS)
+        return ServerResponse.status(HttpStatus.TOO_MANY_REQUESTS.value())
             .contentType(MediaType.TEXT_PLAIN)
             .syncBody(DEFAULT_BLOCK_MSG_PREFIX + ex.getClass().getSimpleName());
     }

--- a/sentinel-adapter/sentinel-spring-cloud-gateway-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/sc/callback/DefaultBlockRequestHandlerTest.java
+++ b/sentinel-adapter/sentinel-spring-cloud-gateway-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/sc/callback/DefaultBlockRequestHandlerTest.java
@@ -1,0 +1,74 @@
+package com.alibaba.csp.sentinel.adapter.gateway.sc.callback;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author cxhello
+ * @date 2024/4/21
+ */
+public class DefaultBlockRequestHandlerTest {
+
+    @Test
+    public void testHandleRequest_acceptsHtml_returnsHtmlErrorResponse() {
+        // Arrange
+        ServerWebExchange exchange = Mockito.mock(ServerWebExchange.class);
+        ServerHttpRequest request = Mockito.mock(ServerHttpRequest.class);
+        HttpHeaders httpHeaders = Mockito.mock(HttpHeaders.class);
+        Mockito.when(exchange.getRequest()).thenReturn(request);
+        Mockito.when(request.getHeaders()).thenReturn(httpHeaders);
+        Throwable ex = new RuntimeException("Test Exception");
+        Mockito.when(exchange.getRequest().getHeaders().getAccept())
+                .thenReturn(Arrays.asList(MediaType.TEXT_HTML));
+
+        // Act
+        Mono<ServerResponse> result = new DefaultBlockRequestHandler().handleRequest(exchange, ex);
+
+        // Assert
+        StepVerifier.create(result)
+                .expectNextMatches(response -> {
+                    assertEquals(HttpStatus.TOO_MANY_REQUESTS.value(), response.statusCode().value());
+                    assertEquals(MediaType.TEXT_PLAIN, response.headers().getContentType());
+                    return true;
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void testHandleRequest_acceptsJson_returnsJsonErrorResponse() {
+        // Arrange
+        ServerWebExchange exchange = Mockito.mock(ServerWebExchange.class);
+        ServerHttpRequest request = Mockito.mock(ServerHttpRequest.class);
+        HttpHeaders httpHeaders = Mockito.mock(HttpHeaders.class);
+        Mockito.when(exchange.getRequest()).thenReturn(request);
+        Mockito.when(request.getHeaders()).thenReturn(httpHeaders);
+        Throwable ex = new RuntimeException("Test Exception");
+        Mockito.when(exchange.getRequest().getHeaders().getAccept())
+                .thenReturn(Arrays.asList(MediaType.APPLICATION_JSON));
+
+        // Act
+        Mono<ServerResponse> result = new DefaultBlockRequestHandler().handleRequest(exchange, ex);
+
+        // Assert
+        StepVerifier.create(result)
+                .expectNextMatches(response -> {
+                    assertEquals(HttpStatus.TOO_MANY_REQUESTS.value(), response.statusCode().value());
+                    assertEquals(MediaType.APPLICATION_JSON_UTF8, response.headers().getContentType());
+                    return true;
+                })
+                .verifyComplete();
+    }
+
+}

--- a/sentinel-adapter/sentinel-spring-webflux-adapter/pom.xml
+++ b/sentinel-adapter/sentinel-spring-webflux-adapter/pom.xml
@@ -16,6 +16,7 @@
         <java.target.version>1.8</java.target.version>
         <spring.version>5.3.18</spring.version>
         <spring.boot.version>2.5.12</spring.boot.version>
+        <reactor.version>3.4.16</reactor.version>
     </properties>
 
     <dependencies>
@@ -49,6 +50,13 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <version>${spring.boot.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <version>${reactor.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/callback/DefaultBlockRequestHandler.java
+++ b/sentinel-adapter/sentinel-spring-webflux-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webflux/callback/DefaultBlockRequestHandler.java
@@ -42,13 +42,13 @@ public class DefaultBlockRequestHandler implements BlockRequestHandler {
             return htmlErrorResponse(ex);
         }
         // JSON result by default.
-        return ServerResponse.status(HttpStatus.TOO_MANY_REQUESTS)
+        return ServerResponse.status(HttpStatus.TOO_MANY_REQUESTS.value())
             .contentType(MediaType.APPLICATION_JSON_UTF8)
             .body(fromObject(buildErrorResult(ex)));
     }
 
     private Mono<ServerResponse> htmlErrorResponse(Throwable ex) {
-        return ServerResponse.status(HttpStatus.TOO_MANY_REQUESTS)
+        return ServerResponse.status(HttpStatus.TOO_MANY_REQUESTS.value())
             .contentType(MediaType.TEXT_PLAIN)
             .syncBody(DEFAULT_BLOCK_MSG_PREFIX + ex.getClass().getSimpleName());
     }

--- a/sentinel-adapter/sentinel-spring-webflux-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/spring/webflux/callback/DefaultBlockRequestHandlerTest.java
+++ b/sentinel-adapter/sentinel-spring-webflux-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/spring/webflux/callback/DefaultBlockRequestHandlerTest.java
@@ -1,0 +1,74 @@
+package com.alibaba.csp.sentinel.adapter.spring.webflux.callback;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author cxhello
+ * @date 2024/4/21
+ */
+public class DefaultBlockRequestHandlerTest {
+
+    @Test
+    public void testHandleRequest_acceptsHtml_returnsHtmlErrorResponse() {
+        // Arrange
+        ServerWebExchange exchange = Mockito.mock(ServerWebExchange.class);
+        ServerHttpRequest request = Mockito.mock(ServerHttpRequest.class);
+        HttpHeaders httpHeaders = Mockito.mock(HttpHeaders.class);
+        Mockito.when(exchange.getRequest()).thenReturn(request);
+        Mockito.when(request.getHeaders()).thenReturn(httpHeaders);
+        Throwable ex = new RuntimeException("Test Exception");
+        Mockito.when(exchange.getRequest().getHeaders().getAccept())
+                .thenReturn(Arrays.asList(MediaType.TEXT_HTML));
+
+        // Act
+        Mono<ServerResponse> result = new DefaultBlockRequestHandler().handleRequest(exchange, ex);
+
+        // Assert
+        StepVerifier.create(result)
+                .expectNextMatches(response -> {
+                    assertEquals(HttpStatus.TOO_MANY_REQUESTS.value(), response.statusCode().value());
+                    assertEquals(MediaType.TEXT_PLAIN, response.headers().getContentType());
+                    return true;
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void testHandleRequest_acceptsJson_returnsJsonErrorResponse() {
+        // Arrange
+        ServerWebExchange exchange = Mockito.mock(ServerWebExchange.class);
+        ServerHttpRequest request = Mockito.mock(ServerHttpRequest.class);
+        HttpHeaders httpHeaders = Mockito.mock(HttpHeaders.class);
+        Mockito.when(exchange.getRequest()).thenReturn(request);
+        Mockito.when(request.getHeaders()).thenReturn(httpHeaders);
+        Throwable ex = new RuntimeException("Test Exception");
+        Mockito.when(exchange.getRequest().getHeaders().getAccept())
+                .thenReturn(Arrays.asList(MediaType.APPLICATION_JSON));
+
+        // Act
+        Mono<ServerResponse> result = new DefaultBlockRequestHandler().handleRequest(exchange, ex);
+
+        // Assert
+        StepVerifier.create(result)
+                .expectNextMatches(response -> {
+                    assertEquals(HttpStatus.TOO_MANY_REQUESTS.value(), response.statusCode().value());
+                    assertEquals(MediaType.APPLICATION_JSON_UTF8, response.headers().getContentType());
+                    return true;
+                })
+                .verifyComplete();
+    }
+
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

DefaultBlockRequestHandler Adapt to SpringBoot 3

### Does this pull request fix one issue?

Closes https://github.com/alibaba/Sentinel/issues/3298

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

org.springframework.web.reactive.function.server.ServerResponse#status(org.springframework.http.HttpStatus) method was modified in springboot 3 to org.springframework.web.reactive.function.server.ServerResponse#status(org.springframework.http.HttpStatusCode)

but Both versions are available org.springframework.web.reactive.function.server.ServerResponse#status(int) method. so i modified it.

### Describe how to verify it

https://github.com/alibaba/spring-cloud-alibaba/issues/3688

### Special notes for reviews
