### PR TITLE
fix issue 2485 which occur oom when using async servlet request.

### DIFF
--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/AbstractSentinelInterceptor.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/AbstractSentinelInterceptor.java
@@ -52,7 +52,7 @@ import java.util.Objects;
  *     return mav;
  * }
  * </pre>
- * 
+ *
  * @author kaizi2009
  * @since 1.7.1
  */
@@ -68,12 +68,12 @@ public abstract class AbstractSentinelInterceptor implements AsyncHandlerInterce
         AssertUtil.assertNotBlank(config.getRequestAttributeName(), "requestAttributeName should not be blank");
         this.baseWebMvcConfig = config;
     }
-    
+
     /**
      * @param request
      * @param rcKey
      * @param step
-     * @return reference count after increasing (initial value as zero to be increased) 
+     * @return reference count after increasing (initial value as zero to be increased)
      */
     private Integer increaseReference(HttpServletRequest request, String rcKey, int step) {
         Object obj = request.getAttribute(rcKey);
@@ -87,10 +87,10 @@ public abstract class AbstractSentinelInterceptor implements AsyncHandlerInterce
         request.setAttribute(rcKey, newRc);
         return newRc;
     }
-    
+
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
-        throws Exception {
+            throws Exception {
         try {
             String resourceName = getResourceName(request);
 
@@ -101,7 +101,7 @@ public abstract class AbstractSentinelInterceptor implements AsyncHandlerInterce
             if (increaseReference(request, this.baseWebMvcConfig.getRequestRefName(), 1) != 1) {
                 return true;
             }
-            
+
             // Parse the request origin using registered origin parser.
             String origin = parseOrigin(request);
             String contextName = getContextName(request);
@@ -141,27 +141,29 @@ public abstract class AbstractSentinelInterceptor implements AsyncHandlerInterce
     /**
      * When a handler starts an asynchronous request, the DispatcherServlet exits without invoking postHandle and afterCompletion
      * Called instead of postHandle and afterCompletion to exit the context and clean thread-local variables when the handler is being executed concurrently.
-     * @param request the current request
+     *
+     * @param request  the current request
      * @param response the current response
-     * @param handler the handler (or {@link HandlerMethod}) that started async
-     * execution, for type and/or instance examination
+     * @param handler  the handler (or {@link HandlerMethod}) that started async
+     *                 execution, for type and/or instance examination
      */
     @Override
     public void afterConcurrentHandlingStarted(HttpServletRequest request, HttpServletResponse response,
-                                        Object handler) throws Exception {
-        exitContext(request);
+                                               Object handler) throws Exception {
+        exit(request);
     }
+
     @Override
     public void afterCompletion(HttpServletRequest request, HttpServletResponse response,
                                 Object handler, Exception ex) throws Exception {
-        exitContext(request, ex);
+        exit(request, ex);
     }
 
-    private void exitContext(HttpServletRequest request) {
-        exitContext(request, null);
+    private void exit(HttpServletRequest request) {
+        exit(request, null);
     }
 
-    private void exitContext(HttpServletRequest request, Exception ex) {
+    private void exit(HttpServletRequest request, Exception ex) {
         if (increaseReference(request, this.baseWebMvcConfig.getRequestRefName(), -1) != 0) {
             return;
         }
@@ -186,7 +188,7 @@ public abstract class AbstractSentinelInterceptor implements AsyncHandlerInterce
 
     protected Entry getEntryInRequest(HttpServletRequest request, String attrKey) {
         Object entryObject = request.getAttribute(attrKey);
-        return entryObject == null ? null : (Entry)entryObject;
+        return entryObject == null ? null : (Entry) entryObject;
     }
 
     protected void removeEntryInRequest(HttpServletRequest request) {
@@ -212,7 +214,7 @@ public abstract class AbstractSentinelInterceptor implements AsyncHandlerInterce
     }
 
     protected void handleBlockException(HttpServletRequest request, HttpServletResponse response, BlockException e)
-        throws Exception {
+            throws Exception {
         if (baseWebMvcConfig.getBlockExceptionHandler() != null) {
             baseWebMvcConfig.getBlockExceptionHandler().handle(request, response, e);
         } else {

--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/AbstractSentinelInterceptor.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/AbstractSentinelInterceptor.java
@@ -30,7 +30,8 @@ import com.alibaba.csp.sentinel.slots.block.BlockException;
 import com.alibaba.csp.sentinel.util.AssertUtil;
 import com.alibaba.csp.sentinel.util.StringUtil;
 
-import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.AsyncHandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
 
 /**
@@ -52,7 +53,7 @@ import org.springframework.web.servlet.ModelAndView;
  * @author kaizi2009
  * @since 1.7.1
  */
-public abstract class AbstractSentinelInterceptor implements HandlerInterceptor {
+public abstract class AbstractSentinelInterceptor implements AsyncHandlerInterceptor {
 
     public static final String SENTINEL_SPRING_WEB_CONTEXT_NAME = "sentinel_spring_web_context";
     private static final String EMPTY_ORIGIN = "";
@@ -133,13 +134,35 @@ public abstract class AbstractSentinelInterceptor implements HandlerInterceptor 
         return SENTINEL_SPRING_WEB_CONTEXT_NAME;
     }
 
+
+    /**
+     * When a handler starts an asynchronous request, the DispatcherServlet exits without invoking postHandle and afterCompletion
+     * Called instead of postHandle and afterCompletion to exit the context and clean thread-local variables when the handler is being executed concurrently.
+     * @param request the current request
+     * @param response the current response
+     * @param handler the handler (or {@link HandlerMethod}) that started async
+     * execution, for type and/or instance examination
+     */
+    @Override
+    public void afterConcurrentHandlingStarted(HttpServletRequest request, HttpServletResponse response,
+                                        Object handler) throws Exception {
+        exitContext(request);
+    }
     @Override
     public void afterCompletion(HttpServletRequest request, HttpServletResponse response,
                                 Object handler, Exception ex) throws Exception {
+        exitContext(request, ex);
+    }
+
+    private void exitContext(HttpServletRequest request) {
+        exitContext(request, null);
+    }
+
+    private void exitContext(HttpServletRequest request, Exception ex) {
         if (increaseReferece(request, this.baseWebMvcConfig.getRequestRefName(), -1) != 0) {
             return;
         }
-        
+
         Entry entry = getEntryInRequest(request, baseWebMvcConfig.getRequestAttributeName());
         if (entry == null) {
             // should not happen
@@ -147,7 +170,7 @@ public abstract class AbstractSentinelInterceptor implements HandlerInterceptor 
                     getClass().getSimpleName(), baseWebMvcConfig.getRequestAttributeName());
             return;
         }
-        
+
         traceExceptionAndExit(entry, ex);
         removeEntryInRequest(request);
         ContextUtil.exit();

--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/SentinelSpringMvcIntegrationTest.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/SentinelSpringMvcIntegrationTest.java
@@ -15,12 +15,12 @@
  */
 package com.alibaba.csp.sentinel.adapter.spring.webmvc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.alibaba.csp.sentinel.context.ContextUtil;
 import com.alibaba.csp.sentinel.node.ClusterNode;
 import com.alibaba.csp.sentinel.slots.block.RuleConstant;
 import com.alibaba.csp.sentinel.slots.block.flow.FlowRule;
@@ -62,6 +62,18 @@ public class SentinelSpringMvcIntegrationTest {
         ClusterNode cn = ClusterBuilderSlot.getClusterNode(url);
         assertNotNull(cn);
         assertEquals(1, cn.passQps(), 0.01);
+    }
+
+    @Test
+    public void testAsync() throws Exception {
+        String url = "/async";
+        this.mvc.perform(get(url))
+                .andExpect(status().isOk());
+
+        ClusterNode cn = ClusterBuilderSlot.getClusterNode(url);
+        assertNotNull(cn);
+        assertEquals(1, cn.passQps(), 0.01);
+        assertNull(ContextUtil.getContext());
     }
 
     @Test

--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/SentinelSpringMvcIntegrationTest.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/SentinelSpringMvcIntegrationTest.java
@@ -15,7 +15,9 @@
  */
 package com.alibaba.csp.sentinel.adapter.spring.webmvc;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/controller/TestController.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/spring/webmvc/controller/TestController.java
@@ -18,7 +18,9 @@ package com.alibaba.csp.sentinel.adapter.spring.webmvc.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.async.DeferredResult;
 
 /**
  * @author kaizi2009
@@ -50,6 +52,18 @@ public class TestController {
     @GetMapping("/exclude/{id}")
     public String apiExclude(@PathVariable("id") Long id) {
         return "Exclude " + id;
+    }
+
+    @GetMapping("/async")
+    @ResponseBody
+    public DeferredResult<String> distribute() throws Exception{
+        DeferredResult<String> result = new DeferredResult<>();
+
+        Thread thread = new Thread(() -> result.setResult("async result."));
+        thread.start();
+
+        Thread.yield();
+        return result;
     }
 
 }

--- a/sentinel-adapter/sentinel-spring-webmvc-v6x-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/spring/webmvc_v6x/controller/TestController.java
+++ b/sentinel-adapter/sentinel-spring-webmvc-v6x-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/spring/webmvc_v6x/controller/TestController.java
@@ -18,7 +18,9 @@ package com.alibaba.csp.sentinel.adapter.spring.webmvc_v6x.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.async.DeferredResult;
 
 /**
  * @author kaizi2009
@@ -50,6 +52,18 @@ public class TestController {
     @GetMapping("/exclude/{id}")
     public String apiExclude(@PathVariable("id") Long id) {
         return "Exclude " + id;
+    }
+
+    @GetMapping("/async")
+    @ResponseBody
+    public DeferredResult<String> distribute() throws Exception {
+        DeferredResult<String> result = new DeferredResult<>();
+
+        Thread thread = new Thread(() -> result.setResult("async result."));
+        thread.start();
+
+        Thread.yield();
+        return result;
     }
 
 }

--- a/sentinel-demo/sentinel-demo-spring-webmvc/src/main/java/com/alibaba/csp/sentinel/demo/spring/webmvc/controller/WebMvcTestController.java
+++ b/sentinel-demo/sentinel-demo-spring-webmvc/src/main/java/com/alibaba/csp/sentinel/demo/spring/webmvc/controller/WebMvcTestController.java
@@ -27,6 +27,7 @@ import org.springframework.web.servlet.ModelAndView;
 
 /**
  * Test controller
+ *
  * @author kaizi2009
  */
 @Controller
@@ -59,7 +60,7 @@ public class WebMvcTestController {
         doBusiness();
         return "Exclude " + id;
     }
-    
+
     @GetMapping("/forward")
     public ModelAndView apiForward() {
         ModelAndView mav = new ModelAndView();
@@ -69,8 +70,7 @@ public class WebMvcTestController {
 
     @GetMapping("/async")
     @ResponseBody
-    public DeferredResult<String> distribute() throws Exception{
-//        return new DeferredResult<String>(5000L, (Supplier<String>) () -> {doBusiness(); return "err";});
+    public DeferredResult<String> distribute() throws Exception {
         DeferredResult<String> result = new DeferredResult<>(4000L);
 
         Thread thread = new Thread(() -> result.setResult("async result"));
@@ -78,6 +78,7 @@ public class WebMvcTestController {
 
         return result;
     }
+
     private void doBusiness() {
         Random random = new Random(1);
         try {

--- a/sentinel-demo/sentinel-demo-spring-webmvc/src/main/java/com/alibaba/csp/sentinel/demo/spring/webmvc/controller/WebMvcTestController.java
+++ b/sentinel-demo/sentinel-demo-spring-webmvc/src/main/java/com/alibaba/csp/sentinel/demo/spring/webmvc/controller/WebMvcTestController.java
@@ -17,10 +17,10 @@ package com.alibaba.csp.sentinel.demo.spring.webmvc.controller;
 
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
+
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.context.request.async.DeferredResult;
 import org.springframework.web.servlet.ModelAndView;
 
 /**
@@ -65,6 +65,17 @@ public class WebMvcTestController {
         return mav;
     }
 
+    @GetMapping("/async")
+    @ResponseBody
+    public DeferredResult<String> distribute() throws Exception{
+//        return new DeferredResult<String>(5000L, (Supplier<String>) () -> {doBusiness(); return "err";});
+        DeferredResult<String> result = new DeferredResult<>(4000L);
+
+        Thread thread = new Thread(() -> result.setResult("async result"));
+        thread.start();
+
+        return result;
+    }
     private void doBusiness() {
         Random random = new Random(1);
         try {

--- a/sentinel-demo/sentinel-demo-spring-webmvc/src/main/java/com/alibaba/csp/sentinel/demo/spring/webmvc/controller/WebMvcTestController.java
+++ b/sentinel-demo/sentinel-demo-spring-webmvc/src/main/java/com/alibaba/csp/sentinel/demo/spring/webmvc/controller/WebMvcTestController.java
@@ -19,7 +19,9 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.context.request.async.DeferredResult;
 import org.springframework.web.servlet.ModelAndView;
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
There is an issue about it.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #2485

### Describe how you did it
Extends HandlerInterceptor with a callback method invoked after the start of asynchronous request handling.
When a handler starts an asynchronous request, the DispatcherServlet exits without invoking postHandle and afterCompletion. Then it will not exit the context and clean the thread-local variables for the request.  So I extends AsynHandlerInterceptor which is to deal with this situation correctly.

### Describe how to verify it
Debug to check context and ctentry.
Add a unit test for Async servlet request, and check the context after response.

### Special notes for reviews
