### PR TITLE
fix: allow regex resource names with all control behaviors

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleUtil.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleUtil.java
@@ -246,7 +246,7 @@ public final class FlowRuleUtil {
             return false;
         }
         if (rule.isRegex()) {
-            return !rule.isClusterMode() && rule.getControlBehavior() == RuleConstant.CONTROL_BEHAVIOR_DEFAULT;
+            return !rule.isClusterMode();
         }
         return true;
     }


### PR DESCRIPTION
## Issue Description

Fixes #3544

Previously, regex resource names were only allowed with `CONTROL_BEHAVIOR_DEFAULT` (fast failure). This restriction prevented users from using warm-up or queue behaviors with regex-matched resources.

## Changes

In `FlowRuleUtil.checkRegexField()`, removed the control behavior restriction for regex rules. Now regex resource names can be used with any control behavior (DEFAULT, WARM_UP, RATE_LIMITER, WARM_UP_RATE_LIMITER), as long as the rule is not in cluster mode.

**Before:**
```java
if (rule.isRegex()) {
    return !rule.isClusterMode() && rule.getControlBehavior() == RuleConstant.CONTROL_BEHAVIOR_DEFAULT;
}
```

**After:**
```java
if (rule.isRegex()) {
    return !rule.isClusterMode();
}
```

## Testing

Verified that flow rules with regex resource names can now be loaded with all control behaviors.