### PR TITLE
fix: stabilize flaky ParamFlowDefaultCheckerTest by using mocked time

### DIFF
--- a/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowDefaultCheckerTest.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowDefaultCheckerTest.java
@@ -248,71 +248,65 @@ public class ParamFlowDefaultCheckerTest extends AbstractTimeBasedTest {
 
     @Test
     public void testParamFlowDefaultCheckSingleValueCheckQpsMultipleThreads() throws Exception {
-        final String resourceName = "testParamFlowDefaultCheckSingleValueCheckQpsMultipleThreads";
-        final ResourceWrapper resourceWrapper = new StringResourceWrapper(resourceName, EntryType.IN);
-        int paramIdx = 0;
+        try (MockedStatic<TimeUtil> mocked = super.mockTimeUtil()) {
+            final String resourceName = "testParamFlowDefaultCheckSingleValueCheckQpsMultipleThreads";
+            final ResourceWrapper resourceWrapper = new StringResourceWrapper(resourceName, EntryType.IN);
+            int paramIdx = 0;
 
-        long threshold = 5L;
+            long threshold = 5L;
 
-        final ParamFlowRule rule = new ParamFlowRule();
-        rule.setResource(resourceName);
-        rule.setCount(threshold);
-        rule.setParamIdx(paramIdx);
-        rule.setDurationInSec(3);
+            final ParamFlowRule rule = new ParamFlowRule();
+            rule.setResource(resourceName);
+            rule.setCount(threshold);
+            rule.setParamIdx(paramIdx);
+            rule.setDurationInSec(3);
 
-        final String valueA = "valueA";
-        ParameterMetric metric = new ParameterMetric();
-        ParameterMetricStorage.getMetricsMap().put(resourceWrapper.getName(), metric);
-        metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
-        metric.getRuleTokenCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<>(4000));
-        int threadCount = 40;
+            final String valueA = "valueA";
+            ParameterMetric metric = new ParameterMetric();
+            ParameterMetricStorage.getMetricsMap().put(resourceWrapper.getName(), metric);
+            metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
+            metric.getRuleTokenCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<>(4000));
+            int threadCount = 40;
 
-        final CountDownLatch waitLatch = new CountDownLatch(threadCount);
-        final AtomicInteger successCount = new AtomicInteger();
-        for (int i = 0; i < threadCount; i++) {
-            Thread t = new Thread(() -> {
-                if (ParamFlowChecker.passSingleValueCheck(resourceWrapper, rule, 1, valueA)) {
-                    successCount.incrementAndGet();
-                }
-                waitLatch.countDown();
-            });
-            t.setName("sentinel-simulate-traffic-task-" + i);
-            t.start();
-        }
-        waitLatch.await();
+            setCurrentMillis(mocked, System.currentTimeMillis());
 
-        assertEquals(threshold, successCount.get());
-        successCount.set(0);
-
-        System.out.println("testParamFlowDefaultCheckSingleValueCheckQpsMultipleThreads: sleep for 3 seconds");
-        TimeUnit.SECONDS.sleep(3);
-
-        successCount.set(0);
-        final CountDownLatch waitLatch1 = new CountDownLatch(threadCount);
-        final long currentTime = TimeUtil.currentTimeMillis();
-        final long endTime = currentTime + rule.getDurationInSec() * 1000 - 500;
-        for (int i = 0; i < threadCount; i++) {
-            Thread t = new Thread(() -> {
-                while (TimeUtil.currentTimeMillis() <= endTime) {
+            final CountDownLatch waitLatch = new CountDownLatch(threadCount);
+            final AtomicInteger successCount = new AtomicInteger();
+            for (int i = 0; i < threadCount; i++) {
+                Thread t = new Thread(() -> {
                     if (ParamFlowChecker.passSingleValueCheck(resourceWrapper, rule, 1, valueA)) {
                         successCount.incrementAndGet();
                     }
+                    waitLatch.countDown();
+                });
+                t.setName("sentinel-simulate-traffic-task-" + i);
+                t.start();
+            }
+            waitLatch.await();
 
-                    try {
-                        TimeUnit.MILLISECONDS.sleep(ThreadLocalRandom.current().nextInt(20));
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
+            assertEquals(threshold, successCount.get());
+            successCount.set(0);
+
+            // Advance time past the duration window to reset counters
+            sleep(mocked, rule.getDurationInSec() * 1000);
+
+            // Second round: 40 threads each call once, should again allow exactly threshold
+            successCount.set(0);
+            final CountDownLatch waitLatch1 = new CountDownLatch(threadCount);
+            for (int i = 0; i < threadCount; i++) {
+                Thread t = new Thread(() -> {
+                    if (ParamFlowChecker.passSingleValueCheck(resourceWrapper, rule, 1, valueA)) {
+                        successCount.incrementAndGet();
                     }
-                }
+                    waitLatch1.countDown();
+                });
+                t.setName("sentinel-simulate-traffic-task-" + i);
+                t.start();
+            }
+            waitLatch1.await();
 
-                waitLatch1.countDown();
-            });
-            t.setName("sentinel-simulate-traffic-task-" + i);
-            t.start();
+            assertEquals(threshold, successCount.get());
         }
-        waitLatch1.await();
-
-        assertEquals(threshold, successCount.get());
     }
 
     @Before


### PR DESCRIPTION
## Summary

The test `testParamFlowDefaultCheckSingleValueCheckQpsMultipleThreads` was flaky because it used real time (`TimeUnit.sleep` and wall-clock-based loops) for concurrent assertions. This caused race conditions when the test ran in isolation vs. after other tests.

### Root Cause

The test's second phase used `TimeUtil.currentTimeMillis()` in a busy loop with real thread sleep, making the assertion result depend on:
- Exact thread scheduling timing
- Whether a previous test's time mock was still active
- Wall-clock drift during the 2.5-second loop

### Fix

- Wrapped the entire test in `MockedStatic<TimeUtil>` (consistent with all other tests in this class)
- Replaced the real-time busy loop with a clean second round of concurrent requests after advancing the mock clock past the duration window
- This makes the test deterministic regardless of thread scheduling or test execution order

Fixes #2426