### PR TITLE
Guard MetricFileNameComparator against filenames with fewer than 3 parts

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/metric/MetricWriter.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/node/metric/MetricWriter.java
@@ -243,12 +243,14 @@ public class MetricWriter {
         public int compare(String o1, String o2) {
             String name1 = new File(o1).getName();
             String name2 = new File(o2).getName();
-            String dateStr1 = name1.split("\\.")[2];
-            String dateStr2 = name2.split("\\.")[2];
+            String[] parts1 = name1.split("\\.");
+            String[] parts2 = name2.split("\\.");
+            String dateStr1 = parts1.length > 2 ? parts1[2] : "";
+            String dateStr2 = parts2.length > 2 ? parts2[2] : "";
             // in case of file name contains pid, skip it, like Sentinel-Admin-metrics.log.pid22568.2018-12-24
             if (dateStr1.startsWith(pid)) {
-                dateStr1 = name1.split("\\.")[3];
-                dateStr2 = name2.split("\\.")[3];
+                dateStr1 = parts1.length > 3 ? parts1[3] : "";
+                dateStr2 = parts2.length > 3 ? parts2[3] : "";
             }
 
             // compare date first

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/node/metric/MetricWriterTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/node/metric/MetricWriterTest.java
@@ -80,4 +80,9 @@ public class MetricWriterTest {
     }
 
 
+
+    @Test
+    public void testFileNameCmpTwoPartFilenameNoAIOOBE() {
+        MetricWriter.METRIC_FILE_NAME_CMP.compare("metrics.log", "metrics.log.2018-03-06");
+    }
 }


### PR DESCRIPTION
`MetricWriter.MetricFileNameComparator.compare` splits the metric file name on `"."` and reads index `[2]` (and `[3]` for pid-prefixed names) without checking the array length. A name with fewer parts (for example `"metrics.log"`) therefore throws `ArrayIndexOutOfBoundsException` during sorting. This falls back to an empty string when the part is absent. Adds a test.

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
