### PR TITLE
fix: Endpoint#toString host formatting; add Endpoint unit test

### DIFF
--- a/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/endpoint/Endpoint.java
+++ b/sentinel-transport/sentinel-transport-common/src/main/java/com/alibaba/csp/sentinel/transport/endpoint/Endpoint.java
@@ -44,6 +44,6 @@ public class Endpoint {
 
     @Override
     public String toString() {
-        return "Endpoint{" + "protocol=" + protocol + ", host='" + host + ", port=" + port + '}';
+        return "Endpoint{" + "protocol=" + protocol + ", host='" + host + '\'' + ", port=" + port + '}';
     }
 }

--- a/sentinel-transport/sentinel-transport-common/src/test/java/com/alibaba/csp/sentinel/transport/endpoint/EndpointTest.java
+++ b/sentinel-transport/sentinel-transport-common/src/test/java/com/alibaba/csp/sentinel/transport/endpoint/EndpointTest.java
@@ -1,0 +1,32 @@
+package com.alibaba.csp.sentinel.transport.endpoint;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class EndpointTest {
+    @Test
+    public void testToStringIPv4() {
+        Endpoint e = new Endpoint(Protocol.HTTP, "127.0.0.1", 8080);
+        assertEquals("Endpoint{protocol=HTTP, host='127.0.0.1', port=8080}", e.toString());
+    }
+
+    @Test
+    public void testToStringIPv6() {
+        Endpoint e = new Endpoint(Protocol.HTTP, "fe80::1", 8080);
+        // Endpoint#toString doesn't modify the host, so IPv6 remains unbracketed
+        assertEquals("Endpoint{protocol=HTTP, host='fe80::1', port=8080}", e.toString());
+    }
+
+    @Test
+    public void testToStringAlreadyBracketed() {
+        Endpoint e = new Endpoint(Protocol.HTTPS, "[fe80::2]", 443);
+        assertEquals("Endpoint{protocol=HTTPS, host='[fe80::2]', port=443}", e.toString());
+    }
+
+    @Test
+    public void testToStringNullHost() {
+        Endpoint e = new Endpoint(Protocol.HTTP, null, 0);
+        assertEquals("Endpoint{protocol=HTTP, host='null', port=0}", e.toString());
+    }
+}


### PR DESCRIPTION
### What does this PR do 
修复 `Endpoint#toString()` 在打印 `host` 字段时缺少右单引号的 bug（会输出成 `host='localhost, port=8900}`），导致日志或输出格式不规范。现已修复为：`host='localhost'`。同时新增单元测试 `EndpointTest`，确保该格式不会回归。

### 这个 PR 是否修复一个 issue？
Fixes #3573

### 实现方式
- 修改 `Endpoint#toString()`：补上 host 的闭合单引号。
- 新增测试 `sentinel-transport/sentinel-transport-common/src/test/java/com/alibaba/csp/sentinel/transport/endpoint/EndpointTest.java`，断言返回字符串包含闭合单引号。

### How to verify it
1. 在本地确认：
   - `mvn -pl sentinel-transport/sentinel-transport-common -am -DskipTests=false test`
   - 或完整构建：
     `mvn -DskipTests=false clean verify`
2. 在运行后，测试 `EndpointTest` 的断言应通过：
   - 期望: `Endpoint{protocol=HTTP, host='localhost', port=8900}`

### Special notes for reviewers
- 本 PR 仅包含代码与新增单元测试，不包含文档修复（README 表格样式）。我会把文档修复拆为单独的 PR（fix/docs-table-style），以避免混淆和便于审查。
- 说明：CI 的 `document-lint` 工作流会对仓库中的 Markdown 做检查。如果你在 CI 看到 `document-lint` 失败，请放心 — 我会后续单独提交 docs PR 来处理 MD060 等问题（或我可以在需要时把 docs 改动一并提上 PR）。
