### PR TITLE
Fix sentinel-dashboard.log wrong path problems

### DIFF
--- a/sentinel-dashboard/src/main/resources/application.properties
+++ b/sentinel-dashboard/src/main/resources/application.properties
@@ -8,7 +8,7 @@ server.servlet.session.cookie.name=sentinel_dashboard_cookie
 
 #logging settings
 logging.level.org.springframework.web=INFO
-logging.file.name=${user.home}/logs/csp/sentinel-dashboard.log
+logging.file.name=${csp.sentinel.log.dir}/sentinel-dashboard.log
 logging.pattern.file= %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
 #logging.pattern.console= %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Fix sentinel-dashboard.log wrong path problems while user defined {csp.sentinel.log.dir}.
### Does this pull request fix one issue?
https://github.com/alibaba/Sentinel/issues/3434

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
correct logging.file.name setting in sentinel-dashboard/src/main/resources/application.properties.

### Describe how to verify it
1. add -Dcsp.sentinel.log.dir=/Users/XXXX/logs1 in VM options.
2. While the DashboardApplication startup, the ${user.home}/logs/csp will not be created.

### Special notes for reviews
