### PR TITLE
Fix slot chain links for shared slots

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slotchain/DefaultProcessorSlotChain.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slotchain/DefaultProcessorSlotChain.java
@@ -49,9 +49,22 @@ public class DefaultProcessorSlotChain extends ProcessorSlotChain {
     }
 
     @Override
-    public void addLast(AbstractLinkedProcessorSlot<?> protocolProcessor) {
-        end.setNext(protocolProcessor);
-        end = protocolProcessor;
+    public void addLast(final AbstractLinkedProcessorSlot<?> protocolProcessor) {
+        AbstractLinkedProcessorSlot<Object> processor = new AbstractLinkedProcessorSlot<Object>() {
+
+            @Override
+            public void entry(Context context, ResourceWrapper resourceWrapper, Object t, int count, boolean prioritized,
+                              Object... args) throws Throwable {
+                protocolProcessor.transformEntry(context, resourceWrapper, t, count, prioritized, args);
+            }
+
+            @Override
+            public void exit(Context context, ResourceWrapper resourceWrapper, int count, Object... args) {
+                protocolProcessor.exit(context, resourceWrapper, count, args);
+            }
+        };
+        end.setNext(processor);
+        end = processor;
     }
 
     /**

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/DefaultSlotChainBuilderTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/DefaultSlotChainBuilderTest.java
@@ -15,8 +15,10 @@
  */
 package com.alibaba.csp.sentinel.slots;
 
+import com.alibaba.csp.sentinel.context.Context;
 import com.alibaba.csp.sentinel.slotchain.AbstractLinkedProcessorSlot;
 import com.alibaba.csp.sentinel.slotchain.ProcessorSlotChain;
+import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
 import com.alibaba.csp.sentinel.slots.block.authority.AuthoritySlot;
 import com.alibaba.csp.sentinel.slots.block.degrade.DefaultCircuitBreakerSlot;
 import com.alibaba.csp.sentinel.slots.block.degrade.DegradeSlot;
@@ -89,5 +91,39 @@ public class DefaultSlotChainBuilderTest {
         NodeSelectorSlot nodeSelectorSlot2 = (NodeSelectorSlot) next;
         // Verify the two NodeSelectorSlot instances are different
         assertNotSame(nodeSelectorSlot, nodeSelectorSlot2);
+    }
+
+    @Test
+    public void testAddSingletonSlotInDifferentChains() {
+        ProcessorSlotChain chain = new ProcessorSlotChain();
+        TestSlot singletonSlot = new TestSlot();
+        TestSlot firstNext = new TestSlot();
+        TestSlot secondNext = new TestSlot();
+
+        chain.addLast(singletonSlot);
+        chain.addLast(firstNext);
+
+        ProcessorSlotChain chain2 = new ProcessorSlotChain();
+        chain2.addLast(singletonSlot);
+        chain2.addLast(secondNext);
+
+        AbstractLinkedProcessorSlot<?> next = chain.getNext().getNext();
+        assertSame(firstNext, next.getNext());
+
+        next = chain2.getNext().getNext();
+        assertSame(secondNext, next.getNext());
+        assertNotSame(firstNext, secondNext);
+    }
+
+    private static class TestSlot extends AbstractLinkedProcessorSlot<Object> {
+
+        @Override
+        public void entry(Context context, ResourceWrapper resourceWrapper, Object t, int count, boolean prioritized,
+                          Object... args) {
+        }
+
+        @Override
+        public void exit(Context context, ResourceWrapper resourceWrapper, int count, Object... args) {
+        }
     }
 }


### PR DESCRIPTION
This updates the default processor slot chain so a shared slot instance no longer has its `next` pointer overwritten when it is added to multiple chains. The chain now keeps its own link node for each added slot and delegates processing to the original slot, preserving each chain’s local successor. A regression test covers building two chains with the same slot instance followed by different downstream slots.

Test: `mvn -pl sentinel-core -Dtest=DefaultSlotChainBuilderTest test` could not be run in this environment because `mvn` is not installed.