### PR TITLE
fix: restrict SentinelResourceAspect pointcut to execution join points

### DIFF
--- a/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/SentinelResourceAspect.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/SentinelResourceAspect.java
@@ -35,7 +35,7 @@ import java.lang.reflect.Method;
 @Aspect
 public class SentinelResourceAspect extends AbstractSentinelAspectSupport {
 
-    @Pointcut("@annotation(com.alibaba.csp.sentinel.annotation.SentinelResource)")
+    @Pointcut("execution(* *(..)) && @annotation(com.alibaba.csp.sentinel.annotation.SentinelResource)")
     public void sentinelResourceAnnotationPointcut() {
     }
 


### PR DESCRIPTION
## Problem

When using native AspectJ (compile-time or load-time weaving) instead of Spring AOP, the `@SentinelResource` annotation aspect fires twice for the same method call on the same thread — once at the `call` join point and once at the `execution` join point. This causes `SphU.entry()` to be called twice, doubling the thread count tracked by Sentinel and resulting in incorrect thread-based flow control (e.g., a thread limit of 2 effectively behaves as a limit of 1).

## Root Cause

The current pointcut `@annotation(com.alibaba.csp.sentinel.annotation.SentinelResource)` does not specify a join point kind. In Spring AOP (proxy-based), this only matches `execution` join points since that's all Spring AOP supports. However, in native AspectJ, `@annotation` matches multiple join point kinds including both `call` and `execution`, causing the advice to trigger twice per method invocation.

## Fix

Changed the pointcut from:
```java
@Pointcut("@annotation(com.alibaba.csp.sentinel.annotation.SentinelResource)")
```
to:
```java
@Pointcut("execution(* *(..)) && @annotation(com.alibaba.csp.sentinel.annotation.SentinelResource)")
```

This explicitly restricts matching to `execution` join points only, which:
- Has **no effect** on Spring AOP users (Spring AOP already only supports execution)
- **Fixes** the double-trigger issue for native AspectJ users
- Makes the pointcut intent explicit and unambiguous

## Tests

All 16 existing tests in `sentinel-annotation-aspectj` pass, including `SentinelAnnotationIntegrationTest` which validates the annotation-based flow control with Spring AOP.

## Impact

Only affects `SentinelResourceAspect.java` pointcut expression. No behavioral change for Spring AOP users. Fixes thread counting accuracy for native AspectJ users.

Fixes #3597