### PR TITLE
Fix invalid prototype slot node issue

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slotchain/DefaultProcessorSlotChain.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slotchain/DefaultProcessorSlotChain.java
@@ -16,6 +16,7 @@
 package com.alibaba.csp.sentinel.slotchain;
 
 import com.alibaba.csp.sentinel.context.Context;
+import com.alibaba.csp.sentinel.slots.block.flow.PrototypeSlotWrapper;
 
 /**
  * @author qinan.qn
@@ -50,8 +51,9 @@ public class DefaultProcessorSlotChain extends ProcessorSlotChain {
 
     @Override
     public void addLast(AbstractLinkedProcessorSlot<?> protocolProcessor) {
-        end.setNext(protocolProcessor);
-        end = protocolProcessor;
+        PrototypeSlotWrapper processor = new PrototypeSlotWrapper(protocolProcessor);
+        end.setNext(processor);
+        end = processor;
     }
 
     /**

--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/PrototypeSlotWrapper.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/PrototypeSlotWrapper.java
@@ -1,0 +1,39 @@
+package com.alibaba.csp.sentinel.slots.block.flow;
+
+import com.alibaba.csp.sentinel.context.Context;
+import com.alibaba.csp.sentinel.slotchain.AbstractLinkedProcessorSlot;
+import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
+
+/**
+ * @author joyce
+ * @date 2026/5/14
+ * @since 1.8.5
+ **/
+public class PrototypeSlotWrapper extends AbstractLinkedProcessorSlot<Object> {
+
+    private final AbstractLinkedProcessorSlot delegate;
+
+    public PrototypeSlotWrapper(AbstractLinkedProcessorSlot delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void fireEntry(Context context, ResourceWrapper resourceWrapper, Object obj, int count, boolean prioritized, Object... args) throws Throwable {
+        this.delegate.fireEntry(context, resourceWrapper, obj, count, prioritized, args);
+    }
+
+    @Override
+    public void fireExit(Context context, ResourceWrapper resourceWrapper, int count, Object... args) {
+        this.delegate.fireExit(context, resourceWrapper, count, args);
+    }
+
+    @Override
+    public void entry(Context context, ResourceWrapper resourceWrapper, Object param, int count, boolean prioritized, Object... args) throws Throwable {
+        delegate.entry(context, resourceWrapper, param, count, prioritized, args);
+    }
+
+    @Override
+    public void exit(Context context, ResourceWrapper resourceWrapper, int count, Object... args) {
+        delegate.exit(context, resourceWrapper, count, args);
+    }
+}

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/ProcessorSlotChainTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/ProcessorSlotChainTest.java
@@ -1,0 +1,76 @@
+package com.alibaba.csp.sentinel.slots;
+
+import com.alibaba.csp.sentinel.context.Context;
+import com.alibaba.csp.sentinel.slotchain.AbstractLinkedProcessorSlot;
+import com.alibaba.csp.sentinel.slotchain.DefaultProcessorSlotChain;
+import com.alibaba.csp.sentinel.slotchain.ResourceWrapper;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import java.lang.reflect.Field;
+
+/**
+ * @author joyce
+ * @date 2026/5/14
+ */
+public class ProcessorSlotChainTest {
+
+    @Test
+    public void testBeforeFix_nextOfSingletonIsShared() throws Exception {
+        DefaultSlot singleton = new DefaultSlot();
+        DefaultProcessorSlotChain chain1 = createLegacyChain();
+        DefaultProcessorSlotChain chain2 = createLegacyChain();
+
+        DefaultSlot prototypeA1 = new DefaultSlot();
+        chain1.addLast(singleton);
+        chain1.addLast(prototypeA1);
+
+        DefaultSlot prototypeA2 = new DefaultSlot();
+        chain2.addLast(singleton);
+        chain2.addLast(prototypeA2);
+
+        Assert.assertEquals(chain1.getNext().getNext(), chain2.getNext().getNext());
+    }
+    @Test
+    public void testAfterFix_eachChainHasItsOwnWrapper() {
+        DefaultSlot singleton = new DefaultSlot();
+        DefaultProcessorSlotChain chain1 = new DefaultProcessorSlotChain();
+        DefaultProcessorSlotChain chain2 = new DefaultProcessorSlotChain();
+
+        chain1.addLast(singleton);
+        chain1.addLast(new DefaultSlot());
+
+        chain2.addLast(singleton);
+        chain2.addLast(new DefaultSlot());
+        Assert.assertNotEquals(chain1.getNext().getNext(), chain2.getNext().getNext());
+    }
+
+    private DefaultProcessorSlotChain createLegacyChain() throws Exception {
+        DefaultProcessorSlotChain chain = Mockito.spy(new DefaultProcessorSlotChain());
+        Field endField = DefaultProcessorSlotChain.class.getDeclaredField("end");
+        endField.setAccessible(true);
+
+        Mockito.doAnswer(invocation -> {
+            AbstractLinkedProcessorSlot<?> slot = invocation.getArgument(0);
+            AbstractLinkedProcessorSlot<?> end =
+                    (AbstractLinkedProcessorSlot<?>) endField.get(chain);
+            end.setNext(slot);
+            endField.set(chain, slot);
+            return null;
+        }).when(chain).addLast(Mockito.any(AbstractLinkedProcessorSlot.class));
+
+        return chain;
+    }
+
+    private static class DefaultSlot extends AbstractLinkedProcessorSlot<Object> {
+
+        @Override
+        public void entry(Context context, ResourceWrapper resourceWrapper, Object t, int count,
+                          boolean prioritized, Object... args) throws Throwable {
+        }
+
+        @Override
+        public void exit(Context context, ResourceWrapper resourceWrapper, int count, Object... args) {
+        }
+    }
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

When a singleton `ProcessorSlot` is placed before a prototype (non-singleton)
`ProcessorSlot` in `DefaultProcessorSlotChain`, all chains share the same singleton
instance. Each time a new chain is built, `addLast` calls `setNext` directly on
the shared singleton, overwriting its `next` pointer. This causes previously built
chains to lose their own prototype slot node — making the prototype slot invalid.

This PR introduces `PrototypeSlotWrapper` and modifies `DefaultProcessorSlotChain#addLast`
to wrap every slot in a new `PrototypeSlotWrapper` per chain. Each wrapper owns an
independent `next` pointer (inherited from `AbstractLinkedProcessorSlot`), so the
singleton's `next` field is never modified during chain construction, and each chain
maintains its own correct node linkage.

### Does this pull request fix one issue?

Fixes #3007

### Describe how you did it

- Added `PrototypeSlotWrapper` (`slots/block/flow/PrototypeSlotWrapper.java`):
  a thin wrapper extending `AbstractLinkedProcessorSlot` that delegates `entry`,
  `exit`, `fireEntry`, and `fireExit` to the underlying slot, while keeping its
  own chain-local `next` pointer via the inherited field.

- Modified `DefaultProcessorSlotChain#addLast`
  (`slotchain/DefaultProcessorSlotChain.java`):
  wrap the incoming slot in a `PrototypeSlotWrapper` before appending it to the
  chain, so `end.setNext` and `end = processor` always operate on a fresh wrapper
  instance rather than the slot itself.

### Describe how to verify it

Two test cases added in `ProcessorSlotChainTest` (`slots/ProcessorSlotChainTest.java`):

- `testBeforeFix_nextOfSingletonIsShared`: uses a Mockito spy to simulate the old
  `addLast` logic (no wrapper) and asserts that after building two chains, both
  chains' prototype slot node is the same object — confirming the bug.

- `testAfterFix_eachChainHasItsOwnWrapper`: uses the fixed `DefaultProcessorSlotChain`
  and asserts that the two chains hold different `PrototypeSlotWrapper` instances as
  their second node — confirming the fix.

### Special notes for reviews

`PrototypeSlotWrapper` does not override `getNext` / `setNext`, so the chain-local
`next` field on the wrapper is used for node linkage. `fireEntry` and `fireExit` are
delegated to the underlying slot to preserve the original propagation behavior.