### PR TITLE
fix: preserve plus signs in param flow rules

### DIFF
--- a/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/command/handler/ModifyParamFlowRulesCommandHandler.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/main/java/com/alibaba/csp/sentinel/command/handler/ModifyParamFlowRulesCommandHandler.java
@@ -15,7 +15,6 @@
  */
 package com.alibaba.csp.sentinel.command.handler;
 
-import java.net.URLDecoder;
 import java.util.List;
 
 import com.alibaba.csp.sentinel.command.CommandHandler;
@@ -43,12 +42,6 @@ public class ModifyParamFlowRulesCommandHandler implements CommandHandler<String
         String data = request.getParam("data");
         if (StringUtil.isBlank(data)) {
             return CommandResponse.ofFailure(new IllegalArgumentException("Bad data"));
-        }
-        try {
-            data = URLDecoder.decode(data, "utf-8");
-        } catch (Exception e) {
-            RecordLog.info("Decode rule data error", e);
-            return CommandResponse.ofFailure(e, "decode rule data error");
         }
 
         RecordLog.info("[API Server] Receiving rule change (type:parameter flow rule): {}", data);

--- a/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ModifyParamFlowRulesCommandHandlerTest.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ModifyParamFlowRulesCommandHandlerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.slots.block.flow.param;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.alibaba.csp.sentinel.command.CommandRequest;
+import com.alibaba.csp.sentinel.command.CommandResponse;
+import com.alibaba.csp.sentinel.command.handler.ModifyParamFlowRulesCommandHandler;
+import com.alibaba.fastjson.JSON;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ModifyParamFlowRulesCommandHandlerTest {
+
+    @After
+    public void tearDown() {
+        ParamFlowRuleManager.loadRules(Collections.<ParamFlowRule>emptyList());
+    }
+
+    @Test
+    public void testHandleDecodedDataPreservesPlusInParamFlowItem() {
+        ParamFlowRule rule = new ParamFlowRule("test-resource")
+            .setParamIdx(0)
+            .setCount(1);
+        rule.setParamFlowItemList(Collections.singletonList(new ParamFlowItem("a+b", 3, String.class.getName())));
+
+        CommandRequest request = new CommandRequest();
+        request.addParam("data", JSON.toJSONString(Collections.singletonList(rule)));
+
+        CommandResponse<String> response = new ModifyParamFlowRulesCommandHandler().handle(request);
+
+        assertTrue(response.isSuccess());
+        List<ParamFlowRule> rules = ParamFlowRuleManager.getRulesOfResource("test-resource");
+        assertEquals(1, rules.size());
+        assertEquals(Integer.valueOf(3), rules.get(0).getParsedHotItems().get("a+b"));
+    }
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

When setting hotspot parameter flow rules through `setParamFlowRules`, values containing a literal plus sign are currently decoded twice. The HTTP command layer already decodes request parameters before they reach `CommandRequest`, so decoding `data` again changes `+` into a space and alters the configured hotspot item value.

### Does this pull request fix one issue?
Fixes #3505

### Describe how you did it

Removed the extra `URLDecoder.decode(...)` call from `ModifyParamFlowRulesCommandHandler` and added a regression test that submits already-decoded rule JSON with a hotspot item value of `a+b`.

### Describe how to verify it
`JAVA_HOME=$(/usr/libexec/java_home -v 17) mvn -pl sentinel-extension/sentinel-parameter-flow-control -am -Dtest=ModifyParamFlowRulesCommandHandlerTest -Dsurefire.failIfNoSpecifiedTests=false test`
`JAVA_HOME=$(/usr/libexec/java_home -v 17) mvn -pl sentinel-extension/sentinel-parameter-flow-control -am -Dsurefire.failIfNoSpecifiedTests=false test`