### PR TITLE
Fix dashboard underscore environment variable lookup

### DIFF
--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/config/DashboardConfig.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/config/DashboardConfig.java
@@ -73,6 +73,13 @@ public class DashboardConfig {
         if (StringUtils.isNotEmpty(val)) {
             return val;
         }
+        String underscoreName = name.replace('.', '_');
+        if (!underscoreName.equals(name)) {
+            val = System.getenv(underscoreName);
+            if (StringUtils.isNotEmpty(val)) {
+                return val;
+            }
+        }
         // properties
         val = System.getProperty(name);
         if (StringUtils.isNotEmpty(val)) {

--- a/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/config/DashboardConfigTest.java
+++ b/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/config/DashboardConfigTest.java
@@ -48,6 +48,15 @@ public class DashboardConfigTest {
     }
 
     @Test
+    public void testGetConfigStrFromUnderscoreEnv() {
+        DashboardConfig.clearCache();
+
+        environmentVariables.set("sentinel_dashboard_auth_password", "from_env");
+
+        assertEquals("from_env", DashboardConfig.getAuthPassword());
+    }
+
+    @Test
     public void testGetConfigInt() {
         // clear cache
         DashboardConfig.clearCache();


### PR DESCRIPTION
### Describe what this PR does / why we need it

The dashboard documentation uses underscore-style environment variables such as `sentinel_dashboard_auth_password`, but `DashboardConfig` only looked up the dotted key (`sentinel.dashboard.auth.password`).

This adds an underscore environment variable fallback for dotted config names, while keeping the existing exact environment variable lookup and system property fallback order unchanged.

### Does this pull request fix one issue?

Fixes #3543

### Describe how you did it

When reading a config key from the environment, `DashboardConfig` now:

1. checks the exact environment variable name first;
2. checks the dotted name converted to underscore form;
3. falls back to the existing system property lookup.

A unit test covers `sentinel_dashboard_auth_password` resolving through `getAuthPassword()`.

### Describe how to verify it

I verified the new behavior with `DashboardConfigTest`:

```bash
mvn -s /tmp/codex-empty-maven-settings.xml -pl sentinel-dashboard -am -DskipTests test-compile

CP="sentinel-dashboard/target/test-classes:sentinel-dashboard/target/classes:sentinel-core/target/classes:$HOME/.m2/repository/junit/junit/4.12/junit-4.12.jar:$HOME/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar:$HOME/.m2/repository/com/github/stefanbirkner/system-rules/1.16.1/system-rules-1.16.1.jar:$HOME/.m2/repository/commons-lang/commons-lang/2.6/commons-lang-2.6.jar:$HOME/.m2/repository/org/springframework/spring-core/5.3.18/spring-core-5.3.18.jar"
java --add-opens java.base/java.util=ALL-UNNAMED -cp "$CP" org.junit.runner.JUnitCore com.alibaba.csp.sentinel.dashboard.config.DashboardConfigTest
```

Result:

```text
OK (3 tests)
```

`git diff --check` also passed.

### Special notes for reviews

The local Maven/Surefire run selected the JUnit Platform provider because `spring-boot-starter-test` brings in JUnit Jupiter, but this test class is JUnit 4 and no Vintage engine is present. I used `JUnitCore` directly so the existing JUnit 4 test class actually runs instead of reporting zero tests.
