### PR TITLE
fix: ensure subsequent slots execute after PriorityWaitException in FlowSlot

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowSlot.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowSlot.java
@@ -159,7 +159,14 @@ public class FlowSlot extends AbstractLinkedProcessorSlot<DefaultNode> {
     @Override
     public void entry(Context context, ResourceWrapper resourceWrapper, DefaultNode node, int count,
                       boolean prioritized, Object... args) throws Throwable {
-        checkFlow(resourceWrapper, context, node, count, prioritized);
+        try {
+            checkFlow(resourceWrapper, context, node, count, prioritized);
+        } catch (PriorityWaitException ex) {
+            // When a prioritized request passes flow control by waiting, subsequent slots
+            // (e.g. circuit breaker / degrade) should still be executed.
+            fireEntry(context, resourceWrapper, node, count, prioritized, args);
+            throw ex;
+        }
 
         fireEntry(context, resourceWrapper, node, count, prioritized, args);
     }

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/FlowSlotTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/FlowSlotTest.java
@@ -16,11 +16,13 @@
 package com.alibaba.csp.sentinel.slots.block.flow;
 
 import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.alibaba.csp.sentinel.EntryType;
 import com.alibaba.csp.sentinel.context.Context;
 import com.alibaba.csp.sentinel.context.ContextTestUtil;
 import com.alibaba.csp.sentinel.node.DefaultNode;
+import com.alibaba.csp.sentinel.slotchain.AbstractLinkedProcessorSlot;
 import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
 import com.alibaba.csp.sentinel.slotchain.StringResourceWrapper;
 import com.alibaba.csp.sentinel.util.function.Function;
@@ -29,6 +31,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -92,5 +95,86 @@ public class FlowSlotTest {
             .thenReturn(false);
 
         flowSlot.checkFlow(new StringResourceWrapper(resA, EntryType.IN), context, node, 1, false);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testPriorityWaitExceptionStillFiresSubsequentSlots() throws Throwable {
+        FlowRuleChecker checker = mock(FlowRuleChecker.class);
+        FlowSlot flowSlot = new FlowSlot(checker);
+        Context context = mock(Context.class);
+        DefaultNode node = mock(DefaultNode.class);
+        ResourceWrapper resource = new StringResourceWrapper("testRes", EntryType.IN);
+
+        // Make checker throw PriorityWaitException
+        doThrow(new PriorityWaitException(100)).when(checker).checkFlow(
+            any(Function.class), any(ResourceWrapper.class), any(Context.class),
+            any(DefaultNode.class), anyInt(), anyBoolean());
+
+        // Track whether the next slot in the chain is called
+        final AtomicBoolean nextSlotCalled = new AtomicBoolean(false);
+        AbstractLinkedProcessorSlot<DefaultNode> nextSlot = new AbstractLinkedProcessorSlot<DefaultNode>() {
+            @Override
+            public void entry(Context context, ResourceWrapper resourceWrapper, DefaultNode node,
+                              int count, boolean prioritized, Object... args) {
+                nextSlotCalled.set(true);
+            }
+
+            @Override
+            public void exit(Context context, ResourceWrapper resourceWrapper, int count, Object... args) {
+            }
+        };
+        flowSlot.setNext(nextSlot);
+
+        // entry() should still throw PriorityWaitException
+        try {
+            flowSlot.entry(context, resource, node, 1, true);
+            fail("Should throw PriorityWaitException");
+        } catch (PriorityWaitException ex) {
+            assertEquals(100, ex.getWaitInMs());
+        }
+
+        // Subsequent slot should have been executed
+        assertTrue("Next slot should be called even when PriorityWaitException is thrown",
+            nextSlotCalled.get());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testPriorityWaitWithDownstreamBlockPropagatesBlockException() throws Throwable {
+        FlowRuleChecker checker = mock(FlowRuleChecker.class);
+        FlowSlot flowSlot = new FlowSlot(checker);
+        Context context = mock(Context.class);
+        DefaultNode node = mock(DefaultNode.class);
+        ResourceWrapper resource = new StringResourceWrapper("testRes", EntryType.IN);
+
+        // Make checker throw PriorityWaitException
+        doThrow(new PriorityWaitException(100)).when(checker).checkFlow(
+            any(Function.class), any(ResourceWrapper.class), any(Context.class),
+            any(DefaultNode.class), anyInt(), anyBoolean());
+
+        // Simulate a downstream slot (e.g. circuit breaker) that blocks
+        AbstractLinkedProcessorSlot<DefaultNode> blockingSlot = new AbstractLinkedProcessorSlot<DefaultNode>() {
+            @Override
+            public void entry(Context context, ResourceWrapper resourceWrapper, DefaultNode node,
+                              int count, boolean prioritized, Object... args) throws Throwable {
+                throw new FlowException("blocked by downstream");
+            }
+
+            @Override
+            public void exit(Context context, ResourceWrapper resourceWrapper, int count, Object... args) {
+            }
+        };
+        flowSlot.setNext(blockingSlot);
+
+        // BlockException from downstream should propagate instead of PriorityWaitException
+        try {
+            flowSlot.entry(context, resource, node, 1, true);
+            fail("Should throw BlockException");
+        } catch (FlowException ex) {
+            // BlockException from downstream slot should propagate
+        } catch (PriorityWaitException ex) {
+            fail("BlockException from downstream should take precedence");
+        }
     }
 }


### PR DESCRIPTION
## Problem

When `FlowSlot.checkFlow()` throws `PriorityWaitException` (for prioritized requests that pass flow control by waiting for a future token), `fireEntry()` is never called. This causes all subsequent slots in the chain to be skipped.

The default slot chain order is:
```
StatisticSlot(-7000) → ... → FlowSlot(-2000) → DefaultCircuitBreakerSlot(-1500) → DegradeSlot(-1000)
```

When `PriorityWaitException` is thrown, `DefaultCircuitBreakerSlot` and `DegradeSlot` are never executed. This means circuit breaker checks are bypassed for priority-waited requests — even if a circuit breaker is in the OPEN state, the request passes through unchecked.

## Root Cause

In `FlowSlot.entry()`, `checkFlow()` is called before `fireEntry()`. When `checkFlow()` throws `PriorityWaitException`, the exception propagates immediately and `fireEntry()` (which chains to downstream slots) is never reached:

```java
// Before fix
public void entry(...) throws Throwable {
    checkFlow(...);         // throws PriorityWaitException
    fireEntry(...);         // NEVER reached
}
```

## Fix

Catch `PriorityWaitException` in `FlowSlot.entry()`, execute downstream slots via `fireEntry()`, then re-throw the exception for `StatisticSlot` to handle:

```java
// After fix
public void entry(...) throws Throwable {
    try {
        checkFlow(...);
    } catch (PriorityWaitException ex) {
        fireEntry(...);     // Execute downstream slots (circuit breaker, degrade)
        throw ex;           // Re-throw for StatisticSlot
    }
    fireEntry(...);
}
```

If a downstream slot throws `BlockException` (e.g., circuit breaker is OPEN), the `BlockException` propagates instead of `PriorityWaitException`, and `StatisticSlot` handles it as a block.

## Tests Added

- `testPriorityWaitExceptionStillFiresSubsequentSlots`: Verifies that downstream slots are executed when `PriorityWaitException` is thrown, and the exception is still re-thrown.
- `testPriorityWaitWithDownstreamBlockPropagatesBlockException`: Verifies that if a downstream slot throws `BlockException` after a priority wait, the `BlockException` takes precedence.

All 225 tests in sentinel-core pass.

## Impact

Only affects `FlowSlot.entry()` behavior when `PriorityWaitException` is thrown (prioritized QPS-based flow control with token waiting). Normal flow control (pass/block) is unchanged.

Fixes #3604