### PR TITLE
Fix #3397 .

### DIFF
--- a/sentinel-demo/sentinel-demo-annotation-spring-aop/src/main/java/com/alibaba/csp/sentinel/demo/annotation/aop/controller/DemoController.java
+++ b/sentinel-demo/sentinel-demo-annotation-spring-aop/src/main/java/com/alibaba/csp/sentinel/demo/annotation/aop/controller/DemoController.java
@@ -47,6 +47,12 @@ public class DemoController {
         return service.hello(t);
     }
 
+    @GetMapping("/count")
+    public int count() {
+        service.test();
+        return service.count();
+    }
+
     @GetMapping("/baz/{name}")
     public String apiBaz(@PathVariable("name") String name) {
         return service.helloAnother(name);

--- a/sentinel-demo/sentinel-demo-annotation-spring-aop/src/main/java/com/alibaba/csp/sentinel/demo/annotation/aop/service/TestService.java
+++ b/sentinel-demo/sentinel-demo-annotation-spring-aop/src/main/java/com/alibaba/csp/sentinel/demo/annotation/aop/service/TestService.java
@@ -26,5 +26,7 @@ public interface TestService {
 
     String hello(String s);
 
+    int count();
+
     String helloAnother(String name);
 }

--- a/sentinel-demo/sentinel-demo-annotation-spring-aop/src/main/java/com/alibaba/csp/sentinel/demo/annotation/aop/service/TestServiceImpl.java
+++ b/sentinel-demo/sentinel-demo-annotation-spring-aop/src/main/java/com/alibaba/csp/sentinel/demo/annotation/aop/service/TestServiceImpl.java
@@ -48,6 +48,12 @@ public class TestServiceImpl implements TestService {
         return String.format("Hello, %s", s);
     }
 
+    @SentinelResource(value = "count", fallback = "helloFallback", defaultFallback = "countDefaultFallback")
+    @Override
+    public int count() {
+        throw new UnsupportedOperationException("unimplemented");
+    }
+
     @Override
     @SentinelResource(value = "helloAnother", defaultFallback = "defaultFallback",
         exceptionsToIgnore = {IllegalStateException.class})
@@ -76,5 +82,9 @@ public class TestServiceImpl implements TestService {
     public String defaultFallback() {
         System.out.println("Go to default fallback");
         return "default_fallback";
+    }
+
+    public int countDefaultFallback() {
+        return -1;
     }
 }

--- a/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/AbstractSentinelAspectSupport.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/AbstractSentinelAspectSupport.java
@@ -179,12 +179,12 @@ public abstract class AbstractSentinelAspectSupport {
         boolean mustStatic = locationClass != null && locationClass.length >= 1;
         Class<?> clazz = mustStatic ? locationClass[0] : pjp.getTarget().getClass();
         Method originMethod = resolveMethod(pjp);
-        MethodWrapper m = ResourceMetadataRegistry.lookupFallback(clazz, fallbackName, originMethod.getParameterTypes());
+        MethodWrapper m = ResourceMetadataRegistry.lookupFallback(originMethod, clazz, fallbackName);
         if (m == null) {
             // First time, resolve the fallback.
             Method method = resolveFallbackInternal(originMethod, fallbackName, clazz, mustStatic);
             // Cache the method instance.
-            ResourceMetadataRegistry.updateFallbackFor(clazz, fallbackName, originMethod.getParameterTypes(), method);
+            ResourceMetadataRegistry.updateFallbackFor(originMethod, clazz, fallbackName, method);
             return method;
         }
         if (!m.isPresent()) {
@@ -209,10 +209,11 @@ public abstract class AbstractSentinelAspectSupport {
         boolean mustStatic = locationClass != null && locationClass.length >= 1;
         Class<?> clazz = mustStatic ? locationClass[0] : pjp.getTarget().getClass();
 
-        MethodWrapper m = ResourceMetadataRegistry.lookupDefaultFallback(clazz, defaultFallback);
+        Method originMethod = resolveMethod(pjp);
+        MethodWrapper m = ResourceMetadataRegistry.lookupDefaultFallback(originMethod, clazz, defaultFallback);
         if (m == null) {
             // First time, resolve the default fallback.
-            Class<?> originReturnType = resolveMethod(pjp).getReturnType();
+            Class<?> originReturnType = originMethod.getReturnType();
             // Default fallback allows two kinds of parameter list.
             // One is empty parameter list.
             Class<?>[] defaultParamTypes = new Class<?>[0];
@@ -225,7 +226,7 @@ public abstract class AbstractSentinelAspectSupport {
                 method = findMethod(mustStatic, clazz, defaultFallback, originReturnType, paramTypeWithException);
             }
             // Cache the method instance.
-            ResourceMetadataRegistry.updateDefaultFallbackFor(clazz, defaultFallback, method);
+            ResourceMetadataRegistry.updateDefaultFallbackFor(originMethod, clazz, defaultFallback, method);
             return method;
         }
         if (!m.isPresent()) {
@@ -262,12 +263,12 @@ public abstract class AbstractSentinelAspectSupport {
             clazz = pjp.getTarget().getClass();
         }
         Method originMethod = resolveMethod(pjp);
-        MethodWrapper m = ResourceMetadataRegistry.lookupBlockHandler(clazz, name, originMethod.getParameterTypes());
+        MethodWrapper m = ResourceMetadataRegistry.lookupBlockHandler(originMethod, clazz, name);
         if (m == null) {
             // First time, resolve the block handler.
             Method method = resolveBlockHandlerInternal(originMethod, name, clazz, mustStatic);
             // Cache the method instance.
-            ResourceMetadataRegistry.updateBlockHandlerFor(clazz, name, originMethod.getParameterTypes(), method);
+            ResourceMetadataRegistry.updateBlockHandlerFor(originMethod, clazz, name, method);
             return method;
         }
         if (!m.isPresent()) {

--- a/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/HandlerMeta.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/HandlerMeta.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 1999-2024 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.annotation.aspectj;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * `blockHandler`, `fallback` and `defaultFallback` handler metadata, describing the features of a handler method.
+ * It helps locate the handler method in the registry.
+ *
+ * @author dowenliu-xyz(hawkdowen@hotmail.com)
+ */
+final class HandlerMeta {
+    private final Class<?> handlerClass;
+    private final Class<?> returnType;
+    private final String handlerName;
+    private final Class<?>[] parameterTypes;
+
+    /**
+     * Create a handler metadata.
+     *
+     * @param originMethod the origin method which is annotated by `@SentinelResource`
+     * @param handlerClass the class of the handler method
+     * @param handlerName  the name of the handler method
+     * @return the handler metadata
+     * @throws IllegalArgumentException if `originMethod` is null
+     */
+    static HandlerMeta handlerMetaOf(Method originMethod, Class<?> handlerClass, String handlerName) {
+        if (originMethod == null) throw new IllegalArgumentException("originMethod should not be null");
+        return new HandlerMeta(
+                handlerClass, originMethod.getReturnType(), handlerName, originMethod.getParameterTypes());
+    }
+
+    private HandlerMeta(Class<?> handlerClass, Class<?> returnType, String handlerName, Class<?>[] parameterTypes) {
+        this.handlerClass = handlerClass;
+        this.returnType = returnType;
+        this.handlerName = handlerName;
+        this.parameterTypes = parameterTypes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        HandlerMeta that = (HandlerMeta) o;
+        return Objects.equals(handlerClass, that.handlerClass) &&
+                Objects.equals(returnType, that.returnType) &&
+                Objects.equals(handlerName, that.handlerName) &&
+                Objects.deepEquals(parameterTypes, that.parameterTypes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(handlerClass, returnType, handlerName, Arrays.hashCode(parameterTypes));
+    }
+}

--- a/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/ResourceMetadataRegistry.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/ResourceMetadataRegistry.java
@@ -30,41 +30,97 @@ import com.alibaba.csp.sentinel.util.StringUtil;
  * @author dowenliu-xyz(hawkdowen@hotmail.com)
  */
 final class ResourceMetadataRegistry {
-
     private static final Map<String, MethodWrapper> FALLBACK_MAP = new ConcurrentHashMap<>();
+    private static final Map<HandlerMeta, MethodWrapper> FALLBACK_METAMAP = new ConcurrentHashMap<>();
     private static final Map<String, MethodWrapper> DEFAULT_FALLBACK_MAP = new ConcurrentHashMap<>();
+    private static final Map<HandlerMeta, MethodWrapper> DEFAULT_FALLBACK_METAMAP = new ConcurrentHashMap<>();
     private static final Map<String, MethodWrapper> BLOCK_HANDLER_MAP = new ConcurrentHashMap<>();
+    private static final Map<HandlerMeta, MethodWrapper> BLOCK_HANDLER_METAMAP = new ConcurrentHashMap<>();
 
     /**
-     * @deprecated use {@link #lookupFallback(Class, String, Class[])}
+     * @deprecated use {@link #lookupFallback(Method, Class, String)}
      */
     @Deprecated
     static MethodWrapper lookupFallback(Class<?> clazz, String name) {
         return FALLBACK_MAP.get(getKey(clazz, name));
     }
 
+    /**
+     * @deprecated use {@link #lookupFallback(Method, Class, String)}
+     */
+    @Deprecated
     static MethodWrapper lookupFallback(Class<?> clazz, String name, Class<?>[] parameterTypes) {
         return FALLBACK_MAP.get(getKey(clazz, name, parameterTypes));
     }
 
+    /**
+     * Lookup the fallback handler method of the origin method, with specified name in the specified class.
+     *
+     * @param originMethod the origin method which is annotated by `@SentinelResource` with the fallback handler
+     *                     name value.
+     * @param handlerClass the class of the defaultFallback handler method.
+     * @param handlerName  the name of expected fallback handler method.
+     * @return the found method wrapper. If currently the method is not registered, return {@code null}. Even if the
+     * returned wrapper is not {@code null}, the method it contains may still be {@code null}, which means that the
+     * expected handler method does not exist.
+     */
+    static MethodWrapper lookupFallback(Method originMethod, Class<?> handlerClass, String handlerName) {
+        return FALLBACK_METAMAP.get(HandlerMeta.handlerMetaOf(originMethod, handlerClass, handlerName));
+    }
+
+    /**
+     * @deprecated use {@link #lookupDefaultFallback(Method, Class, String)}
+     */
     static MethodWrapper lookupDefaultFallback(Class<?> clazz, String name) {
         return DEFAULT_FALLBACK_MAP.get(getKey(clazz, name));
     }
 
     /**
-     * @deprecated use {@link #lookupBlockHandler(Class, String, Class[])}
+     * Lookup the defaultFallback handler method of the origin method, with specified name in the specified class.
+     *
+     * @param originMethod the origin method which is annotated by `@SentinelResource` with the defaultFallback
+     *                     handler name value.
+     * @param handlerClass the class of the defaultFallback handler method.
+     * @param handlerName  the name of expected defaultFallback handler method.
+     * @return the found method wrapper. If currently the method is not registered, return {@code null}. Even if the
+     * returned wrapper is not {@code null}, the method it contains may still be {@code null}, which means that the
+     * expected handler method does not exist.
+     */
+    static MethodWrapper lookupDefaultFallback(Method originMethod, Class<?> handlerClass, String handlerName) {
+        return DEFAULT_FALLBACK_METAMAP.get(HandlerMeta.handlerMetaOf(originMethod, handlerClass, handlerName));
+    }
+
+    /**
+     * @deprecated use {@link #lookupBlockHandler(Method, Class, String)}
      */
     @Deprecated
     static MethodWrapper lookupBlockHandler(Class<?> clazz, String name) {
         return BLOCK_HANDLER_MAP.get(getKey(clazz, name));
     }
 
+    /**
+     * @deprecated use {@link #lookupBlockHandler(Method, Class, String)}
+     */
     static MethodWrapper lookupBlockHandler(Class<?> clazz, String name, Class<?>[] parameterTypes) {
         return BLOCK_HANDLER_MAP.get(getKey(clazz, name, parameterTypes));
     }
 
     /**
-     * @deprecated use {@link #updateFallbackFor(Class, String, Class[], Method)}
+     * Lookup the blockHandler handler method of the origin method, with specified name in the specified class.
+     * @param originMethod the origin method which is annotated by `@SentinelResource` with the blockHandler handler
+     *                    name value.
+     * @param handlerClass the class of the blockHandler handler method.
+     * @param handlerName the name of expected blockHandler handler method.
+     * @return the found method wrapper. If currently the method is not registered, return {@code null}. Even if the
+     * returned wrapper is not {@code null}, the method it contains may still be {@code null}, which means that the
+     * expected handler method does not exist.
+     */
+    static MethodWrapper lookupBlockHandler(Method originMethod, Class<?> handlerClass, String handlerName) {
+        return BLOCK_HANDLER_METAMAP.get(HandlerMeta.handlerMetaOf(originMethod, handlerClass, handlerName));
+    }
+
+    /**
+     * @deprecated use {@link #updateFallbackFor(Method, Class, String, Method)}
      */
     @Deprecated
     static void updateFallbackFor(Class<?> clazz, String name, Method method) {
@@ -74,6 +130,9 @@ final class ResourceMetadataRegistry {
         FALLBACK_MAP.put(getKey(clazz, name), MethodWrapper.wrap(method));
     }
 
+    /**
+     * @deprecated use {@link #updateFallbackFor(Method, Class, String, Method)}
+     */
     static void updateFallbackFor(Class<?> clazz, String handlerName, Class<?>[] parameterTypes, Method handlerMethod) {
         if (clazz == null || StringUtil.isBlank(handlerName)) {
             throw new IllegalArgumentException("Bad argument");
@@ -81,6 +140,15 @@ final class ResourceMetadataRegistry {
         FALLBACK_MAP.put(getKey(clazz, handlerName, parameterTypes), MethodWrapper.wrap(handlerMethod));
     }
 
+    static void updateFallbackFor(Method originMethod, Class<?> handlerClass, String handlerName,
+                                  Method handlerMethod) {
+        FALLBACK_METAMAP.put(HandlerMeta.handlerMetaOf(originMethod, handlerClass, handlerName),
+                MethodWrapper.wrap(handlerMethod));
+    }
+
+    /**
+     * @deprecated use {@link #updateDefaultFallbackFor(Method, Class, String, Method)}
+     */
     static void updateDefaultFallbackFor(Class<?> clazz, String name, Method method) {
         if (clazz == null || StringUtil.isBlank(name)) {
             throw new IllegalArgumentException("Bad argument");
@@ -88,9 +156,15 @@ final class ResourceMetadataRegistry {
         DEFAULT_FALLBACK_MAP.put(getKey(clazz, name), MethodWrapper.wrap(method));
     }
 
+    static void updateDefaultFallbackFor(Method originMethod, Class<?> handlerClass, String handlerName,
+                                         Method handlerMethod) {
+        DEFAULT_FALLBACK_METAMAP.put(HandlerMeta.handlerMetaOf(originMethod, handlerClass, handlerName),
+                MethodWrapper.wrap(handlerMethod));
+    }
+
 
     /**
-     * @deprecated use {@link #updateBlockHandlerFor(Class, String, Class[], Method)}
+     * @deprecated use {@link #updateBlockHandlerFor(Method, Class, String, Method)}
      */
     @Deprecated
     static void updateBlockHandlerFor(Class<?> clazz, String name, Method method) {
@@ -100,12 +174,21 @@ final class ResourceMetadataRegistry {
         BLOCK_HANDLER_MAP.put(getKey(clazz, name), MethodWrapper.wrap(method));
     }
 
+    /**
+     * @deprecated use {@link #updateBlockHandlerFor(Method, Class, String, Method)}
+     */
     static void updateBlockHandlerFor(Class<?> clazz, String handlerName, Class<?>[] parameterTypes,
                                       Method handlerMethod) {
         if (clazz == null || StringUtil.isBlank(handlerName)) {
             throw new IllegalArgumentException("Bad argument");
         }
         BLOCK_HANDLER_MAP.put(getKey(clazz, handlerName, parameterTypes), MethodWrapper.wrap(handlerMethod));
+    }
+
+    static void updateBlockHandlerFor(Method originMethod, Class<?> handlerClass, String handlerName,
+                                      Method handlerMethod) {
+        BLOCK_HANDLER_METAMAP.put(HandlerMeta.handlerMetaOf(originMethod, handlerClass, handlerName),
+                MethodWrapper.wrap(handlerMethod));
     }
 
     private static String getKey(Class<?> clazz, String name) {
@@ -126,6 +209,7 @@ final class ResourceMetadataRegistry {
      */
     static void clearFallbackMap() {
         FALLBACK_MAP.clear();
+        FALLBACK_METAMAP.clear();
     }
 
     /**
@@ -133,5 +217,13 @@ final class ResourceMetadataRegistry {
      */
     static void clearBlockHandlerMap() {
         BLOCK_HANDLER_MAP.clear();
+        BLOCK_HANDLER_METAMAP.clear();
+    }
+
+    /**
+     * Only for internal test.
+     */
+    static void clearDefaultFallbackMap() {
+        DEFAULT_FALLBACK_METAMAP.clear();
     }
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it
This PR try to fix #3397

### Does this pull request fix one issue?
Yes, #3397 

### Describe how you did it
Like the solution that fix #3386, the issue is caused by trying locate method with incomplete signature. So I rewrite the register map, with a key type that holds all method signature parts.

### Describe how to verify it
Unit tests are provided and passed.

Also, an spring-aop example that fits #3397 case is also provided:

Run module sentinel-demo-annotation-spring-aop, and run following requests (in curl format) to verify that handlers won't conflict with each other. Once the module started, you can call requests in any sequence.

curl -XGET localhost:19966/bar?t=
curl -XGET localhost:19966/foo?t=-1
curl -XGET localhost:19966/count

### Special notes for reviews
