### PR TITLE
chore: bump version to 1.8.11-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     </issueManagement>
 
     <properties>
-        <revision>1.8.10</revision>
+        <revision>1.8.11-SNAPSHOT</revision>
         <!-- Compile libs -->
         <fastjson.version>1.2.83_noneautotype</fastjson.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

After the 1.8.10 release, bump the development version to `1.8.11-SNAPSHOT` to start the next development iteration.

### Does this pull request fix one issue?

NONE

### Describe how you did it

Update `<revision>` in the root `pom.xml` from `1.8.10` to `1.8.11-SNAPSHOT`. All module poms inherit this via the flatten-maven-plugin.

### Describe how to verify it


### Special notes for reviews