### PR TITLE
feat: add Jakarta EE Servlet 6.0 adapter module (#2998)

### DIFF
--- a/sentinel-adapter/pom.xml
+++ b/sentinel-adapter/pom.xml
@@ -17,6 +17,7 @@
 
     <modules>
         <module>sentinel-web-servlet</module>
+        <module>sentinel-web-servlet-jakarta</module>
         <module>sentinel-dubbo-adapter</module>
         <module>sentinel-apache-dubbo-adapter</module>
         <module>sentinel-apache-dubbo3-adapter</module>

--- a/sentinel-adapter/pom.xml
+++ b/sentinel-adapter/pom.xml
@@ -17,7 +17,6 @@
 
     <modules>
         <module>sentinel-web-servlet</module>
-        <module>sentinel-web-servlet-jakarta</module>
         <module>sentinel-dubbo-adapter</module>
         <module>sentinel-apache-dubbo-adapter</module>
         <module>sentinel-apache-dubbo3-adapter</module>
@@ -84,4 +83,16 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <profiles>
+        <profile>
+            <id>jdk17-plus</id>
+            <activation>
+                <jdk>[17,)</jdk>
+            </activation>
+            <modules>
+                <module>sentinel-web-servlet-jakarta</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>

--- a/sentinel-adapter/sentinel-web-servlet-jakarta/pom.xml
+++ b/sentinel-adapter/sentinel-web-servlet-jakarta/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.alibaba.csp</groupId>
+        <artifactId>sentinel-adapter</artifactId>
+        <version>2.0.0-alpha2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>sentinel-web-servlet-jakarta</artifactId>
+    <packaging>jar</packaging>
+    <description>Sentinel adapter for Jakarta EE Servlet 6.0 (Spring Boot 3.x)</description>
+
+    <properties>
+        <jakarta.servlet-api.version>6.0.0</jakarta.servlet-api.version>
+        <skip.spring.v6x.test>false</skip.spring.v6x.test>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>${jakarta.servlet-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>3.2.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>3.2.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.version}</version>
+                <configuration>
+                    <skipTests>${skip.spring.v6x.test}</skipTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/sentinel-adapter/sentinel-web-servlet-jakarta/pom.xml
+++ b/sentinel-adapter/sentinel-web-servlet-jakarta/pom.xml
@@ -16,6 +16,8 @@
     <properties>
         <jakarta.servlet-api.version>6.0.0</jakarta.servlet-api.version>
         <skip.spring.v6x.test>false</skip.spring.v6x.test>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/sentinel-adapter/sentinel-web-servlet-jakarta/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/CommonFilter.java
+++ b/sentinel-adapter/sentinel-web-servlet-jakarta/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/CommonFilter.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.servlet;
+
+import java.io.IOException;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import com.alibaba.csp.sentinel.Entry;
+import com.alibaba.csp.sentinel.EntryType;
+import com.alibaba.csp.sentinel.ResourceTypeConstants;
+import com.alibaba.csp.sentinel.SphU;
+import com.alibaba.csp.sentinel.Tracer;
+import com.alibaba.csp.sentinel.adapter.servlet.callback.RequestOriginParser;
+import com.alibaba.csp.sentinel.adapter.servlet.callback.UrlCleaner;
+import com.alibaba.csp.sentinel.adapter.servlet.callback.WebCallbackManager;
+import com.alibaba.csp.sentinel.adapter.servlet.config.WebServletConfig;
+import com.alibaba.csp.sentinel.adapter.servlet.util.FilterUtil;
+import com.alibaba.csp.sentinel.context.ContextUtil;
+import com.alibaba.csp.sentinel.slots.block.BlockException;
+import com.alibaba.csp.sentinel.util.StringUtil;
+
+/**
+ * Servlet filter that integrates with Sentinel.
+ *
+ * @author youji.zj
+ * @author Eric Zhao
+ * @author zhaoyuguang
+ */
+public class CommonFilter implements Filter {
+
+    /**
+     * Specify whether the URL resource name should contain the HTTP method prefix (e.g. {@code POST:}).
+     */
+    public static final String HTTP_METHOD_SPECIFY = "HTTP_METHOD_SPECIFY";
+    /**
+     * If enabled, use the default context name, or else use the URL path as the context name,
+     * {@link WebServletConfig#WEB_SERVLET_CONTEXT_NAME}. Please pay attention to the number of context (EntranceNode),
+     * which may affect the memory footprint.
+     *
+     * @since 1.7.0
+     */
+    public static final String WEB_CONTEXT_UNIFY = "WEB_CONTEXT_UNIFY";
+
+    private final static String COLON = ":";
+
+    private boolean httpMethodSpecify = false;
+    private boolean webContextUnify = true;
+
+    @Override
+    public void init(FilterConfig filterConfig) {
+        httpMethodSpecify = Boolean.parseBoolean(filterConfig.getInitParameter(HTTP_METHOD_SPECIFY));
+        if (filterConfig.getInitParameter(WEB_CONTEXT_UNIFY) != null) {
+            webContextUnify = Boolean.parseBoolean(filterConfig.getInitParameter(WEB_CONTEXT_UNIFY));
+        }
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        HttpServletRequest sRequest = (HttpServletRequest) request;
+        Entry urlEntry = null;
+
+        try {
+            String target = FilterUtil.filterTarget(sRequest);
+            // Clean and unify the URL.
+            // For REST APIs, you have to clean the URL (e.g. `/foo/1` and `/foo/2` -> `/foo/:id`), or
+            // the amount of context and resources will exceed the threshold.
+            UrlCleaner urlCleaner = WebCallbackManager.getUrlCleaner();
+            if (urlCleaner != null) {
+                target = urlCleaner.clean(target);
+            }
+
+            // If you intend to exclude some URLs, you can convert the URLs to the empty string ""
+            // in the UrlCleaner implementation.
+            if (!StringUtil.isEmpty(target)) {
+                // Parse the request origin using registered origin parser.
+                String origin = parseOrigin(sRequest);
+                String contextName = webContextUnify ? WebServletConfig.WEB_SERVLET_CONTEXT_NAME : target;
+                ContextUtil.enter(contextName, origin);
+
+                if (httpMethodSpecify) {
+                    // Add HTTP method prefix if necessary.
+                    String pathWithHttpMethod = sRequest.getMethod().toUpperCase() + COLON + target;
+                    urlEntry = SphU.entry(pathWithHttpMethod, ResourceTypeConstants.COMMON_WEB, EntryType.IN);
+                } else {
+                    urlEntry = SphU.entry(target, ResourceTypeConstants.COMMON_WEB, EntryType.IN);
+                }
+            }
+            chain.doFilter(request, response);
+        } catch (BlockException e) {
+            HttpServletResponse sResponse = (HttpServletResponse) response;
+            // Return the block page, or redirect to another URL.
+            WebCallbackManager.getUrlBlockHandler().blocked(sRequest, sResponse, e);
+        } catch (IOException | ServletException | RuntimeException e2) {
+            Tracer.traceEntry(e2, urlEntry);
+            throw e2;
+        } finally {
+            if (urlEntry != null) {
+                urlEntry.exit();
+            }
+            ContextUtil.exit();
+        }
+    }
+
+    private String parseOrigin(HttpServletRequest request) {
+        RequestOriginParser originParser = WebCallbackManager.getRequestOriginParser();
+        String origin = EMPTY_ORIGIN;
+        if (originParser != null) {
+            origin = originParser.parseOrigin(request);
+            if (StringUtil.isEmpty(origin)) {
+                return EMPTY_ORIGIN;
+            }
+        }
+        return origin;
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+
+    private static final String EMPTY_ORIGIN = "";
+}

--- a/sentinel-adapter/sentinel-web-servlet-jakarta/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/CommonTotalFilter.java
+++ b/sentinel-adapter/sentinel-web-servlet-jakarta/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/CommonTotalFilter.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.servlet;
+
+import java.io.IOException;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import com.alibaba.csp.sentinel.Entry;
+import com.alibaba.csp.sentinel.ResourceTypeConstants;
+import com.alibaba.csp.sentinel.SphU;
+import com.alibaba.csp.sentinel.Tracer;
+import com.alibaba.csp.sentinel.adapter.servlet.callback.WebCallbackManager;
+import com.alibaba.csp.sentinel.adapter.servlet.config.WebServletConfig;
+import com.alibaba.csp.sentinel.context.ContextUtil;
+import com.alibaba.csp.sentinel.slots.block.BlockException;
+
+/***
+ * Servlet filter for all requests.
+ *
+ * @author youji.zj
+ */
+public class CommonTotalFilter implements Filter {
+
+    public static final String TOTAL_URL_REQUEST = "total-url-request";
+
+    @Override
+    public void init(FilterConfig filterConfig) {
+
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response,
+                         FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest sRequest = (HttpServletRequest)request;
+
+        Entry entry = null;
+        try {
+            ContextUtil.enter(WebServletConfig.WEB_SERVLET_CONTEXT_NAME);
+            entry = SphU.entry(TOTAL_URL_REQUEST, ResourceTypeConstants.COMMON_WEB);
+            chain.doFilter(request, response);
+        } catch (BlockException e) {
+            HttpServletResponse sResponse = (HttpServletResponse)response;
+            WebCallbackManager.getUrlBlockHandler().blocked(sRequest, sResponse, e);
+        } catch (IOException | ServletException | RuntimeException e2) {
+            Tracer.trace(e2);
+            throw e2;
+        } finally {
+            if (entry != null) {
+                entry.exit();
+            }
+            ContextUtil.exit();
+        }
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+
+}

--- a/sentinel-adapter/sentinel-web-servlet-jakarta/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/callback/DefaultUrlBlockHandler.java
+++ b/sentinel-adapter/sentinel-web-servlet-jakarta/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/callback/DefaultUrlBlockHandler.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.servlet.callback;
+
+import java.io.IOException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import com.alibaba.csp.sentinel.adapter.servlet.util.FilterUtil;
+import com.alibaba.csp.sentinel.slots.block.BlockException;
+
+/***
+ * The default {@link UrlBlockHandler}.
+ *
+ * @author youji.zj
+ */
+public class DefaultUrlBlockHandler implements UrlBlockHandler {
+
+    @Override
+    public void blocked(HttpServletRequest request, HttpServletResponse response, BlockException ex)
+        throws IOException {
+        // Directly redirect to the default flow control (blocked) page or customized block page.
+        FilterUtil.blockRequest(request, response);
+    }
+}

--- a/sentinel-adapter/sentinel-web-servlet-jakarta/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/callback/DefaultUrlCleaner.java
+++ b/sentinel-adapter/sentinel-web-servlet-jakarta/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/callback/DefaultUrlCleaner.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.servlet.callback;
+
+/***
+ * @author youji.zj
+ */
+public class DefaultUrlCleaner implements UrlCleaner {
+
+    @Override
+    public String clean(String originUrl) {
+        return originUrl;
+    }
+}

--- a/sentinel-adapter/sentinel-web-servlet-jakarta/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/callback/RequestOriginParser.java
+++ b/sentinel-adapter/sentinel-web-servlet-jakarta/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/callback/RequestOriginParser.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.servlet.callback;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * The origin parser parses request origin (e.g. IP, user, appName) from HTTP request.
+ *
+ * @author Eric Zhao
+ * @since 0.2.0
+ */
+public interface RequestOriginParser {
+
+    /**
+     * Parse the origin from given HTTP request.
+     *
+     * @param request HTTP request
+     * @return parsed origin
+     */
+    String parseOrigin(HttpServletRequest request);
+}

--- a/sentinel-adapter/sentinel-web-servlet-jakarta/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/callback/UrlBlockHandler.java
+++ b/sentinel-adapter/sentinel-web-servlet-jakarta/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/callback/UrlBlockHandler.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.servlet.callback;
+
+import java.io.IOException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import com.alibaba.csp.sentinel.slots.block.BlockException;
+
+/***
+ * The URL block handler handles requests when blocked.
+ *
+ * @author youji.zj
+ */
+public interface UrlBlockHandler {
+
+    /**
+     * Handle the request when blocked.
+     *
+     * @param request  Servlet request
+     * @param response Servlet response
+     * @param ex       the block exception.
+     * @throws IOException some error occurs
+     */
+    void blocked(HttpServletRequest request, HttpServletResponse response, BlockException ex) throws IOException;
+}

--- a/sentinel-adapter/sentinel-web-servlet-jakarta/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/callback/UrlCleaner.java
+++ b/sentinel-adapter/sentinel-web-servlet-jakarta/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/callback/UrlCleaner.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.servlet.callback;
+
+/***
+ * @author youji.zj
+ */
+public interface UrlCleaner {
+
+    /***
+     * <p>Process the url. Some path variables should be handled and unified.</p>
+     * <p>e.g. collect_item_relation--10200012121-.html will be converted to collect_item_relation.html</p>
+     *
+     * @param originUrl original url
+     * @return processed url
+     */
+    String clean(String originUrl);
+}

--- a/sentinel-adapter/sentinel-web-servlet-jakarta/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/callback/WebCallbackManager.java
+++ b/sentinel-adapter/sentinel-web-servlet-jakarta/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/callback/WebCallbackManager.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.servlet.callback;
+
+import com.alibaba.csp.sentinel.util.AssertUtil;
+
+/**
+ * Registry for URL cleaner and URL block handler.
+ *
+ * @author youji.zj
+ */
+public class WebCallbackManager {
+
+    /**
+     * URL cleaner.
+     */
+    private static volatile UrlCleaner urlCleaner = new DefaultUrlCleaner();
+
+    /**
+     * URL block handler.
+     */
+    private static volatile UrlBlockHandler urlBlockHandler = new DefaultUrlBlockHandler();
+
+    private static volatile RequestOriginParser requestOriginParser = null;
+
+    public static UrlCleaner getUrlCleaner() {
+        return urlCleaner;
+    }
+
+    public static void setUrlCleaner(UrlCleaner urlCleaner) {
+        WebCallbackManager.urlCleaner = urlCleaner;
+    }
+
+    public static UrlBlockHandler getUrlBlockHandler() {
+        return urlBlockHandler;
+    }
+
+    public static void setUrlBlockHandler(UrlBlockHandler urlBlockHandler) {
+        AssertUtil.isTrue(urlBlockHandler != null, "URL block handler should not be null");
+        WebCallbackManager.urlBlockHandler = urlBlockHandler;
+    }
+
+    public static RequestOriginParser getRequestOriginParser() {
+        return requestOriginParser;
+    }
+
+    public static void setRequestOriginParser(RequestOriginParser requestOriginParser) {
+        WebCallbackManager.requestOriginParser = requestOriginParser;
+    }
+}

--- a/sentinel-adapter/sentinel-web-servlet-jakarta/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/config/WebServletConfig.java
+++ b/sentinel-adapter/sentinel-web-servlet-jakarta/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/config/WebServletConfig.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.servlet.config;
+
+import com.alibaba.csp.sentinel.adapter.servlet.CommonFilter;
+import com.alibaba.csp.sentinel.adapter.servlet.CommonTotalFilter;
+import com.alibaba.csp.sentinel.config.SentinelConfig;
+import com.alibaba.csp.sentinel.log.RecordLog;
+import com.alibaba.csp.sentinel.util.StringUtil;
+
+/**
+ * The configuration center for Web Servlet adapter.
+ *
+ * @author leyou
+ * @author zhaoyuguang
+ */
+public final class WebServletConfig {
+
+    public static final String WEB_SERVLET_CONTEXT_NAME = "sentinel_web_servlet_context";
+
+    public static final String BLOCK_PAGE_URL_CONF_KEY = "csp.sentinel.web.servlet.block.page";
+    public static final String BLOCK_PAGE_HTTP_STATUS_CONF_KEY = "csp.sentinel.web.servlet.block.status";
+
+    private static final int HTTP_STATUS_TOO_MANY_REQUESTS = 429;
+
+    /**
+     * Get redirecting page when Sentinel blocking for {@link CommonFilter} or
+     * {@link CommonTotalFilter} occurs.
+     *
+     * @return the block page URL, maybe null if not configured.
+     */
+    public static String getBlockPage() {
+        return SentinelConfig.getConfig(BLOCK_PAGE_URL_CONF_KEY);
+    }
+
+    public static void setBlockPage(String blockPage) {
+        SentinelConfig.setConfig(BLOCK_PAGE_URL_CONF_KEY, blockPage);
+    }
+
+    /**
+     * <p>Get the HTTP status when using the default block page.</p>
+     * <p>You can set the status code with the {@code -Dcsp.sentinel.web.servlet.block.status}
+     * property. When the property is empty or invalid, Sentinel will use 429 (Too Many Requests)
+     * as the default status code.</p>
+     *
+     * @return the HTTP status of the default block page
+     * @since 1.7.0
+     */
+    public static int getBlockPageHttpStatus() {
+        String value = SentinelConfig.getConfig(BLOCK_PAGE_HTTP_STATUS_CONF_KEY);
+        if (StringUtil.isEmpty(value)) {
+            return HTTP_STATUS_TOO_MANY_REQUESTS;
+        }
+        try {
+            int s = Integer.parseInt(value);
+            if (s <= 0) {
+                throw new IllegalArgumentException("Invalid status code: " + s);
+            }
+            return s;
+        } catch (Exception e) {
+            RecordLog.warn("[WebServletConfig] Invalid block HTTP status (" + value + "), using default 429");
+            setBlockPageHttpStatus(HTTP_STATUS_TOO_MANY_REQUESTS);
+        }
+        return HTTP_STATUS_TOO_MANY_REQUESTS;
+    }
+
+    /**
+     * Set the HTTP status of the default block page.
+     *
+     * @param httpStatus the HTTP status of the default block page
+     * @since 1.7.0
+     */
+    public static void setBlockPageHttpStatus(int httpStatus) {
+        if (httpStatus <= 0) {
+            throw new IllegalArgumentException("Invalid HTTP status code: " + httpStatus);
+        }
+        SentinelConfig.setConfig(BLOCK_PAGE_HTTP_STATUS_CONF_KEY, String.valueOf(httpStatus));
+    }
+
+    private WebServletConfig() {}
+}

--- a/sentinel-adapter/sentinel-web-servlet-jakarta/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/util/FilterUtil.java
+++ b/sentinel-adapter/sentinel-web-servlet-jakarta/src/main/java/com/alibaba/csp/sentinel/adapter/servlet/util/FilterUtil.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.adapter.servlet.util;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import com.alibaba.csp.sentinel.adapter.servlet.config.WebServletConfig;
+import com.alibaba.csp.sentinel.util.StringUtil;
+
+/**
+ * Util class for web servlet filter.
+ *
+ * @author zhaoyuguang
+ * @author youji.zj
+ * @author Eric Zhao
+ */
+public final class FilterUtil {
+
+    private static final String PATH_SPLIT = "/";
+
+    public static String filterTarget(HttpServletRequest request) {
+        String pathInfo = getResourcePath(request);
+        if (!pathInfo.startsWith(PATH_SPLIT)) {
+            pathInfo = PATH_SPLIT + pathInfo;
+        }
+
+        if (PATH_SPLIT.equals(pathInfo)) {
+            return pathInfo;
+        }
+
+        // Note: pathInfo should be converted to camelCase style.
+        int lastSlashIndex = pathInfo.lastIndexOf("/");
+
+        if (lastSlashIndex >= 0) {
+            pathInfo = pathInfo.substring(0, lastSlashIndex) + "/"
+                + StringUtil.trim(pathInfo.substring(lastSlashIndex + 1));
+        } else {
+            pathInfo = PATH_SPLIT + StringUtil.trim(pathInfo);
+        }
+
+        return pathInfo;
+    }
+
+    public static void blockRequest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        StringBuffer url = request.getRequestURL();
+
+        if ("GET".equals(request.getMethod()) && StringUtil.isNotBlank(request.getQueryString())) {
+            url.append("?").append(request.getQueryString());
+        }
+
+        if (StringUtil.isBlank(WebServletConfig.getBlockPage())) {
+            writeDefaultBlockedPage(response, WebServletConfig.getBlockPageHttpStatus());
+        } else {
+            String redirectUrl = WebServletConfig.getBlockPage() + "?http_referer=" + url.toString();
+            // Redirect to the customized block page.
+            response.sendRedirect(redirectUrl);
+        }
+    }
+
+    private static void writeDefaultBlockedPage(HttpServletResponse response, int httpStatus) throws IOException {
+        response.setStatus(httpStatus);
+        PrintWriter out = response.getWriter();
+        out.print(DEFAULT_BLOCK_MSG);
+        out.flush();
+        out.close();
+    }
+
+    private static String getResourcePath(HttpServletRequest request) {
+        String pathInfo = normalizeAbsolutePath(request.getPathInfo(), false);
+        String servletPath = normalizeAbsolutePath(request.getServletPath(), pathInfo.length() != 0);
+
+        return servletPath + pathInfo;
+    }
+
+    private static String normalizeAbsolutePath(String path, boolean removeTrailingSlash) throws IllegalStateException {
+        return normalizePath(path, true, false, removeTrailingSlash);
+    }
+
+    private static String normalizePath(String path, boolean forceAbsolute, boolean forceRelative,
+                                        boolean removeTrailingSlash) throws IllegalStateException {
+        char[] pathChars = StringUtil.trimToEmpty(path).toCharArray();
+        int length = pathChars.length;
+
+        // Check path and slash.
+        boolean startsWithSlash = false;
+        boolean endsWithSlash = false;
+
+        if (length > 0) {
+            char firstChar = pathChars[0];
+            char lastChar = pathChars[length - 1];
+
+            startsWithSlash = firstChar == PATH_SPLIT.charAt(0) || firstChar == '\\';
+            endsWithSlash = lastChar == PATH_SPLIT.charAt(0) || lastChar == '\\';
+        }
+
+        StringBuilder buf = new StringBuilder(length);
+        boolean isAbsolutePath = forceAbsolute || !forceRelative && startsWithSlash;
+        int index = startsWithSlash ? 0 : -1;
+        int level = 0;
+
+        if (isAbsolutePath) {
+            buf.append(PATH_SPLIT);
+        }
+
+        while (index < length) {
+            index = indexOfSlash(pathChars, index + 1, false);
+
+            if (index == length) {
+                break;
+            }
+
+            int nextSlashIndex = indexOfSlash(pathChars, index, true);
+
+            String element = new String(pathChars, index, nextSlashIndex - index);
+            index = nextSlashIndex;
+
+            // Ignore "."
+            if (".".equals(element)) {
+                continue;
+            }
+
+            // Backtrack ".."
+            if ("..".equals(element)) {
+                if (level == 0) {
+                    if (isAbsolutePath) {
+                        throw new IllegalStateException(path);
+                    } else {
+                        buf.append("..").append(PATH_SPLIT);
+                    }
+                } else {
+                    buf.setLength(pathChars[--level]);
+                }
+
+                continue;
+            }
+
+            pathChars[level++] = (char)buf.length();
+            buf.append(element).append(PATH_SPLIT);
+        }
+
+        // remove the last "/"
+        if (buf.length() > 0) {
+            if (!endsWithSlash || removeTrailingSlash) {
+                buf.setLength(buf.length() - 1);
+            }
+        }
+
+        return buf.toString();
+    }
+
+    private static int indexOfSlash(char[] chars, int beginIndex, boolean slash) {
+        int i = beginIndex;
+
+        for (; i < chars.length; i++) {
+            char ch = chars[i];
+
+            if (slash) {
+                if (ch == PATH_SPLIT.charAt(0) || ch == '\\') {
+                    break; // if a slash
+                }
+            } else {
+                if (ch != PATH_SPLIT.charAt(0) && ch != '\\') {
+                    break; // if not a slash
+                }
+            }
+        }
+
+        return i;
+    }
+
+    public static final String DEFAULT_BLOCK_MSG = "Blocked by Sentinel (flow limiting)";
+
+    private FilterUtil() {}
+}


### PR DESCRIPTION
Fixes #2998

Replaces #3618 (rebased onto latest `1.8` to resolve merge conflicts).

## Summary

Add sentinel-web-servlet-jakarta module to support Jakarta EE Servlet 6.0 (Spring Boot 3.x, JDK 17+).

## Background

Spring Boot 3.x migrated from javax.servlet to jakarta.servlet as part of the Jakarta EE 9+ transition. The existing sentinel-web-servlet module uses javax.servlet-api 3.1.0 and is incompatible with Spring Boot 3.x applications.

## Changes

### New module: sentinel-adapter/sentinel-web-servlet-jakarta

- pom.xml: Maven configuration with jakarta.servlet-api 6.0.0 and Spring Boot 3.2.0 for tests
- 10 Java source files from sentinel-web-servlet with javax.servlet to jakarta.servlet migration
  - CommonFilter, CommonTotalFilter, callback classes, config, utils

### Modified: sentinel-adapter/pom.xml

- Added module sentinel-web-servlet-jakarta (only in jdk17-plus profile)
- Added `skip.spring.v6x.test` property to skip tests on JDK < 17

## Compatibility

- Jakarta EE Servlet 6.0+
- Spring Boot 3.x
- JDK 17+