### PR TITLE
fix ClusterMetric#tryOccupyNext return the wrong wait seconds problem

### DIFF
--- a/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/statistic/metric/ClusterMetric.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/main/java/com/alibaba/csp/sentinel/cluster/flow/statistic/metric/ClusterMetric.java
@@ -83,7 +83,7 @@ public class ClusterMetric {
         }
         metric.addOccupyPass(acquireCount);
         add(ClusterFlowEvent.WAITING, acquireCount);
-        return 1000 / metric.getSampleCount();
+        return metric.getWindowLengthInMs();
     }
 
     private boolean canOccupy(ClusterFlowEvent event, int acquireCount, double latestQps, double threshold) {

--- a/sentinel-cluster/sentinel-cluster-server-default/src/test/java/com/alibaba/csp/sentinel/cluster/flow/statistic/metric/ClusterMetricTest.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/test/java/com/alibaba/csp/sentinel/cluster/flow/statistic/metric/ClusterMetricTest.java
@@ -36,11 +36,11 @@ public class ClusterMetricTest extends AbstractTimeBasedTest {
             Assert.assertEquals(4, metric.getSum(ClusterFlowEvent.PASS));
             Assert.assertEquals(1, metric.getSum(ClusterFlowEvent.BLOCK));
             Assert.assertEquals(160, metric.getAvg(ClusterFlowEvent.PASS), 0.01);
-            Assert.assertEquals(200, metric.tryOccupyNext(ClusterFlowEvent.PASS, 111, 900));
+            Assert.assertEquals(5, metric.tryOccupyNext(ClusterFlowEvent.PASS, 111, 900));
             metric.add(ClusterFlowEvent.PASS, 1);
             metric.add(ClusterFlowEvent.PASS, 2);
             metric.add(ClusterFlowEvent.PASS, 1);
-            Assert.assertEquals(200, metric.tryOccupyNext(ClusterFlowEvent.PASS, 222, 900));
+            Assert.assertEquals(5, metric.tryOccupyNext(ClusterFlowEvent.PASS, 222, 900));
             metric.add(ClusterFlowEvent.PASS, 1);
             metric.add(ClusterFlowEvent.PASS, 2);
             metric.add(ClusterFlowEvent.PASS, 1);

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/base/LeapArray.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/statistic/base/LeapArray.java
@@ -381,6 +381,14 @@ public abstract class LeapArray<T> {
     }
 
     /**
+     * Get window length of a single bucket in milliseconds.
+     * @return window length in milliseconds
+     */
+    public int getWindowLengthInMs() {
+        return windowLengthInMs;
+    }
+
+    /**
      * Get total interval length of the sliding window in milliseconds.
      *
      * @return interval in second


### PR DESCRIPTION
### Describe what this PR does / why we need it
修复了该问题：原本ClusterMetric#tryOccupyNext返回的等待时间直接使用了1000/sampleCount，但是在在intervalInMs不为1000ms时这不是一个窗口的时间。


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
