### PR TITLE
fix(transport): fix unclosed quote in Endpoint.toString()

### DIFF
--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/endpoint/Endpoint.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/endpoint/Endpoint.java
@@ -44,6 +44,6 @@ public class Endpoint {
 
     @Override
     public String toString() {
-        return "Endpoint{" + "protocol=" + protocol + ", host='" + host + ", port=" + port + '}';
+        return "Endpoint{" + "protocol=" + protocol + ", host=" + host + ", port=" + port + '}';
     }
 }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

This PR fixes a malformed `toString()` output in the `Endpoint` class, where the `host` field was printed with an unclosed single quote (e.g., `host='localhost, port=8900}`). The unmatched quote causes confusing log messages. This change removes the stray quote for a clean format like `host=localhost`.

### Does this pull request fix one issue?

Fixes #3573

### Describe how you did it

Removed the opening single quote before the `host` value in the `toString()` method of `com.alibaba.csp.sentinel.transport.heartbeat.Endpoint`, so the field is now printed without quotes.

### Describe how to verify it

1. Build with `mvn clean package`.
2. Run a demo that connects to Sentinel Dashboard (e.g., `sentinel-demo-basic`).
3. Check logs during startup or heartbeat — the output should be:

    Endpoint{protocol=HTTP, host=localhost, port=8900}

No unmatched quotes appear.

### Special notes for reviews

- Purely cosmetic; no functional impact.
- Safe to omit quotes since `host` is typically a hostname or IP without special characters.
- Consistent with the style of other fields (`protocol`, `port`) which are also unquoted.