### PR TITLE
Guard MetricNode.fromThinString against lines with fewer than 7 fields

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/metric/MetricNode.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/metric/MetricNode.java
@@ -183,13 +183,27 @@ public class MetricNode {
     public static MetricNode fromThinString(String line) {
         MetricNode node = new MetricNode();
         String[] strs = line.split("\\|");
-        node.setTimestamp(Long.parseLong(strs[0]));
-        node.setResource(strs[1]);
-        node.setPassQps(Long.parseLong(strs[2]));
-        node.setBlockQps(Long.parseLong(strs[3]));
-        node.setSuccessQps(Long.parseLong(strs[4]));
-        node.setExceptionQps(Long.parseLong(strs[5]));
-        node.setRt(Long.parseLong(strs[6]));
+        if (strs.length >= 1) {
+            node.setTimestamp(Long.parseLong(strs[0]));
+        }
+        if (strs.length >= 2) {
+            node.setResource(strs[1]);
+        }
+        if (strs.length >= 3) {
+            node.setPassQps(Long.parseLong(strs[2]));
+        }
+        if (strs.length >= 4) {
+            node.setBlockQps(Long.parseLong(strs[3]));
+        }
+        if (strs.length >= 5) {
+            node.setSuccessQps(Long.parseLong(strs[4]));
+        }
+        if (strs.length >= 6) {
+            node.setExceptionQps(Long.parseLong(strs[5]));
+        }
+        if (strs.length >= 7) {
+            node.setRt(Long.parseLong(strs[6]));
+        }
         if (strs.length >= 8) {
             node.setOccupiedPassQps(Long.parseLong(strs[7]));
         }

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/node/metric/MetricNodeTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/node/metric/MetricNodeTest.java
@@ -34,4 +34,17 @@ public class MetricNodeTest {
         assertEquals(2, node.getConcurrency());
         assertEquals(1, node.getSuccessQps());
     }
+
+    @Test
+    public void testFromThinStringShortInput() {
+        // Input with only 3 pipe-separated fields (fewer than the required 7).
+        // The method should gracefully handle missing fields and NOT throw
+        // ArrayIndexOutOfBoundsException, consistent with how later fields
+        // (strs[7], strs[8], strs[9]) already have length guards.
+        String line = "1564382218000|resource|10";
+        MetricNode node = MetricNode.fromThinString(line);
+        assertEquals(1564382218000L, node.getTimestamp());
+        assertEquals("resource", node.getResource());
+        assertEquals(10L, node.getPassQps());
+    }
 }


### PR DESCRIPTION
## Problem

`MetricNode.fromThinString` splits the line on `|` and then reads `strs[0]` through `strs[6]` unconditionally:

```java
String[] strs = line.split("\\|");
node.setTimestamp(Long.parseLong(strs[0]));
...
node.setRt(Long.parseLong(strs[6]));
if (strs.length >= 8) {            // trailing fields are already guarded
    node.setOccupiedPassQps(Long.parseLong(strs[7]));
}
```

A line with fewer than seven fields (a short or truncated metric line) throws `ArrayIndexOutOfBoundsException`, even though the optional trailing fields are already protected with length checks.

## Fix

Apply the same length guard to the leading fields, so a short line is parsed defensively (populating the fields that are present) instead of crashing — consistent with the existing handling of `strs[7]`/`strs[8]`.

## Test

Adds `testFromThinStringShortInput` to `MetricNodeTest` with a 3-field line. It fails on `1.8` (`ArrayIndexOutOfBoundsException: Index 3 out of bounds for length 3`) and passes with this change.

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
