### PR TITLE
Fix Reactor adapter async-context race in `SentinelReactorSubscriber.currentContext`

### DIFF
--- a/sentinel-adapter/sentinel-reactor-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/reactor/SentinelReactorSubscriber.java
+++ b/sentinel-adapter/sentinel-reactor-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/reactor/SentinelReactorSubscriber.java
@@ -67,7 +67,7 @@ public class SentinelReactorSubscriber<T> extends InheritableBaseSubscriber<T> {
             return actual.currentContext();
         }
         return actual.currentContext()
-            .put(SentinelReactorConstants.SENTINEL_CONTEXT_KEY, currentEntry.getAsyncContext());
+            .put(SentinelReactorConstants.SENTINEL_CONTEXT_KEY, sentinelContext);
     }
 
     private void doWithContextOrCurrent(Supplier<Optional<com.alibaba.csp.sentinel.context.Context>> contextSupplier,

--- a/sentinel-adapter/sentinel-reactor-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/reactor/SentinelReactorSubscriberTest.java
+++ b/sentinel-adapter/sentinel-reactor-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/reactor/SentinelReactorSubscriberTest.java
@@ -1,0 +1,86 @@
+package com.alibaba.csp.sentinel.adapter.reactor;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.alibaba.csp.sentinel.AsyncEntry;
+
+import org.junit.Test;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.util.context.Context;
+
+import static org.junit.Assert.*;
+
+public class SentinelReactorSubscriberTest {
+
+    @Test
+    public void testCurrentContextShouldUseCapturedAsyncContextWhenExitHappensDuringContextRead() throws Exception {
+        AtomicBoolean allowCancelInContextRead = new AtomicBoolean(false);
+        AtomicBoolean canceledInContextRead = new AtomicBoolean(false);
+        AtomicReference<SentinelReactorSubscriber<Integer>> subscriberRef = new AtomicReference<>();
+
+        CoreSubscriber<Integer> actual = new CoreSubscriber<Integer>() {
+            @Override
+            public Context currentContext() {
+                SentinelReactorSubscriber<Integer> subscriber = subscriberRef.get();
+                if (allowCancelInContextRead.get() && subscriber != null
+                    && canceledInContextRead.compareAndSet(false, true)) {
+                    subscriber.cancel();
+                }
+                return Context.empty();
+            }
+
+            @Override
+            public void onSubscribe(Subscription s) {
+            }
+
+            @Override
+            public void onNext(Integer integer) {
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                fail("Unexpected error: " + t);
+            }
+
+            @Override
+            public void onComplete() {
+            }
+        };
+
+        SentinelReactorSubscriber<Integer> subscriber =
+            new SentinelReactorSubscriber<>(new EntryConfig("testCurrentContextRace"), actual, false);
+        subscriberRef.set(subscriber);
+        subscriber.onSubscribe(new NoopSubscription());
+
+        AsyncEntry currentEntry = getCurrentEntry(subscriber);
+        assertNotNull(currentEntry);
+        com.alibaba.csp.sentinel.context.Context asyncContextBeforeExit = currentEntry.getAsyncContext();
+        assertNotNull(asyncContextBeforeExit);
+
+        allowCancelInContextRead.set(true);
+        Context reactorContext = subscriber.currentContext();
+
+        assertTrue(canceledInContextRead.get());
+        assertSame(asyncContextBeforeExit, reactorContext.get(SentinelReactorConstants.SENTINEL_CONTEXT_KEY));
+        assertNull(currentEntry.getAsyncContext());
+    }
+
+    private static AsyncEntry getCurrentEntry(SentinelReactorSubscriber<?> subscriber) throws Exception {
+        Field field = SentinelReactorSubscriber.class.getDeclaredField("currentEntry");
+        field.setAccessible(true);
+        return (AsyncEntry)field.get(subscriber);
+    }
+
+    private static final class NoopSubscription implements Subscription {
+        @Override
+        public void request(long n) {
+        }
+
+        @Override
+        public void cancel() {
+        }
+    }
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

`SentinelReactorSubscriber.currentContext()` could throw `NullPointerException: value` under concurrent termination because it read `currentEntry.getAsyncContext()` twice. If `AsyncEntry.exit()` cleared async context between those reads, `Context.put(...)` received `null`.

- **Race fix in context propagation**
  - Updated `currentContext()` to use the already-captured local `sentinelContext` when putting Sentinel context into Reactor `Context`.
  - This removes the check-then-act race window created by re-reading `currentEntry.getAsyncContext()`.

- **Targeted regression coverage**
  - Added `SentinelReactorSubscriberTest` in the reactor adapter test module.
  - The test drives a deterministic interleaving where `currentContext()` captures a non-null async context, a concurrent cancel path exits/clears context, and `currentContext()` must still propagate the captured value (the pre-fix path would pass `null` to `Context.put`).

```java
com.alibaba.csp.sentinel.context.Context sentinelContext = currentEntry.getAsyncContext();
if (sentinelContext == null) {
    return actual.currentContext();
}
return actual.currentContext()
    .put(SentinelReactorConstants.SENTINEL_CONTEXT_KEY, sentinelContext);
```

```
26-05-21 09:28:59.436  WARN [x-server,,,TID:N/A] 766243 --- [ventExecutorLoop-1-4] [i.n.u.c.SingleThreadEventExecutor       :1002] [                 run] : Unexpected exception from an event executor:
java.lang.NullPointerException: value
        at java.util.Objects.requireNonNull(Objects.java:228)
        at reactor.util.context.Context5.put(Context5.java:61)
        at com.alibaba.csp.sentinel.adapter.reactor.SentinelReactorSubscriber.currentContext(SentinelReactorSubscriber.java:70)
        at com.alibaba.csp.sentinel.adapter.reactor.InheritableBaseSubscriber.onError(InheritableBaseSubscriber.java:169)
        at com.alibaba.csp.sentinel.adapter.reactor.SentinelReactorSubscriber.onError(SentinelReactorSubscriber.java:37)
        at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onError(FluxOnAssembly.java:544)
        at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onError(FluxOnAssembly.java:544)
        at reactor.core.publisher.FluxDoFinally$DoFinallySubscriber.onError(FluxDoFinally.java:119)
        at reactor.core.publisher.FluxContextWrite$ContextWriteSubscriber.onError(FluxContextWrite.java:121)
        at reactor.core.publisher.MonoFlatMap$FlatMapMain.onError(MonoFlatMap.java:172)
        at reactor.core.publisher.MonoFlatMap$FlatMapMain.secondError(MonoFlatMap.java:192)
        at reactor.core.publisher.MonoFlatMap$FlatMapInner.onError(MonoFlatMap.java:259)
        at reactor.core.publisher.MonoIgnoreThen$ThenIgnoreMain.onError(MonoIgnoreThen.java:278)
        at reactor.core.publisher.FluxDoFinally$DoFinallySubscriber.onError(FluxDoFinally.java:119)
        at reactor.core.publisher.FluxPeek$PeekSubscriber.onError(FluxPeek.java:222)
        at reactor.core.publisher.MonoIgnoreThen$ThenIgnoreMain.onError(MonoIgnoreThen.java:278)
        at reactor.core.publisher.MonoPeekTerminal$MonoTerminalPeekSubscriber.onError(MonoPeekTerminal.java:258)
        at org.springframework.http.server.reactive.ChannelSendOperator$WriteCompletionBarrier.onError(ChannelSendOperator.java:418)
```

某Redis Reactive请求先发生异常
→ Reactor进入onError链路
→ SentinelReactorSubscriber.currentContext()
→ Context.put(null)
→ NullPointerException
→ 未捕获异常打穿Netty EventExecutor
→ lettuce-eventExecutorLoop-1-4 号线程死亡(threadStatus=2)
→ executor terminated
→ 后续Redis Reactive callback无法调度
→ Spring Session Reactive Pipeline部分卡死 （重启恢复）

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

fixed #3556  #1907 

This pull request was created from Copilot chat.