### PR TITLE
docs: normalize README table style (MD060) + add .gitignore ignore node_modules/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ Thumbs.db
 
 # flattened pom file
 .flattened-pom.xml
+node_modules/

--- a/sentinel-adapter/sentinel-apache-httpclient-adapter/README.md
+++ b/sentinel-adapter/sentinel-apache-httpclient-adapter/README.md
@@ -32,11 +32,11 @@ CloseableHttpClient httpclient = builder.build();
 
 - `SentinelApacheHttpClientConfig` configuration:
 
-| name | description | type | default value |
-|------|------------|------|-------|
-| prefix | customize resource prefix | `String` | `httpclient:` |
-| extractor | customize resource extractor | `ApacheHttpClientResourceExtractor` | `DefaultApacheHttpClientResourceExtractor` |
-| fallback | handle request when it is blocked | `ApacheHttpClientFallback` | `DefaultApacheHttpClientFallback` |
+ | name | description | type | default value | 
+ | ------ | ------------ | ------ | ------- | 
+ | prefix | customize resource prefix | `String` | `httpclient:` | 
+ | extractor | customize resource extractor | `ApacheHttpClientResourceExtractor` | `DefaultApacheHttpClientResourceExtractor` | 
+ | fallback | handle request when it is blocked | `ApacheHttpClientFallback` | `DefaultApacheHttpClientFallback` | 
 
 ### extractor (resource extractor)
 

--- a/sentinel-adapter/sentinel-okhttp-adapter/README.md
+++ b/sentinel-adapter/sentinel-okhttp-adapter/README.md
@@ -26,11 +26,11 @@ OkHttpClient client = new OkHttpClient.Builder()
 
 `SentinelOkHttpConfig` configuration:
 
-| name | description | type | default value |
-|------|------------|------|-------|
-| resourcePrefix | customized resource name prefix | `String` | `okhttp:` |
-| resourceExtractor | customized resource extractor | `OkHttpResourceExtractor` | `DefaultOkHttpResourceExtractor` |
-| fallback | handle request when it is blocked | `OkHttpFallback` | `DefaultOkHttpFallback` |
+ | name | description | type | default value | 
+ | ------ | ------------ | ------ | ------- | 
+ | resourcePrefix | customized resource name prefix | `String` | `okhttp:` | 
+ | resourceExtractor | customized resource extractor | `OkHttpResourceExtractor` | `DefaultOkHttpResourceExtractor` | 
+ | fallback | handle request when it is blocked | `OkHttpFallback` | `DefaultOkHttpFallback` | 
 
 ### Resource Extractor
 

--- a/sentinel-adapter/sentinel-spring-webmvc-adapter/README.md
+++ b/sentinel-adapter/sentinel-spring-webmvc-adapter/README.md
@@ -91,23 +91,23 @@ config.setBlockExceptionHandler((request, response, e) -> {
 
 - Common configuration in `SentinelWebMvcConfig` and `SentinelWebMvcTotalConfig`:
 
-| name | description | type | default value |
-|------|------------|------|-------|
-| `blockExceptionHandler`| The handler that handles the block request | `BlockExceptionHandler` | null (throw out the BlockException) |
-| `originParser` | Extracting request origin (e.g. IP or appName from HTTP Header) from HTTP request | `RequestOriginParser` | - |
+ | name | description | type | default value | 
+ | ------ | ------------ | ------ | ------- | 
+ | `blockExceptionHandler` | The handler that handles the block request | `BlockExceptionHandler` | null (throw out the BlockException) | 
+ | `originParser` | Extracting request origin (e.g. IP or appName from HTTP Header) from HTTP request | `RequestOriginParser` | - | 
 
 - `SentinelWebMvcConfig` configuration:
 
-| name | description | type | default value |
-|------|------------|------|-------|
-| urlCleaner | The `UrlCleaner` interface is designed for clean and unify the URL resource. | `UrlCleaner` | - |
-| requestAttributeName | Attribute key in request used by Sentinel (internal) | `String` | `$$sentinel_spring_web_entry_attr` |
-| httpMethodSpecify | Specify whether the URL resource name should contain the HTTP method prefix (e.g. `POST:`). | `boolean` | `false` |
-| webContextUnify | Specify whether unify web context(i.e. use the default context name). | `boolean` | `true` |
+ | name | description | type | default value | 
+ | ------ | ------------ | ------ | ------- | 
+ | urlCleaner | The `UrlCleaner` interface is designed for clean and unify the URL resource. | `UrlCleaner` | - | 
+ | requestAttributeName | Attribute key in request used by Sentinel (internal) | `String` | `$$sentinel_spring_web_entry_attr` | 
+ | httpMethodSpecify | Specify whether the URL resource name should contain the HTTP method prefix (e.g. `POST:`). | `boolean` | `false` | 
+ | webContextUnify | Specify whether unify web context(i.e. use the default context name). | `boolean` | `true` | 
 
 - `SentinelWebMvcTotalConfig` configuration:
 
-| name | description | type | default value |
-|------|------------|------|-------|
-| totalResourceName | The resource name in `SentinelTotalInterceptor` | `String` | `spring-mvc-total-url-request` |
-| requestAttributeName | Attribute key in request used by Sentinel (internal) | `String` | `$$sentinel_spring_web_total_entry_attr` |
+ | name | description | type | default value | 
+ | ------ | ------------ | ------ | ------- | 
+ | totalResourceName | The resource name in `SentinelTotalInterceptor` | `String` | `spring-mvc-total-url-request` | 
+ | requestAttributeName | Attribute key in request used by Sentinel (internal) | `String` | `$$sentinel_spring_web_total_entry_attr` | 

--- a/sentinel-adapter/sentinel-spring-webmvc-v6x-adapter/README.md
+++ b/sentinel-adapter/sentinel-spring-webmvc-v6x-adapter/README.md
@@ -85,23 +85,23 @@ config.setBlockExceptionHandler((request, response, e) -> {
 
 - Common configuration in `SentinelWebMvcConfig` and `SentinelWebMvcTotalConfig`:
 
-| name | description | type | default value |
-|------|------------|------|-------|
-| `blockExceptionHandler`| The handler that handles the block request | `BlockExceptionHandler` | null (throw out the BlockException) |
-| `originParser` | Extracting request origin (e.g. IP or appName from HTTP Header) from HTTP request | `RequestOriginParser` | - |
+ | name | description | type | default value | 
+ | ------ | ------------ | ------ | ------- | 
+ | `blockExceptionHandler` | The handler that handles the block request | `BlockExceptionHandler` | null (throw out the BlockException) | 
+ | `originParser` | Extracting request origin (e.g. IP or appName from HTTP Header) from HTTP request | `RequestOriginParser` | - | 
 
 - `SentinelWebMvcConfig` configuration:
 
-| name | description | type | default value |
-|------|------------|------|-------|
-| urlCleaner | The `UrlCleaner` interface is designed for clean and unify the URL resource. | `UrlCleaner` | - |
-| requestAttributeName | Attribute key in request used by Sentinel (internal) | `String` | `$$sentinel_spring_web_entry_attr` |
-| httpMethodSpecify | Specify whether the URL resource name should contain the HTTP method prefix (e.g. `POST:`). | `boolean` | `false` |
-| webContextUnify | Specify whether unify web context(i.e. use the default context name). | `boolean` | `true` |
+ | name | description | type | default value | 
+ | ------ | ------------ | ------ | ------- | 
+ | urlCleaner | The `UrlCleaner` interface is designed for clean and unify the URL resource. | `UrlCleaner` | - | 
+ | requestAttributeName | Attribute key in request used by Sentinel (internal) | `String` | `$$sentinel_spring_web_entry_attr` | 
+ | httpMethodSpecify | Specify whether the URL resource name should contain the HTTP method prefix (e.g. `POST:`). | `boolean` | `false` | 
+ | webContextUnify | Specify whether unify web context(i.e. use the default context name). | `boolean` | `true` | 
 
 - `SentinelWebMvcTotalConfig` configuration:
 
-| name | description | type | default value |
-|------|------------|------|-------|
-| totalResourceName | The resource name in `SentinelTotalInterceptor` | `String` | `spring-mvc-total-url-request` |
-| requestAttributeName | Attribute key in request used by Sentinel (internal) | `String` | `$$sentinel_spring_web_total_entry_attr` |
+ | name | description | type | default value | 
+ | ------ | ------------ | ------ | ------- | 
+ | totalResourceName | The resource name in `SentinelTotalInterceptor` | `String` | `spring-mvc-total-url-request` | 
+ | requestAttributeName | Attribute key in request used by Sentinel (internal) | `String` | `$$sentinel_spring_web_total_entry_attr` | 

--- a/sentinel-cluster/sentinel-cluster-server-envoy-rls/README.md
+++ b/sentinel-cluster/sentinel-cluster-server-envoy-rls/README.md
@@ -50,11 +50,11 @@ We may also retrieve the converted `FlowRule` via the command API `localhost:871
 
 The configuration list:
 
-| Item (env) | Item (JVM property) | Description | Default Value | Required |
-|--------|--------|--------|--------|--------|
-| `SENTINEL_RLS_GRPC_PORT` | `csp.sentinel.grpc.server.port` | The RLS gRPC server port | **10240** | false |
-| `SENTINEL_RLS_RULE_FILE_PATH` | `csp.sentinel.rls.rule.file` | The path of the RLS rule yaml file | - | **true** |
-| `SENTINEL_RLS_ACCESS_LOG` | - | Whether to enable the access log (`on` for enable) | off | false |
+ | Item (env) | Item (JVM property) | Description | Default Value | Required | 
+ | -------- | -------- | -------- | -------- | -------- | 
+ | `SENTINEL_RLS_GRPC_PORT` | `csp.sentinel.grpc.server.port` | The RLS gRPC server port | **10240** | false | 
+ | `SENTINEL_RLS_RULE_FILE_PATH` | `csp.sentinel.rls.rule.file` | The path of the RLS rule yaml file | - | **true** | 
+ | `SENTINEL_RLS_ACCESS_LOG` | - | Whether to enable the access log (`on` for enable) | off | false | 
 
 ## Samples
 

--- a/sentinel-dashboard/README.md
+++ b/sentinel-dashboard/README.md
@@ -31,10 +31,10 @@ java -Dserver.port=8080 \
 为便于演示，我们对控制台本身加入了流量控制功能，具体做法是引入 Sentinel 提供的 `CommonFilter` 这个 Servlet Filter。
 上述 JVM 参数的含义是：
 
-| 参数 | 作用 |
-|--------|--------|
-|`-Dcsp.sentinel.dashboard.server=localhost:8080`|向 Sentinel 接入端指定控制台的地址|
-|`-Dproject.name=sentinel-dashboard`|向 Sentinel 指定应用名称，比如上面对应的应用名称就为 `sentinel-dashboard`|
+ | 参数 | 作用 | 
+ | -------- | -------- | 
+ | `-Dcsp.sentinel.dashboard.server=localhost:8080` | 向 Sentinel 接入端指定控制台的地址 | 
+ | `-Dproject.name=sentinel-dashboard` | 向 Sentinel 指定应用名称，比如上面对应的应用名称就为 `sentinel-dashboard` | 
 
 全部的配置项可以参考 [启动配置项文档](https://github.com/alibaba/Sentinel/wiki/%E5%90%AF%E5%8A%A8%E9%85%8D%E7%BD%AE%E9%A1%B9)。
 

--- a/sentinel-extension/sentinel-parameter-flow-control/README.md
+++ b/sentinel-extension/sentinel-parameter-flow-control/README.md
@@ -48,12 +48,12 @@ ParamFlowRuleManager.loadRules(Collections.singletonList(rule));
 
 The description for fields of `ParamFlowRule`:
 
-| Field | Description | Default |
-| :----: | :----| :----|
-| resource| resource name (**required**) ||
-| count | flow control threshold (**required**) ||
-| grade | metric type (QPS or thread count) | QPS mode |
-| paramIdx | the index of provided parameter in `SphU.entry(xxx, args)` (**required**) ||
-| paramFlowItemList | the exception items of parameter; you can set threshold to a specific parameter value ||
+ | Field | Description | Default | 
+ | :----: | :---- | :---- | 
+ | resource | resource name (**required**) |  | 
+ | count | flow control threshold (**required**) |  | 
+ | grade | metric type (QPS or thread count) | QPS mode | 
+ | paramIdx | the index of provided parameter in `SphU.entry(xxx, args)` (**required**) |  | 
+ | paramFlowItemList | the exception items of parameter; you can set threshold to a specific parameter value |  | 
 
 Now the parameter flow control rules will take effect.


### PR DESCRIPTION


What this PR does ：

    统一 README 的表格格式以满足 markdown lint（MD060）CI 校验。
    添加 [.gitignore](https://supreme-space-carnival-v6564p6x7rvrhxjpw.github.dev/) 中 node_modules/（避免本地 node deps 被误提交）。
    使用脚本 fix_md_tables.py 批量调整文件，具体 README 的改动为尽量把“表格单元格两端的空格移除/标准化”。这些改动只涉及格式，不改动代码或示例逻辑。

Does this PR fix one issue?

   Fixes #3573（Fixes: CI document-lint MD060）

How I did it ：

    增加 Python 自动化脚本：fix_md_tables.py（运行该脚本对 README 文件进行格式标准化）
    对 README 中表格进行修复（统一空格和管道的样式）
    在仓库根 [.gitignore](https://supreme-space-carnival-v6564p6x7rvrhxjpw.github.dev/) 中加入 node_modules/

How to verify ：

    使用 markdownlint 检查：

    推送到 CI，确保 document-lint 工作流（document-lint.yml）中 MD060 不再报错。

Special notes for reviews:

    该 PR 仅做文档样式优化，避免干扰功能/测试变更的review。
   
