### PR TITLE
fix issue 3453: bridge ParamFlow and Authority rules to Nacos correctly (#3453)

### DIFF
--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/datasource/entity/rule/AuthorityRuleCorrectEntity.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/datasource/entity/rule/AuthorityRuleCorrectEntity.java
@@ -1,0 +1,58 @@
+package com.alibaba.csp.sentinel.dashboard.datasource.entity.rule;
+
+import com.alibaba.csp.sentinel.slots.block.Rule;
+
+import java.util.Date;
+
+
+public class AuthorityRuleCorrectEntity implements RuleEntity {
+
+    private Long id;
+    private String app;
+    private String ip;
+    private Integer port;
+    private String limitApp;
+    private String resource;
+    private Date gmtCreate;
+    private Date gmtModified;
+
+    private int strategy = 0;
+
+    @Override
+    public Long getId() { return id; }
+    @Override
+    public void setId(Long id) { this.id = id; }
+
+    @Override
+    public String getApp() { return app; }
+    public void setApp(String app) { this.app = app; }
+
+    @Override
+    public String getIp() { return ip; }
+    public void setIp(String ip) { this.ip = ip; }
+
+    @Override
+    public Integer getPort() { return port; }
+    public void setPort(Integer port) { this.port = port; }
+
+    public String getLimitApp() { return limitApp; }
+    public void setLimitApp(String limitApp) { this.limitApp = limitApp; }
+
+    public String getResource() { return resource; }
+    public void setResource(String resource) { this.resource = resource; }
+
+    @Override
+    public Date getGmtCreate() { return gmtCreate; }
+    public void setGmtCreate(Date gmtCreate) { this.gmtCreate = gmtCreate; }
+
+    public Date getGmtModified() { return gmtModified; }
+    public void setGmtModified(Date gmtModified) { this.gmtModified = gmtModified; }
+
+    public int getStrategy() { return strategy; }
+    public void setStrategy(int strategy) { this.strategy = strategy; }
+
+    @Override
+    public Rule toRule() {
+        return null;
+    }
+}

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/datasource/entity/rule/ParamFlowRuleCorrectEntity.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/datasource/entity/rule/ParamFlowRuleCorrectEntity.java
@@ -1,0 +1,95 @@
+package com.alibaba.csp.sentinel.dashboard.datasource.entity.rule;
+
+import com.alibaba.csp.sentinel.slots.block.Rule;
+import com.alibaba.csp.sentinel.slots.block.flow.param.ParamFlowClusterConfig;
+import com.alibaba.csp.sentinel.slots.block.flow.param.ParamFlowItem;
+
+import java.util.*;
+
+public class ParamFlowRuleCorrectEntity implements RuleEntity {
+
+    private Long id;
+    private String app;
+    private String ip;
+    private Integer port;
+    private String limitApp;
+    private String resource;
+    private Date gmtCreate;
+
+    private int grade = 1;
+    private Integer paramIdx = 0;
+    private double count;
+    private int controlBehavior = 0;
+    private int maxQueueingTimeMs = 0;
+    private int burstCount = 0;
+    private long durationInSec = 1L;
+    private List<ParamFlowItem> paramFlowItemList = new ArrayList<>();
+    private Map<Object, Integer> hotItems = new HashMap<>();
+    private boolean clusterMode = false;
+    private ParamFlowClusterConfig clusterConfig;
+
+    @Override
+    public Long getId() { return id; }
+    @Override
+    public void setId(Long id) { this.id = id; }
+
+    @Override
+    public String getApp() { return app; }
+    public void setApp(String app) { this.app = app; }
+
+    @Override
+    public String getIp() { return ip; }
+    public void setIp(String ip) { this.ip = ip; }
+
+    @Override
+    public Integer getPort() { return port; }
+    public void setPort(Integer port) { this.port = port; }
+
+    public String getLimitApp() { return limitApp; }
+    public void setLimitApp(String limitApp) { this.limitApp = limitApp; }
+
+    public String getResource() { return resource; }
+    public void setResource(String resource) { this.resource = resource; }
+
+    @Override
+    public Date getGmtCreate() { return gmtCreate; }
+    public void setGmtCreate(Date gmtCreate) { this.gmtCreate = gmtCreate; }
+
+    public int getGrade() { return grade; }
+    public void setGrade(int grade) { this.grade = grade; }
+
+    public Integer getParamIdx() { return paramIdx; }
+    public void setParamIdx(Integer paramIdx) { this.paramIdx = paramIdx; }
+
+    public double getCount() { return count; }
+    public void setCount(double count) { this.count = count; }
+
+    public int getControlBehavior() { return controlBehavior; }
+    public void setControlBehavior(int controlBehavior) { this.controlBehavior = controlBehavior; }
+
+    public int getMaxQueueingTimeMs() { return maxQueueingTimeMs; }
+    public void setMaxQueueingTimeMs(int maxQueueingTimeMs) { this.maxQueueingTimeMs = maxQueueingTimeMs; }
+
+    public int getBurstCount() { return burstCount; }
+    public void setBurstCount(int burstCount) { this.burstCount = burstCount; }
+
+    public long getDurationInSec() { return durationInSec; }
+    public void setDurationInSec(long durationInSec) { this.durationInSec = durationInSec; }
+
+    public List<ParamFlowItem> getParamFlowItemList() { return paramFlowItemList; }
+    public void setParamFlowItemList(List<ParamFlowItem> paramFlowItemList) { this.paramFlowItemList = paramFlowItemList; }
+
+    public Map<Object, Integer> getHotItems() { return hotItems; }
+    public void setHotItems(Map<Object, Integer> hotItems) { this.hotItems = hotItems; }
+
+    public boolean isClusterMode() { return clusterMode; }
+    public void setClusterMode(boolean clusterMode) { this.clusterMode = clusterMode; }
+
+    public ParamFlowClusterConfig getClusterConfig() { return clusterConfig; }
+    public void setClusterConfig(ParamFlowClusterConfig clusterConfig) { this.clusterConfig = clusterConfig; }
+
+    @Override
+    public Rule toRule() {
+        return null;
+    }
+}

--- a/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/rule/nacos/AuthorityRuleNacosProvider.java
+++ b/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/rule/nacos/AuthorityRuleNacosProvider.java
@@ -1,0 +1,46 @@
+package com.alibaba.csp.sentinel.dashboard.rule.nacos;
+
+import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.AuthorityRuleCorrectEntity;
+import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.AuthorityRuleEntity;
+import com.alibaba.csp.sentinel.dashboard.rule.DynamicRuleProvider;
+import com.alibaba.csp.sentinel.datasource.Converter;
+import com.alibaba.csp.sentinel.slots.block.authority.AuthorityRule;
+import com.alibaba.csp.sentinel.util.StringUtil;
+import com.alibaba.nacos.api.config.ConfigService;
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component("authorityRuleNacosProvider")
+public class AuthorityRuleNacosProvider implements DynamicRuleProvider<List<AuthorityRuleEntity>> {
+
+    @Autowired
+    private ConfigService configService;
+    @Autowired
+    private Converter<String, List<AuthorityRuleCorrectEntity>> converter;
+
+    @Override
+    public List<AuthorityRuleEntity> getRules(String appName) throws Exception {
+        String rules = configService.getConfig(
+                appName + NacosConfigUtil.AUTHORITY_DATA_ID_POSTFIX,
+                NacosConfigUtil.GROUP_ID, 3000);
+        if (StringUtil.isEmpty(rules)) {
+            return new ArrayList<>();
+        }
+        List<AuthorityRuleCorrectEntity> list = converter.convert(rules);
+        return list.stream().map(e -> {
+            AuthorityRule rule = new AuthorityRule();
+            BeanUtils.copyProperties(e, rule);
+            AuthorityRuleEntity entity = AuthorityRuleEntity.fromAuthorityRule(
+                    appName, e.getIp(), e.getPort(), rule);
+            entity.setId(e.getId());
+            entity.setGmtCreate(e.getGmtCreate());
+            entity.setGmtModified(e.getGmtModified());
+            return entity;
+        }).collect(Collectors.toList());
+    }
+}

--- a/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/rule/nacos/AuthorityRuleNacosPublisher.java
+++ b/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/rule/nacos/AuthorityRuleNacosPublisher.java
@@ -1,0 +1,41 @@
+package com.alibaba.csp.sentinel.dashboard.rule.nacos;
+
+import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.AuthorityRuleCorrectEntity;
+import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.AuthorityRuleEntity;
+import com.alibaba.csp.sentinel.dashboard.rule.DynamicRulePublisher;
+import com.alibaba.csp.sentinel.datasource.Converter;
+import com.alibaba.csp.sentinel.util.AssertUtil;
+import com.alibaba.nacos.api.config.ConfigService;
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component("authorityRuleNacosPublisher")
+public class AuthorityRuleNacosPublisher implements DynamicRulePublisher<List<AuthorityRuleEntity>> {
+
+    @Autowired
+    private ConfigService configService;
+    @Autowired
+    private Converter<List<AuthorityRuleCorrectEntity>, String> converter;
+
+    @Override
+    public void publish(String app, List<AuthorityRuleEntity> rules) throws Exception {
+        AssertUtil.notEmpty(app, "app name cannot be empty");
+        if (rules == null) {
+            return;
+        }
+        List<AuthorityRuleCorrectEntity> list = rules.stream().map(r -> {
+            AuthorityRuleCorrectEntity e = new AuthorityRuleCorrectEntity();
+            BeanUtils.copyProperties(r, e);
+            return e;
+        }).collect(Collectors.toList());
+
+        configService.publishConfig(
+                app + NacosConfigUtil.AUTHORITY_DATA_ID_POSTFIX,
+                NacosConfigUtil.GROUP_ID,
+                converter.convert(list));
+    }
+}

--- a/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/rule/nacos/NacosConfig.java
+++ b/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/rule/nacos/NacosConfig.java
@@ -1,22 +1,9 @@
-/*
- * Copyright 1999-2018 Alibaba Group Holding Ltd.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.alibaba.csp.sentinel.dashboard.rule.nacos;
 
 import java.util.List;
 
+import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.AuthorityRuleCorrectEntity;
+import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.ParamFlowRuleCorrectEntity;
 import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.FlowRuleEntity;
 import com.alibaba.csp.sentinel.datasource.Converter;
 import com.alibaba.fastjson.JSON;
@@ -26,10 +13,6 @@ import com.alibaba.nacos.api.config.ConfigService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-/**
- * @author Eric Zhao
- * @since 1.4.0
- */
 @Configuration
 public class NacosConfig {
 
@@ -41,6 +24,26 @@ public class NacosConfig {
     @Bean
     public Converter<String, List<FlowRuleEntity>> flowRuleEntityDecoder() {
         return s -> JSON.parseArray(s, FlowRuleEntity.class);
+    }
+
+    @Bean
+    public Converter<List<ParamFlowRuleCorrectEntity>, String> paramFlowRuleCorrectEntityEncoder() {
+        return JSON::toJSONString;
+    }
+
+    @Bean
+    public Converter<String, List<ParamFlowRuleCorrectEntity>> paramFlowRuleCorrectEntityDecoder() {
+        return s -> JSON.parseArray(s, ParamFlowRuleCorrectEntity.class);
+    }
+
+    @Bean
+    public Converter<List<AuthorityRuleCorrectEntity>, String> authorityRuleCorrectEntityEncoder() {
+        return JSON::toJSONString;
+    }
+
+    @Bean
+    public Converter<String, List<AuthorityRuleCorrectEntity>> authorityRuleCorrectEntityDecoder() {
+        return s -> JSON.parseArray(s, AuthorityRuleCorrectEntity.class);
     }
 
     @Bean

--- a/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/rule/nacos/NacosConfigUtil.java
+++ b/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/rule/nacos/NacosConfigUtil.java
@@ -26,6 +26,7 @@ public final class NacosConfigUtil {
     public static final String FLOW_DATA_ID_POSTFIX = "-flow-rules";
     public static final String PARAM_FLOW_DATA_ID_POSTFIX = "-param-rules";
     public static final String CLUSTER_MAP_DATA_ID_POSTFIX = "-cluster-map";
+    public static final String AUTHORITY_DATA_ID_POSTFIX    = "-authority-rules";
 
     /**
      * cc for `cluster-client`

--- a/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/rule/nacos/ParamFlowRuleNacosProvider.java
+++ b/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/rule/nacos/ParamFlowRuleNacosProvider.java
@@ -1,0 +1,45 @@
+package com.alibaba.csp.sentinel.dashboard.rule.nacos;
+
+import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.ParamFlowRuleCorrectEntity;
+import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.ParamFlowRuleEntity;
+import com.alibaba.csp.sentinel.dashboard.rule.DynamicRuleProvider;
+import com.alibaba.csp.sentinel.datasource.Converter;
+import com.alibaba.csp.sentinel.slots.block.flow.param.ParamFlowRule;
+import com.alibaba.csp.sentinel.util.StringUtil;
+import com.alibaba.nacos.api.config.ConfigService;
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component("paramFlowRuleNacosProvider")
+public class ParamFlowRuleNacosProvider implements DynamicRuleProvider<List<ParamFlowRuleEntity>> {
+
+    @Autowired
+    private ConfigService configService;
+    @Autowired
+    private Converter<String, List<ParamFlowRuleCorrectEntity>> converter;
+
+    @Override
+    public List<ParamFlowRuleEntity> getRules(String appName) throws Exception {
+        String rules = configService.getConfig(
+                appName + NacosConfigUtil.PARAM_FLOW_DATA_ID_POSTFIX,
+                NacosConfigUtil.GROUP_ID, 3000);
+        if (StringUtil.isEmpty(rules)) {
+            return new ArrayList<>();
+        }
+        List<ParamFlowRuleCorrectEntity> list = converter.convert(rules);
+        return list.stream().map(e -> {
+            ParamFlowRule rule = new ParamFlowRule();
+            BeanUtils.copyProperties(e, rule);
+            ParamFlowRuleEntity entity = ParamFlowRuleEntity.fromParamFlowRule(
+                    appName, e.getIp(), e.getPort(), rule);
+            entity.setId(e.getId());
+            entity.setGmtCreate(e.getGmtCreate());
+            return entity;
+        }).collect(Collectors.toList());
+    }
+}

--- a/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/rule/nacos/ParamFlowRuleNacosPublisher.java
+++ b/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/rule/nacos/ParamFlowRuleNacosPublisher.java
@@ -1,0 +1,41 @@
+package com.alibaba.csp.sentinel.dashboard.rule.nacos;
+
+import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.ParamFlowRuleCorrectEntity;
+import com.alibaba.csp.sentinel.dashboard.datasource.entity.rule.ParamFlowRuleEntity;
+import com.alibaba.csp.sentinel.dashboard.rule.DynamicRulePublisher;
+import com.alibaba.csp.sentinel.datasource.Converter;
+import com.alibaba.csp.sentinel.util.AssertUtil;
+import com.alibaba.nacos.api.config.ConfigService;
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component("paramFlowRuleNacosPublisher")
+public class ParamFlowRuleNacosPublisher implements DynamicRulePublisher<List<ParamFlowRuleEntity>> {
+
+    @Autowired
+    private ConfigService configService;
+    @Autowired
+    private Converter<List<ParamFlowRuleCorrectEntity>, String> converter;
+
+    @Override
+    public void publish(String app, List<ParamFlowRuleEntity> rules) throws Exception {
+        AssertUtil.notEmpty(app, "app name cannot be empty");
+        if (rules == null) {
+            return;
+        }
+        List<ParamFlowRuleCorrectEntity> list = rules.stream().map(r -> {
+            ParamFlowRuleCorrectEntity e = new ParamFlowRuleCorrectEntity();
+            BeanUtils.copyProperties(r, e);
+            return e;
+        }).collect(Collectors.toList());
+
+        configService.publishConfig(
+                app + NacosConfigUtil.PARAM_FLOW_DATA_ID_POSTFIX,
+                NacosConfigUtil.GROUP_ID,
+                converter.convert(list));
+    }
+}


### PR DESCRIPTION

This pull request fixes issue #3453 by ensuring that ParamFlow and Authority rules published by Sentinel‑Dashboard to Nacos can be correctly parsed by Sentinel clients. In version 1.8.8 the dashboard’s entity classes and the core rule classes became out of sync, causing clients to fail to deserialize JSON and never load the rules.

What was changed:
1. Introduced two “CorrectEntity” classes  
   - `ParamFlowRuleCorrectEntity`  
   - `AuthorityRuleCorrectEntity`  
   These mirror the fields of the core `ParamFlowRule` and `AuthorityRule` types exactly.  
2. Registered new FastJSON Converter beans in `NacosConfig` for  
   - `String ↔ List<ParamFlowRuleCorrectEntity>`  
   - `String ↔ List<AuthorityRuleCorrectEntity>`  
3. Added dedicated Nacos provider & publisher components for both rule types:  
   - `ParamFlowRuleNacosProvider` / `ParamFlowRuleNacosPublisher`  
   - `AuthorityRuleNacosProvider` / `AuthorityRuleNacosPublisher`  
   These bridge between the CorrectEntity JSON and the original Dashboard `RuleEntity` types via `BeanUtils.copyProperties`.

### Describe what this PR does / why we need it
Sentinel‑Dashboard and Sentinel clients must share a consistent JSON schema when persisting rules in Nacos. After upgrading to 1.8.8, the Dashboard’s entity definitions drifted from the core rule classes, breaking client‑side deserialization. This PR restores compatibility so that rules published via Dashboard are correctly loaded by any Sentinel client.

### Does this pull request fix one issue?
Fixes #3453

### Describe how you did it
- Added two “CorrectEntity” classes that exactly match the core rule classes’ fields.  
- Registered FastJSON converters in `NacosConfig` for the new entity lists.  
- Implemented provider & publisher beans that convert between Dashboard entities and core rule types at runtime.

### Describe how to verify it
1. Start Sentinel‑Dashboard (v1.8.8+) and connect it to a Nacos instance.  
2. Create / update ParamFlow and Authority rules via the Dashboard UI.  
3. On a Sentinel client, load rules from Nacos and assert that:  
   - No JSON parsing errors occur.  
   - The rules take effect as expected (e.g. QPS limits and authority checks).

### Special notes for reviews
- Backward compatibility is preserved: older clients (pre‑1.8.8) will still see the old JSON structure.  
- No changes to other rule types or transports.  
- All new classes and beans are isolated under the `sentinel-dashboard` Nacos extension.

Thank you for your time and feedback!
