### PR TITLE
fix: 修复ParameterMetric在生产环境导致的内存泄漏（请求对象继承ParamFlowArgument，包含sku等多个无限…

### DIFF
--- a/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParameterMetric.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParameterMetric.java
@@ -141,6 +141,10 @@ public class ParameterMetric {
                 if (arg == null) {
                     continue;
                 }
+                if (arg instanceof ParamFlowArgument) {
+                    arg = ((ParamFlowArgument) arg).paramFlowKey();
+                }
+
                 if (Collection.class.isAssignableFrom(arg.getClass())) {
 
                     for (Object value : ((Collection)arg)) {
@@ -200,6 +204,9 @@ public class ParameterMetric {
 
                 if (arg == null) {
                     continue;
+                }
+                if (arg instanceof ParamFlowArgument) {
+                    arg = ((ParamFlowArgument) arg).paramFlowKey();
                 }
 
                 if (Collection.class.isAssignableFrom(arg.getClass())) {


### PR DESCRIPTION
…枚举值字段）

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
生产环境dubbo接口配置了热点参数限流规则，请求对象包含sku\店铺id等多个无限枚举值字段，继承ParamFlowArgument指定某个字段配置不同的限流阈值，每隔几天订单服务出现堆内存溢出，服务不可用; 通过分析堆内存，发现ParameterMetric下的HashMap对象在服务启动后逐渐增长达到4g大小，无法gc回收

### Does this pull request fix one issue?
NONE

### Describe how you did it
ParamFlowArgument.threadCount.CacheMap会为每次dubbo接口的请求的复合请求对象put一组新的健值对, 当dubbo复合请求对象存在无限多个枚举值时, 内存溢出; 优化为只采集ParamFlowArgument指定字段枚举值的线程指标

### Describe how to verify it
通过jmter压测或者单测debug ParameterMetric类，每次请求构造不同的arg对象（not equals）, ParamFlowArgument.threadCount.CacheMap每次请求都会put一组新的健值对, 超过默认大小4000后无法及时回收
threadCount.putIfAbsent(arg, new AtomicInteger());

### Special notes for reviews
