### PR TITLE
fix: ensure each ProcessorSlotChain gets independent slot instances

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/DefaultSlotChainBuilder.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/DefaultSlotChainBuilder.java
@@ -46,9 +46,39 @@ public class DefaultSlotChainBuilder implements SlotChainBuilder {
                 continue;
             }
 
-            chain.addLast((AbstractLinkedProcessorSlot<?>) slot);
+            // Always create a new instance of the slot to ensure each chain has its own
+            // copy with independent next pointers. This is necessary because singleton slots
+            // (isSingleton=true in @Spi annotation) are shared across all build() calls.
+            // If a singleton slot is directly used in multiple chains, modifying its 'next'
+            // pointer when building one chain will affect all other chains that use it.
+            // See: https://github.com/alibaba/Sentinel/issues/3007
+            AbstractLinkedProcessorSlot<?> newSlot = newSlot(slot);
+            chain.addLast(newSlot);
         }
 
         return chain;
+    }
+
+    /**
+     * Create a new instance of the given slot.
+     * <p>
+     * This method creates a fresh instance of the slot's concrete class via reflection,
+     * ensuring that each chain gets its own independent copy of every slot. This prevents
+     * the issue where singleton slots shared across multiple chains would have their
+     * {@code next} pointer overwritten by the last chain built.
+     * </p>
+     *
+     * @param slot the slot to create a new instance of
+     * @return a new instance of the slot, or the original slot if creation fails
+     */
+    @SuppressWarnings("unchecked")
+    private static AbstractLinkedProcessorSlot<?> newSlot(ProcessorSlot slot) {
+        try {
+            return slot.getClass().getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            RecordLog.warn("Failed to create new instance of ProcessorSlot("
+                + slot.getClass().getCanonicalName() + "), using original instance", e);
+            return (AbstractLinkedProcessorSlot<?>) slot;
+        }
     }
 }


### PR DESCRIPTION
Fixes #3007

## Problem

When building a `ProcessorSlotChain`, singleton slots (`isSingleton=true` in `@Spi` annotation) are shared across all `build()` calls. Directly adding a singleton slot to a chain sets its `next` pointer, which then affects all other chains that reference the same singleton instance.

**Reproduction:** When a non-singleton ProcessorSlot (A) is placed after a singleton ProcessorSlot (B), all chains share B's `next` pointer, causing it to point to the last-created A instance.

## Fix

In `DefaultSlotChainBuilder.build()`, always create a new instance of each slot via reflection (`getDeclaredConstructor().newInstance()`) instead of directly using the SPI-loaded instance. This ensures each chain has independent `next` pointers regardless of whether the slot is a singleton.

## Changes

- `DefaultSlotChainBuilder.java`: Added `newSlot()` helper method that creates a fresh instance of each slot via reflection. Falls back to the original instance if creation fails (e.g., no default constructor).