### PR TITLE
修复bug: NodeSelectorSlot只会记录初次调用记录

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/nodeselector/NodeSelectorSlot.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/nodeselector/NodeSelectorSlot.java
@@ -163,13 +163,11 @@ public class NodeSelectorSlot extends AbstractLinkedProcessorSlot<Object> {
                     cacheMap.putAll(map);
                     cacheMap.put(context.getName(), node);
                     map = cacheMap;
-                    // Build invocation tree
-                    ((DefaultNode) context.getLastNode()).addChild(node);
                 }
-
             }
         }
-
+        // Build invocation tree
+        ((DefaultNode) context.getLastNode()).addChild(node);
         context.setCurNode(node);
         fireEntry(context, resourceWrapper, node, count, prioritized, args);
     }

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/CtEntryTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/CtEntryTest.java
@@ -4,12 +4,21 @@ import com.alibaba.csp.sentinel.context.Context;
 import com.alibaba.csp.sentinel.context.ContextTestUtil;
 import com.alibaba.csp.sentinel.context.ContextUtil;
 import com.alibaba.csp.sentinel.context.NullContext;
+import com.alibaba.csp.sentinel.node.DefaultNode;
 import com.alibaba.csp.sentinel.node.Node;
 import com.alibaba.csp.sentinel.slotchain.StringResourceWrapper;
 
+import com.alibaba.csp.sentinel.slots.block.BlockException;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
@@ -19,6 +28,51 @@ import static org.mockito.Mockito.when;
  * @author Eric Zhao
  */
 public class CtEntryTest {
+
+    @Test
+    public void testInvoiceTree(){
+        try{
+            ContextUtil.enter("invoice-tree");
+            DefaultNode entranceNode =(DefaultNode) Constants.ROOT.getChildList().stream()
+                    .filter(e -> ((DefaultNode) e).getId().getName().equals("invoice-tree"))
+                    .findFirst().get();
+            Entry a = SphU.entry("A");
+            Entry b = SphU.entry("B");
+            Entry c = SphU.entry("C");
+            c.exit();
+            b.exit();
+            a.exit();
+            // A -> B -> C
+            List<Node> childList = new ArrayList<>(entranceNode.getChildList());
+            assertEquals(1, childList.size());
+            DefaultNode nodeA = (DefaultNode) childList.get(0);
+            assertEquals("A", nodeA.getId().getName());
+            DefaultNode nodeB = (DefaultNode) new ArrayList<>(nodeA.getChildList()).get(0);
+            assertEquals("B", nodeB.getId().getName());
+            DefaultNode nodeC = (DefaultNode) new ArrayList<>(nodeB.getChildList()).get(0);
+            assertEquals("C", nodeC.getId().getName());
+            // A -> C
+            a = SphU.entry("A");
+            Entry d = SphU.entry("D");
+            d.exit();
+            a.exit();
+            childList = new ArrayList<>(entranceNode.getChildList());
+            assertEquals(1, childList.size());
+            nodeA = (DefaultNode) childList.get(0);
+            Map<String, DefaultNode> nodeAChildMap = nodeA.getChildList()
+                    .stream().map(node -> (DefaultNode) node)
+                    .collect(Collectors.toMap(node -> node.getId().getName(), node -> node));
+            assertNotNull(nodeAChildMap.get("B"));
+            assertNotNull(nodeAChildMap.get("D"));
+
+        }catch (BlockException ignore){
+
+        }finally {
+            ContextUtil.exit();
+        }
+
+    }
+
 
     @Test
     public void testExitNotMatchCurEntry() {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
NodeSelectorSlot只会在创建Node时候记录资源的调用关系，这样就只会记录初次调用关系。
eg : A B C三个资源
 ContextUtil.enter("invoice-tree");
// 第一次调用
 Entry a = SphU.entry("A");
 Entry b = SphU.entry("B");
 Entry c = SphU.entry("C");
 c.exit();
 b.exit();
 a.exit();
// 第二次调用
a = SphU.entry("A");
Entry d = SphU.entry("D");
d.exit(); 
a.exit();
仅仅会记录 A -> B -> C 调用关系，， 不会记录 A->D调用关系

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
将NodeSelectorSlot记录调用的代码移出外围执行

### Describe how to verify it
CtEntryTest有相关验证代码

### Special notes for reviews
