### PR TITLE
Guard TokenClientHandler.getRemoteAddress against unresolved remote address

### DIFF
--- a/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/handler/TokenClientHandler.java
+++ b/sentinel-cluster/sentinel-cluster-client-default/src/main/java/com/alibaba/csp/sentinel/cluster/client/handler/TokenClientHandler.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.csp.sentinel.cluster.client.handler;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -106,7 +107,8 @@ public class TokenClientHandler extends ChannelInboundHandlerAdapter {
             return null;
         }
         InetSocketAddress inetAddress = (InetSocketAddress) ctx.channel().remoteAddress();
-        return inetAddress.getAddress().getHostAddress() + ":" + inetAddress.getPort();
+        InetAddress addr = inetAddress.getAddress();
+        return (addr != null ? addr.getHostAddress() : inetAddress.getHostName()) + ":" + inetAddress.getPort();
     }
 
     public int getCurrentState() {

--- a/sentinel-cluster/sentinel-cluster-client-default/src/test/java/com/alibaba/csp/sentinel/cluster/client/handler/TokenClientHandlerTest.java
+++ b/sentinel-cluster/sentinel-cluster-client-default/src/test/java/com/alibaba/csp/sentinel/cluster/client/handler/TokenClientHandlerTest.java
@@ -1,0 +1,47 @@
+package com.alibaba.csp.sentinel.cluster.client.handler;
+
+import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TokenClientHandlerTest {
+
+    private Channel mockChannel;
+    private ChannelHandlerContext mockCtx;
+    private TokenClientHandler handler;
+
+    @Before
+    public void setUp() {
+        mockChannel = mock(Channel.class);
+        mockCtx = mock(ChannelHandlerContext.class);
+        handler = new TokenClientHandler(new AtomicInteger(0), () -> { });
+        when(mockCtx.channel()).thenReturn(mockChannel);
+    }
+
+    @Test
+    public void testGetRemoteAddressWithUnresolvedSocketAddress() throws Exception {
+        InetSocketAddress unresolved = InetSocketAddress.createUnresolved("unresolved.host", 8710);
+        Assert.assertNull("Unresolved address should have null InetAddress", unresolved.getAddress());
+        when(mockChannel.remoteAddress()).thenReturn(unresolved);
+        Method method = TokenClientHandler.class.getDeclaredMethod("getRemoteAddress", ChannelHandlerContext.class);
+        method.setAccessible(true);
+        try {
+            String result = (String) method.invoke(handler, mockCtx);
+            Assert.assertNotNull("Should return a non-null result for unresolved address", result);
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            if (e.getCause() instanceof NullPointerException) {
+                Assert.fail("getRemoteAddress should handle unresolved InetSocketAddress without NPE, but got: " + e.getCause());
+            }
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
`TokenClientHandler.getRemoteAddress` does:

```java
inetAddress.getAddress().getHostAddress()
```

For an unresolved `InetSocketAddress` (the remote address never resolved, or `createUnresolved(...)`), `getAddress()` returns `null`, so this throws `NullPointerException`. It is reached from `channelUnregistered`, which logs the remote address during channel cleanup, so a channel whose remote address is unresolved NPEs on unregister.

This falls back to `getHostName()` when `getAddress()` is null. Adds a test that fails before the change (NPE) and passes after.

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
