### PR TITLE
chore: bump version to 1.8.10-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     </issueManagement>
 
     <properties>
-        <revision>1.8.9</revision>
+        <revision>1.8.10-SNAPSHOT</revision>
         <!-- Compile libs -->
         <fastjson.version>1.2.83_noneautotype</fastjson.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>


### PR DESCRIPTION
## Summary

- Bump the `revision` property in root `pom.xml` from `1.8.9` to `1.8.10-SNAPSHOT` for the next development iteration.
- After the 1.8.9 release, several PRs have been merged (#3565, #3569, #3578, #3583, #3600, #3602, etc.) but the development version was not updated accordingly.

## Changes

- `pom.xml`: `<revision>1.8.9</revision>` → `<revision>1.8.10-SNAPSHOT</revision>`


Made with [Cursor](https://cursor.com)