### PR TITLE
fix window deprecated check

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/base/LeapArray.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/base/LeapArray.java
@@ -268,7 +268,7 @@ public abstract class LeapArray<T> {
     }
 
     public boolean isWindowDeprecated(long time, WindowWrap<T> windowWrap) {
-        return time - windowWrap.windowStart() > intervalInMs;
+        return time - windowWrap.windowStart() >= intervalInMs;
     }
 
     /**


### PR DESCRIPTION
The logic for determining whether the window has expired is incorrect.

The bucket time range is [startTime, startTime + interval).