### PR TITLE
fix: decouple HTTP status from body code in Zuul BlockResponse

### DIFF
--- a/sentinel-adapter/sentinel-zuul-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/zuul/fallback/BlockResponse.java
+++ b/sentinel-adapter/sentinel-zuul-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/zuul/fallback/BlockResponse.java
@@ -24,17 +24,40 @@ package com.alibaba.csp.sentinel.adapter.gateway.zuul.fallback;
 public class BlockResponse {
 
     /**
-     * HTTP status code.
+     * HTTP status code used for the actual HTTP response.
+     */
+    private int status;
+
+    /**
+     * Business code carried in the response body, independent of {@link #status}.
      */
     private int code;
 
     private String message;
     private String route;
 
+    /**
+     * @deprecated use {@link #BlockResponse(int, int, String, String)} instead.
+     * The given {@code code} will be used as both the HTTP status and the body code.
+     */
+    @Deprecated
     public BlockResponse(int code, String message, String route) {
+        this(code, code, message, route);
+    }
+
+    public BlockResponse(int status, int code, String message, String route) {
+        this.status = status;
         this.code = code;
         this.message = message;
         this.route = route;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    public void setStatus(int status) {
+        this.status = status;
     }
 
     public int getCode() {

--- a/sentinel-adapter/sentinel-zuul-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/zuul/filters/SentinelZuulPreFilter.java
+++ b/sentinel-adapter/sentinel-zuul-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/zuul/filters/SentinelZuulPreFilter.java
@@ -142,7 +142,7 @@ public class SentinelZuulPreFilter extends ZuulFilter {
 
             // Set fallback response.
             ctx.setResponseBody(blockResponse.toString());
-            ctx.setResponseStatusCode(blockResponse.getCode());
+            ctx.setResponseStatusCode(blockResponse.getStatus());
             // Set Response ContentType
             ctx.getResponse().setContentType("application/json; charset=utf-8");
         } finally {

--- a/sentinel-adapter/sentinel-zuul-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/zuul/fallback/BlockResponseTest.java
+++ b/sentinel-adapter/sentinel-zuul-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/zuul/fallback/BlockResponseTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.csp.sentinel.adapter.gateway.zuul.fallback;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test cases for {@link BlockResponse}.
+ */
+public class BlockResponseTest {
+
+    @Test
+    public void testDeprecatedConstructorKeepsStatusAndCodeInSync() {
+        BlockResponse response = new BlockResponse(429, "blocked", "/foo");
+
+        Assert.assertEquals(429, response.getStatus());
+        Assert.assertEquals(429, response.getCode());
+    }
+
+    @Test
+    public void testStatusAndCodeCanBeCustomizedIndependently() {
+        // Body code can differ from the actual HTTP status, see issue #2985.
+        BlockResponse response = new BlockResponse(200, 10018, "blocked", "/foo");
+
+        Assert.assertEquals(200, response.getStatus());
+        Assert.assertEquals(10018, response.getCode());
+        Assert.assertTrue(response.toString().contains("\"code\":10018"));
+    }
+}

--- a/sentinel-adapter/sentinel-zuul2-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/zuul2/fallback/BlockResponse.java
+++ b/sentinel-adapter/sentinel-zuul2-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/zuul2/fallback/BlockResponse.java
@@ -24,17 +24,40 @@ package com.alibaba.csp.sentinel.adapter.gateway.zuul2.fallback;
 public class BlockResponse {
 
     /**
-     * HTTP status code.
+     * HTTP status code used for the actual HTTP response.
+     */
+    private int status;
+
+    /**
+     * Business code carried in the response body, independent of {@link #status}.
      */
     private int code;
 
     private String message;
     private String route;
 
+    /**
+     * @deprecated use {@link #BlockResponse(int, int, String, String)} instead.
+     * The given {@code code} will be used as both the HTTP status and the body code.
+     */
+    @Deprecated
     public BlockResponse(int code, String message, String route) {
+        this(code, code, message, route);
+    }
+
+    public BlockResponse(int status, int code, String message, String route) {
+        this.status = status;
         this.code = code;
         this.message = message;
         this.route = route;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    public void setStatus(int status) {
+        this.status = status;
     }
 
     public int getCode() {

--- a/sentinel-adapter/sentinel-zuul2-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/zuul2/filters/endpoint/SentinelZuulEndpoint.java
+++ b/sentinel-adapter/sentinel-zuul2-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/gateway/zuul2/filters/endpoint/SentinelZuulEndpoint.java
@@ -42,7 +42,7 @@ public class SentinelZuulEndpoint extends HttpSyncEndpoint {
         ZuulBlockFallbackProvider zuulBlockFallbackProvider = ZuulBlockFallbackManager
             .getFallbackProvider(fallBackRoute);
         BlockResponse response = zuulBlockFallbackProvider.fallbackResponse(fallBackRoute, throwable);
-        HttpResponseMessage resp = new HttpResponseMessageImpl(context, request, response.getCode());
+        HttpResponseMessage resp = new HttpResponseMessageImpl(context, request, response.getStatus());
         resp.setBodyAsText(response.toString());
         return resp;
     }

--- a/sentinel-adapter/sentinel-zuul2-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/zuul2/fallback/BlockResponseTest.java
+++ b/sentinel-adapter/sentinel-zuul2-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/gateway/zuul2/fallback/BlockResponseTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.csp.sentinel.adapter.gateway.zuul2.fallback;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test cases for {@link BlockResponse}.
+ */
+public class BlockResponseTest {
+
+    @Test
+    public void testDeprecatedConstructorKeepsStatusAndCodeInSync() {
+        BlockResponse response = new BlockResponse(429, "blocked", "/foo");
+
+        Assert.assertEquals(429, response.getStatus());
+        Assert.assertEquals(429, response.getCode());
+    }
+
+    @Test
+    public void testStatusAndCodeCanBeCustomizedIndependently() {
+        // Body code can differ from the actual HTTP status, see issue #2985.
+        BlockResponse response = new BlockResponse(200, 10018, "blocked", "/foo");
+
+        Assert.assertEquals(200, response.getStatus());
+        Assert.assertEquals(10018, response.getCode());
+        Assert.assertTrue(response.toString().contains("\"code\":10018"));
+    }
+}


### PR DESCRIPTION
ZuulBlockFallbackProvider reused BlockResponse#code as both the response body's business code and the actual HTTP status code, so a custom fallback provider could not set body code (e.g. 10018) while keeping HTTP status 200.

Add a separate `status` field for the HTTP status, keep `code` for the body only, and keep the old 3-arg constructor for backward compatibility (status defaults to code).

Fixes #2985

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Zuul adapter's ZuulBlockFallbackProvider reused BlockResponse#code as both the
response body's business code and the actual HTTP status code, so a custom
fallback provider could not set the body code (e.g. 10018) while keeping the
HTTP status 200.

### Does this pull request fix one issue?
Fixes #2985

### Describe how you did it
Added a separate `status` field to `BlockResponse` (used for the real HTTP
status) and kept `code` purely as the body's business code. The old 3-arg
constructor is kept for backward compatibility (status defaults to code).
Applied the same change symmetrically to sentinel-zuul-adapter and
sentinel-zuul2-adapter.

### Describe how to verify it
See new `BlockResponseTest` in both modules: a custom provider can now return
`new BlockResponse(200, 10018, ...)` to get HTTP status 200 with body
`{"code":10018,...}`.

### Special notes for reviews
Existing 3-arg constructor is unchanged in behavior (deprecated but not
removed), so no breaking change for current users.