### PR TITLE
Fix FlowRuleComparator violating the Comparator contract

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleComparator.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleComparator.java
@@ -37,8 +37,14 @@ public class FlowRuleComparator implements Comparator<FlowRule> {
             return -1;
         }
 
-        if (o1.getLimitApp() == null) {
+        if (o1.getLimitApp() == null && o2.getLimitApp() == null) {
             return 0;
+        }
+        if (o1.getLimitApp() == null) {
+            return 1;
+        }
+        if (o2.getLimitApp() == null) {
+            return -1;
         }
 
         if (o1.getLimitApp().equals(o2.getLimitApp())) {
@@ -50,7 +56,7 @@ public class FlowRuleComparator implements Comparator<FlowRule> {
         } else if (RuleConstant.LIMIT_APP_DEFAULT.equals(o2.getLimitApp())) {
             return -1;
         } else {
-            return 0;
+            return o1.getLimitApp().compareTo(o2.getLimitApp());
         }
     }
 

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleComparatorTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/FlowRuleComparatorTest.java
@@ -42,4 +42,42 @@ public class FlowRuleComparatorTest {
             assertEquals(expected.get(i), actual.get(i));
         }
     }
+
+    @Test
+    public void testNullVsNonNullLimitApp() {
+        FlowRuleComparator comparator = new FlowRuleComparator();
+
+        // o1 has null limitApp, o2 has non-null limitApp
+        FlowRule ruleNull = new FlowRule("abc");
+        ruleNull.setLimitApp(null);
+        FlowRule ruleNonNull = new FlowRule("abc");
+        ruleNonNull.setLimitApp("originA");
+
+        // Comparator should NOT return 0 when one is null and the other is not
+        int result = comparator.compare(ruleNull, ruleNonNull);
+        assertNotEquals("null vs non-null should not be equal", 0, result);
+
+        // Symmetry: compare(o2, o1) should be -compare(o1, o2)
+        int reverseResult = comparator.compare(ruleNonNull, ruleNull);
+        assertEquals("comparator must be antisymmetric", -result, reverseResult);
+    }
+
+    @Test
+    public void testDifferentNonDefaultLimitApps() {
+        FlowRuleComparator comparator = new FlowRuleComparator();
+
+        // Two rules with different non-DEFAULT limitApp values
+        FlowRule ruleA = new FlowRule("abc");
+        ruleA.setLimitApp("originA");
+        FlowRule ruleB = new FlowRule("abc");
+        ruleB.setLimitApp("originB");
+
+        // Different apps should NOT compare as equal (0)
+        int result = comparator.compare(ruleA, ruleB);
+        assertNotEquals("different non-default apps should not be equal", 0, result);
+
+        // Symmetry check
+        int reverseResult = comparator.compare(ruleB, ruleA);
+        assertEquals("comparator must be antisymmetric", -result, reverseResult);
+    }
 }


### PR DESCRIPTION
## Problem

`FlowRuleComparator.compare` returns `0` (equal) for rules that are not actually equal:

```java
if (o1.getLimitApp() == null) {
    return 0;                       // returns 0 even when o2.getLimitApp() is non-null
}
...
} else {
    return 0;                       // two different non-default limitApps compare as equal
}
```

So a rule whose `limitApp` is `null` compares equal to any other rule, and two rules with different non-default `limitApp` values (e.g. `originA` vs `originB`) compare equal. Returning `0` for unequal elements violates the `Comparator` contract and can cause rules to be dropped when stored in a sorted structure.

## Fix

- Return `0` only when both `limitApp`s are `null`; otherwise order a `null` consistently against a non-null value.
- Compare two different non-default `limitApp`s with `String.compareTo` instead of returning `0`.

## Test

Adds `testNullVsNonNullLimitApp` and `testDifferentNonDefaultLimitApps` to `FlowRuleComparatorTest`, each also checking antisymmetry. Both fail on `1.8` (`compare` returns `0` for unequal rules) and pass with this change.

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
