### PR TITLE
fix(dashboard): reset field values when switching circuit breaker strategy

### DIFF
--- a/sentinel-dashboard/src/main/webapp/resources/app/scripts/controllers/degrade.js
+++ b/sentinel-dashboard/src/main/webapp/resources/app/scripts/controllers/degrade.js
@@ -83,6 +83,11 @@ app.controller('DegradeCtl', ['$scope', '$stateParams', 'DegradeService', 'ngDia
       });
     };
 
+    $scope.onGradeChange = function () {
+      $scope.currentRule.count = undefined;
+      $scope.currentRule.slowRatioThreshold = undefined;
+    };
+
     $scope.saveRule = function () {
       if (!DegradeService.checkRuleValid($scope.currentRule)) {
         return;

--- a/sentinel-dashboard/src/main/webapp/resources/app/views/dialog/degrade-rule-dialog.html
+++ b/sentinel-dashboard/src/main/webapp/resources/app/views/dialog/degrade-rule-dialog.html
@@ -32,9 +32,9 @@
 						<label class="col-sm-2 control-label">熔断策略</label>
 						<div class="col-sm-9">
 							<div class="form-control highlight-border" align="center">
-								<input type="radio" name="grade" value="0" checked ng-model='currentRule.grade' title="慢调用比例（1.8.0+ 版本生效）" />&nbsp;慢调用比例&nbsp;&nbsp;
-								<input type="radio" name="grade" value="1" ng-model='currentRule.grade' title="异常比例" />&nbsp;异常比例&nbsp;&nbsp;
-								<input type="radio" name="grade" value="2" ng-model='currentRule.grade' title="异常数" />&nbsp;异常数
+								<input type="radio" name="grade" value="0" checked ng-model='currentRule.grade' ng-change="onGradeChange()" title="慢调用比例（1.8.0+ 版本生效）" />&nbsp;慢调用比例&nbsp;&nbsp;
+								<input type="radio" name="grade" value="1" ng-model='currentRule.grade' ng-change="onGradeChange()" title="异常比例" />&nbsp;异常比例&nbsp;&nbsp;
+								<input type="radio" name="grade" value="2" ng-model='currentRule.grade' ng-change="onGradeChange()" title="异常数" />&nbsp;异常数
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
## Problem

When editing or adding a circuit breaker (degrade) rule in the Sentinel dashboard, switching between strategies (slow call ratio / exception ratio / exception count) does not reset the threshold input field. For example, after setting max RT to 1000ms for slow call ratio strategy, switching to exception ratio still shows 1000 in the ratio threshold field, which is invalid since the valid range is [0.0, 1.0].

## Root Cause

All three circuit breaker strategies share the same `currentRule.count` model in the dialog template. When the user switches the strategy via radio buttons, the `count` value is not cleared, causing the previous strategy's value to persist in the input field.

## Fix

- Added `onGradeChange()` handler in `DegradeCtl` controller that resets `currentRule.count` and `currentRule.slowRatioThreshold` to `undefined` when the strategy changes.
- Added `ng-change="onGradeChange()"` to all three strategy radio buttons in `degrade-rule-dialog.html`.
- The `ng-change` directive only fires on user interaction, so existing values are preserved when editing a rule (no reset on initial dialog load).

## Tests

The dashboard frontend has no test infrastructure (`"test": "echo no test case"` in package.json). Manual verification steps:

1. Open Sentinel dashboard, go to circuit breaker (degrade) rules page
2. Add or edit a rule, select "Slow call ratio", set max RT to 1000
3. Switch to "Exception ratio" — the threshold field should now be empty with placeholder text "[0.0, 1.0]"
4. Switch to "Exception count" — the field should be empty with placeholder "异常数"
5. Switch back to "Slow call ratio" — both RT and ratio threshold fields should be empty

## Impact

Only affects the circuit breaker rule dialog UI in the dashboard. No backend or core logic changes.

Fixes #3582