### PR TITLE
feat: add global fallback support for AspectJ annotation extension (#3110)

### DIFF
--- a/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/AbstractSentinelAspectSupport.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/AbstractSentinelAspectSupport.java
@@ -37,6 +37,30 @@ import java.util.Arrays;
  */
 public abstract class AbstractSentinelAspectSupport {
 
+    /**
+     * Global fallback handler, invoked as last resort when no per-method fallback
+     * or default fallback is configured.
+     */
+    private volatile SentinelAnnotationGlobalFallback globalFallback;
+
+    /**
+     * Set the global fallback handler.
+     *
+     * @param globalFallback the global fallback handler (may be {@code null} to clear)
+     */
+    public void setGlobalFallback(SentinelAnnotationGlobalFallback globalFallback) {
+        this.globalFallback = globalFallback;
+    }
+
+    /**
+     * Get the current global fallback handler.
+     *
+     * @return the global fallback handler, or {@code null} if not set
+     */
+    public SentinelAnnotationGlobalFallback getGlobalFallback() {
+        return globalFallback;
+    }
+
     protected void traceException(Throwable ex) {
         Tracer.trace(ex);
     }
@@ -116,6 +140,12 @@ public abstract class AbstractSentinelAspectSupport {
             // Construct args.
             Object[] args = fallbackMethod.getParameterTypes().length == 0 ? new Object[0] : new Object[] {ex};
             return invoke(pjp, fallbackMethod, args);
+        }
+
+        // If no default fallback is present, try the global fallback.
+        if (globalFallback != null) {
+            Method originMethod = resolveMethod(pjp);
+            return globalFallback.handle(originMethod, pjp.getArgs(), ex);
         }
 
         // If no any fallback is present, then directly throw the exception.

--- a/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/SentinelAnnotationGlobalFallback.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/main/java/com/alibaba/csp/sentinel/annotation/aspectj/SentinelAnnotationGlobalFallback.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 1999-2024 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.annotation.aspectj;
+
+import java.lang.reflect.Method;
+
+/**
+ * Global fallback handler for {@link com.alibaba.csp.sentinel.annotation.SentinelResource} annotations.
+ * <p>
+ * When set on {@link SentinelResourceAspect}, this handler serves as the last-resort fallback
+ * for all {@code @SentinelResource}-annotated methods, even when neither {@code fallback}
+ * nor {@code defaultFallback} is specified in the annotation.
+ * <p>
+ * The global fallback is invoked only after both per-method fallback and default fallback
+ * have been exhausted (i.e., not configured or not found).
+ *
+ * @author EvanYao826
+ * @since 1.8.8
+ */
+public interface SentinelAnnotationGlobalFallback {
+
+    /**
+     * Handle the fallback when a {@code @SentinelResource}-annotated method is blocked
+     * or throws a traced exception.
+     *
+     * @param originalMethod the original annotated method
+     * @param args           the arguments passed to the original method
+     * @param t              the exception that triggered the fallback (may be a {@link
+     *                       com.alibaba.csp.sentinel.slots.block.BlockException} or a traced business exception)
+     * @return the fallback result
+     * @throws Throwable if the fallback itself fails
+     */
+    Object handle(Method originalMethod, Object[] args, Throwable t) throws Throwable;
+}

--- a/sentinel-extension/sentinel-annotation-aspectj/src/test/java/com/alibaba/csp/sentinel/annotation/aspectj/AbstractSentinelAspectSupportTest.java
+++ b/sentinel-extension/sentinel-annotation-aspectj/src/test/java/com/alibaba/csp/sentinel/annotation/aspectj/AbstractSentinelAspectSupportTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import java.lang.reflect.Method;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 /**
  * @author Eric Zhao
@@ -35,5 +36,24 @@ public class AbstractSentinelAspectSupportTest extends AbstractSentinelAspectSup
         assertThat(getResourceName(resourceName, method)).isEqualTo(resourceName);
         assertThat(getResourceName(null, method)).isEqualTo(expectedResolvedName);
         assertThat(getResourceName("", method)).isEqualTo(expectedResolvedName);
+    }
+
+    @Test
+    public void testGlobalFallbackDefaultIsNull() {
+        assertThat(getGlobalFallback()).isNull();
+    }
+
+    @Test
+    public void testSetAndGetGlobalFallback() throws Throwable {
+        SentinelAnnotationGlobalFallback fallback = mock(SentinelAnnotationGlobalFallback.class);
+        setGlobalFallback(fallback);
+        assertThat(getGlobalFallback()).isSameAs(fallback);
+    }
+
+    @Test
+    public void testClearGlobalFallback() {
+        setGlobalFallback(mock(SentinelAnnotationGlobalFallback.class));
+        setGlobalFallback(null);
+        assertThat(getGlobalFallback()).isNull();
     }
 }


### PR DESCRIPTION
Fixes #3110

## Summary

Add `SentinelAnnotationGlobalFallback` interface and integrate it into `AbstractSentinelAspectSupport` as a last-resort fallback handler.

When set on `SentinelResourceAspect`, the global fallback is invoked for **all** `@SentinelResource`-annotated methods when neither per-method `fallback` nor `defaultFallback` is configured (or found). This provides a universal 兜底 strategy without requiring each annotation to specify its own fallback.

## Design

Follows the direction suggested by @sczyh30 in #3116: the global fallback lives in `SentinelResourceAspect` (not in the annotation), making it a cross-cutting concern.

**Fallback resolution order:**
1. Per-method `fallback` (annotation attribute)
2. Per-method `defaultFallback` (annotation attribute or class-level)
3. **Global fallback** (set on the aspect) ← NEW
4. Throw exception

## Changes

### New: `SentinelAnnotationGlobalFallback` interface

```java
public interface SentinelAnnotationGlobalFallback {
    Object handle(Method originalMethod, Object[] args, Throwable t) throws Throwable;
}
```

### Modified: `AbstractSentinelAspectSupport`

- Added `globalFallback` field with getter/setter
- Modified `handleDefaultFallback()` to try global fallback before throwing

### Tests

3 unit tests for get/set/clear global fallback on `AbstractSentinelAspectSupportTest`.

## Usage

```java
@Bean
public SentinelResourceAspect sentinelResourceAspect() {
    SentinelResourceAspect aspect = new SentinelResourceAspect();
    aspect.setGlobalFallback((method, args, t) -> {
        // Universal fallback logic
        return "Global fallback: " + t.getMessage();
    });
    return aspect;
}
```

## Notes

- Previous PRs #3116 and #3383 were closed without merge. This implementation follows the maintainer feedback: global fallback is in the aspect, not the annotation.
- The `globalFallback` field is `volatile` for thread-safe reads in the aspect's `@Around` advice.