### PR TITLE
fix: replace printStackTrace with RecordLog in ConfigUtil

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/ConfigUtil.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/ConfigUtil.java
@@ -27,6 +27,8 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Properties;
 
+import com.alibaba.csp.sentinel.log.RecordLog;
+
 /**
  * <p>
  * Util class for loading configuration from file or command arguments.
@@ -75,7 +77,7 @@ public final class ConfigUtil {
                 properties.load(bufferedReader);
             }
         } catch (Throwable e) {
-            e.printStackTrace();
+            RecordLog.warn("Failed to load properties from absolute file: {}", fileName, e);
         }
         return properties;
     }
@@ -102,7 +104,7 @@ public final class ConfigUtil {
                 list.add(urls.nextElement());
             }
         } catch (Throwable e) {
-            e.printStackTrace();
+            RecordLog.warn("Failed to get resources from classpath: {}", fileName, e);
         }
 
         if (list.isEmpty()) {
@@ -117,7 +119,7 @@ public final class ConfigUtil {
                 p.load(bufferedReader);
                 properties.putAll(p);
             } catch (Throwable e) {
-                e.printStackTrace();
+                RecordLog.warn("Failed to load properties from URL: {}", url, e);
             }
         }
         return properties;


### PR DESCRIPTION
## Problem

ConfigUtil.java uses e.printStackTrace() in 3 places for error handling, which bypasses Sentinel's logging framework (RecordLog).

## Impact

- Stack traces go directly to stderr instead of through the configured logging system
- Cannot control log level, format, or output destination for these errors
- Inconsistent with the rest of the codebase which uses RecordLog

## Fix

Replace all 3 occurrences of e.printStackTrace() with RecordLog.warn() calls that include contextual information (file name or URL being loaded).

Closes #3637

Local environment limitations, relying on CI/CD automated testing.